### PR TITLE
Add `template` cached property

### DIFF
--- a/src/rlxf/prompts/base.py
+++ b/src/rlxf/prompts/base.py
@@ -1,11 +1,29 @@
+import importlib.resources as importlib_resources
 from abc import ABC, abstractmethod
-from typing import Any, List
+from functools import cached_property
+from typing import Any, List, Union
 
+from jinja2 import Template
 from pydantic import BaseModel
+
+
+def get_template(template_name: str) -> str:
+    return str(importlib_resources.files("rlxf") / "prompts/templates" / template_name)
 
 
 class PromptTemplate(BaseModel, ABC):
     system_prompt: str
+
+    __jinja2_template__: Union[str, None] = None
+
+    @cached_property
+    def template(self) -> "Template":
+        if self.__jinja2_template__ is None:
+            raise ValueError(
+                "You must provide a `__jinja2_template__` attribute to your PromptTemplate subclass."
+            )
+
+        return Template(open(self.__jinja2_template__).read())
 
     @abstractmethod
     def generate_prompt(self, **kwargs: Any) -> str:

--- a/src/rlxf/prompts/llama.py
+++ b/src/rlxf/prompts/llama.py
@@ -1,0 +1,32 @@
+from rlxf.prompts.base import PromptTemplate, get_template
+
+_LLAMA2_TEXT_GENERATION_TEMPLATE = get_template("llama2-generation.jinja2")
+
+
+class Llama2GenerationPromptTemplate(PromptTemplate):
+    system_prompt: str = (
+        "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible,"
+        " while being safe. Your answers should not include any harmful, unethical, racist, sexist,"
+        " toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased"
+        " and positive in nature.\nIf a question does not make any sense, or is not factually coherent,"
+        " explain why instead of answering something not correct. If you don't know the answer to a"
+        " question, please don't share false information."
+    )
+
+    __jinja2_template__: str = _LLAMA2_TEXT_GENERATION_TEMPLATE
+
+    def generate_prompt(self, instruction: str) -> str:
+        return self.template.render(
+            system_prompt=self.system_prompt, instruction=instruction
+        )
+
+    def _parse_output(self, output: str) -> dict[str, str]:
+        return {"generations": output}
+
+    @property
+    def input_args_names(self) -> list[str]:
+        return ["instruction"]
+
+    @property
+    def output_args_names(self) -> list[str]:
+        return ["generations"]

--- a/src/rlxf/prompts/openai_.py
+++ b/src/rlxf/prompts/openai_.py
@@ -1,18 +1,12 @@
-import importlib.resources as importlib_resources
 from textwrap import dedent
 from typing import List, Literal, Union
 
-import jinja2
 from typing_extensions import TypedDict
 
-from rlxf.prompts.base import PromptTemplate
+from rlxf.prompts.base import PromptTemplate, get_template
 
-_GPT4_RANKING_TEMPLATE = str(
-    importlib_resources.files("rlxf") / "prompts/templates/gpt4-response-ranking.jinja2"
-)
-_GPT_TEXT_GENERATION_TEMPLATE = str(
-    importlib_resources.files("rlxf") / "prompts/templates/gpt-text-generation.jinja2"
-)
+_GPT4_RANKING_TEMPLATE = get_template("gpt4-response-ranking.jinja2")
+_GPT_TEXT_GENERATION_TEMPLATE = get_template("gpt-text-generation.jinja2")
 
 
 class Rank(TypedDict):
@@ -55,7 +49,6 @@ class OpenAIResponseRanking(PromptTemplate):
     def generate_prompt(
         self, instruction: str, generations: List[str]
     ) -> Union[str, List[ChatCompletion]]:
-        template = jinja2.Template(open(self.__jinja2_template__).read())
         render_kwargs = {
             "task_description": self.task_description,
             "ranks": self.ranks,
@@ -63,7 +56,7 @@ class OpenAIResponseRanking(PromptTemplate):
             "instruction": instruction,
             "responses": generations,
         }
-        generated_prompt = template.render(render_kwargs)
+        generated_prompt = self.template.render(render_kwargs)
         return [
             ChatCompletion(
                 role="system",
@@ -103,8 +96,7 @@ class OpenAITextGenerationPromptTemplate(PromptTemplate):
     )
 
     def generate_prompt(self, instruction: str) -> Union[str, List[ChatCompletion]]:
-        template = jinja2.Template(open(self.__jinja2_template__).read())
-        generated_prompt = template.render(
+        generated_prompt = self.template.render(
             system_prompt=self.system_prompt, instruction=instruction
         )
         return [

--- a/src/rlxf/prompts/templates/llama2-generation.jinja2
+++ b/src/rlxf/prompts/templates/llama2-generation.jinja2
@@ -1,0 +1,6 @@
+<s>[INST] <<SYS>>
+{{ system_prompt }}
+<</SYS>>
+
+{{ instruction }} [/INST]
+


### PR DESCRIPTION
This PR adds a new property called `template` to the `PromptTemplate` base class. If the subclass provides a path to a `jinja2` template setting the `__jinja2_template__` attribute, then `template` property will return the loaded template and cache it.

In addition, this PR adds a basic prompt for generating texts using Llama 2.