### PR TITLE
Fix `ultrafeedback.jinja2` kwargs

### DIFF
--- a/src/ultralabel/tasks/_templates/ultrafeedback.jinja2
+++ b/src/ultralabel/tasks/_templates/ultrafeedback.jinja2
@@ -1,8 +1,8 @@
 {{ task_description }}
 
-**Scoring**: {{ ranks_description }}
-{%- for rank in ranks %}
-{{ rank.rank }}. {{ rank.description }}
+**Scoring**: {{ ratings_description }}
+{%- for rating in ratings %}
+{{ rating.value }}. {{ rating.description }}
 {%- endfor %}
 
 ---


### PR DESCRIPTION
## Description

This PR solves a bug in the current `ultrafeedback.jinja2` template as the replacements were still using the outdated `ranks` and `rank_description` kwargs, while those have already been renamed to `ratings` and `ratings_description`, respectively.

Mentioned at #35 

## Disclaimer

This PR does not close the issue at #35, it's just a partial fix of a bug identified by @dvsrepo