### PR TITLE
Fix `examples/*.py`

### DIFF
--- a/examples/inference-endpoints-llm.py
+++ b/examples/inference-endpoints-llm.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from ultralabel.llm.huggingface import InferenceEndpointsLLM
-from ultralabel.tasks.base import Task
+from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
+from distilabel.tasks.base import Task
 
 
 class Llama2TextGenerationTask(Task):

--- a/examples/pipeline-to-argilla.py
+++ b/examples/pipeline-to-argilla.py
@@ -1,25 +1,21 @@
-import os
-import time
-
+import argilla as rg
 from datasets import load_dataset
-from distilabel.llm.huggingface import InferenceEndpointsLLM
+from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
 from distilabel.llm.openai_ import OpenAILLM
 from distilabel.pipeline import Pipeline
 from distilabel.tasks.preference.ultrafeedback import UltraFeedbackTask
 from distilabel.tasks.text_generation.llama import Llama2GenerationTask
 
-url = "..."
-
 dataset = (
-    load_dataset("HuggingFaceH4/instruction-dataset", split="test[:1]")
+    load_dataset("HuggingFaceH4/instruction-dataset", split="test[:5]")
     .remove_columns(["completion", "meta"])
     .rename_column("prompt", "input")
 )
 
 pipeline = Pipeline(
     generator=InferenceEndpointsLLM(
-        endpoint_url=url,
-        token=os.environ["HF_TOKEN"],
+        endpoint_url="<HUGGING_FACE_INFERENCE_ENDPOINTS_URL>",
+        token="<HUGGING_FACE_HUB_TOKEN>",
         task=Llama2GenerationTask(),
         max_new_tokens=128,
         num_threads=4,
@@ -30,23 +26,23 @@ pipeline = Pipeline(
         task=UltraFeedbackTask.for_text_quality(),
         max_new_tokens=128,
         num_threads=2,
-        # openai_api_key="<OPENAI_API_KEY>",
+        openai_api_key="<OPENAI_API_KEY>",
         temperature=0.0,
     ),
 )
 
-start = time.time()
 dataset = pipeline.generate(
-    dataset, num_generations=2, batch_size=1, display_progress_bar=True
+    dataset,
+    num_generations=2,
+    batch_size=1,
+    enable_checkpoints=True,
+    display_progress_bar=True,
 )
-end = time.time()
-print("Elapsed", end - start)
 
 # Push to the HuggingFace Hub
-# dataset.push_to_hub("<REPO_ID>", split="train", private=True)
+dataset.push_to_hub("<REPO_ID>", split="train", private=True)
 
 # Convert into an Argilla dataset and push it to Argilla
-# rg.init(api_url="<ARGILLA_API_URL>", api_key="<ARGILLA_API_KEY>")
-# rg_dataset = dataset.to_argilla()
-# print(rg_dataset)
-# rg_dataset.push_to_argilla(name=f"my-dataset-{uuid4()}", workspace="admin")
+rg.init(api_url="<ARGILLA_API_URL>", api_key="<ARGILLA_API_KEY>")
+rg_dataset = dataset.to_argilla()
+rg_dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")


### PR DESCRIPTION
## Description

This PR fixes some of the examples under `examples/*.py` to use `distilabel` instead of the former `ultralabel` naming, as well as to ensure that everything's working fine and that those can be easily reproduced.