### PR TITLE
Add more generation parameters to LLMs

### DIFF
--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -27,14 +27,10 @@ class LLM(ABC):
     def __init__(
         self,
         task: Task,
-        max_new_tokens: int = 128,
-        temperature: float = 0.7,
         num_threads: Union[int, None] = None,
         formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
         self.task = task
-        self.max_new_tokens = max_new_tokens
-        self.temperature = temperature
 
         self.thread_pool_executor = (
             ThreadPoolExecutor(max_workers=num_threads)

--- a/src/distilabel/llm/huggingface/transformers.py
+++ b/src/distilabel/llm/huggingface/transformers.py
@@ -22,17 +22,26 @@ class TransformersLLM(LLM):
         tokenizer: PreTrainedTokenizer,
         task: "Task",
         max_new_tokens: int = 128,
-        temperature: float = 0.7,
+        do_sample: bool = False,
+        temperature: Union[float, None] = None,
+        top_k: Union[int, None] = None,
+        top_p: Union[float, None] = None,
+        typical_p: Union[float, None] = None,
         num_threads: Union[int, None] = None,
         formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
         super().__init__(
             task=task,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
             num_threads=num_threads,
             formatting_fn=formatting_fn,
         )
+
+        self.max_new_tokens = max_new_tokens
+        self.do_sample = do_sample
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        self.typical_p = typical_p
 
         self.model = model
         if self.device != "cpu":
@@ -74,8 +83,12 @@ class TransformersLLM(LLM):
             generated_ids = self.model.generate(
                 **encoding,
                 generation_config=GenerationConfig(
+                    do_sample=self.do_sample,
                     temperature=self.temperature,
                     max_new_tokens=self.max_new_tokens,
+                    top_k=self.top_k,
+                    top_p=self.top_p,
+                    typical_p=self.typical_p,
                     num_generations=num_generations,
                 ),
             )

--- a/src/distilabel/llm/llamacpp.py
+++ b/src/distilabel/llm/llamacpp.py
@@ -34,15 +34,19 @@ class LlamaCppLLM(LLM):
         model: "Llama",
         task: "Task",
         max_new_tokens: int = 128,
-        temperature: float = 0.7,
+        temperature: Union[float, None] = None,
+        top_p: Union[float, None] = None,
+        top_k: Union[int, None] = None,
+        repeat_penalty: Union[float, None] = None,
         formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
-        super().__init__(
-            task=task,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-            formatting_fn=formatting_fn,
-        )
+        super().__init__(task=task, formatting_fn=formatting_fn)
+
+        self.max_new_tokens = max_new_tokens
+        self.temperature = temperature
+        self.top_p = top_p
+        self.top_k = top_k
+        self.repeat_penalty = repeat_penalty
 
         self.model = model
 
@@ -55,7 +59,12 @@ class LlamaCppLLM(LLM):
         outputs = []
         for _ in range(num_generations):
             raw_output = self.model.create_completion(
-                prompt, max_tokens=self.max_new_tokens, temperature=self.temperature
+                prompt,
+                max_tokens=self.max_new_tokens,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                top_k=self.top_k,
+                repeat_penalty=self.repeat_penalty,
             )
             try:
                 parsed_output = self.task.parse_output(

--- a/src/distilabel/llm/openai_.py
+++ b/src/distilabel/llm/openai_.py
@@ -58,17 +58,24 @@ class OpenAILLM(LLM):
         model: str = "gpt-3.5-turbo",
         openai_api_key: Union[str, None] = None,
         max_new_tokens: int = 128,
-        temperature: float = 0.7,
+        frequence_penalty: Union[float, None] = None,
+        presence_penalty: Union[float, None] = None,
+        temperature: Union[float, None] = None,
+        top_p: Union[float, None] = None,
         num_threads: Union[int, None] = None,
         formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
         super().__init__(
             task=task,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
             num_threads=num_threads,
             formatting_fn=formatting_fn,
         )
+
+        self.max_new_tokens = max_new_tokens
+        self.frequence_penalty = frequence_penalty
+        self.presence_penalty = presence_penalty
+        self.temperature = temperature
+        self.top_p = top_p
 
         openai.api_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
         assert (
@@ -121,11 +128,14 @@ class OpenAILLM(LLM):
                 f"The provided `prompt={prompt}` is of `type={type(prompt)}`, but it must be a `list`, make sure that `task.generate_prompt` returns a `list` or that the `formatting_fn` formats the prompt as a `list`, where each item follows OpenAI's format of `{'role': ..., 'content': ...}`."
             )
         raw_responses = self._chat_completion_with_backoff(
-            model=self.model,
             messages=prompt,
-            n=num_generations,
-            temperature=self.temperature,
+            model=self.model,
+            frequency_penalty=self.frequence_penalty,
             max_tokens=self.max_new_tokens,
+            n=num_generations,
+            presence_penalty=self.presence_penalty,
+            temperature=self.temperature,
+            top_p=self.top_p,
         )
         raw_responses = raw_responses.to_dict_recursive()
 


### PR DESCRIPTION
## Description

This PR adds more parameters to tweak the generation of the LLMs currently implemented in `distilabel`. There are some parameters from some implementations that haven't been added as they are not useful for the `distilabel` case or they could break our code if the user provides a value that affects to the output and it's not aware how `distilabel` works.

Apart from that, the parameters of `InferenceEndpointLLM` and `TransformersLLM` are the same, even though `transformers` has much more parameters, but they are not relevant for our case.

In the case of `LlamaCpp`, the `create_completion` accept some more arguments apart from the ones included in this PR, but they are not document in the docstring and not used in the examples.

Finally, I didn't want to add more complexity for now, but probably in the future we will have to validate these parameters so the user inputs make sense.

Closes #39