### PR TITLE
Fix JudgeLM score parsing

### DIFF
--- a/src/distilabel/tasks/preference/judgelm.py
+++ b/src/distilabel/tasks/preference/judgelm.py
@@ -79,7 +79,7 @@ class JudgeLMTask(Task):
 
     def parse_output(self, output: str) -> JudgeLMOutput:
         split_output = output.split("\n")
-        ratings = [int(rating) for rating in split_output[0].split(" ")]
+        ratings = [int(float(rating)) for rating in split_output[0].split(" ")]
         rationale = "".join(split_output[1:])
         return JudgeLMOutput(ratings=ratings, rationale=rationale)
 

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -87,7 +87,7 @@ class UltraFeedbackTask(Task):
         parsed_output = []
         for section in output.split("#### Output for Text ")[1:]:
             rating, rationale = section.split("\n")[1:3]
-            rating = int(rating.split(": ")[1])
+            rating = int(float(rating.split(": ")[1]))
             rationale = rationale.split(": ")[1]
             parsed_output.append(
                 UltraFeedbackOutput(rating=rating, rationale=rationale)


### PR DESCRIPTION
## Description

This PR provides a fix for parsing scores that are rationale numbers generated by the JudgeLM template.

Closes #55