### PR TITLE
Update to `openai>=1.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["black ==23.10.0", "ruff ==0.1.0", "pre-commit >=3.5.0"]
 huggingface = ["transformers >=4.34.1", "tenacity >=8"]
-openai = ["openai >=0.28.1", "tenacity >=8"]
+openai = ["openai >=1.0.0"]
 vllm = ["vllm>=0.2.1"]
 argilla = ["argilla >=1.16.0"]
 

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -95,7 +95,7 @@ class InferenceEndpointsLLM(LLM):
 
     def _generate(
         self, inputs: List[Dict[str, Any]], num_generations: int = 1
-    ) -> List[LLMOutput]:
+    ) -> List[List[LLMOutput]]:
         prompts = self._generate_prompts(inputs)
         outputs = []
         for prompt in prompts:


### PR DESCRIPTION
## Description

This PR pins `openai` depency to `>=1.0.0` and updates the `OpenAILLM` class to use the new version of the library, as described here: https://github.com/openai/openai-python/discussions/742.

Details:
- The retry code that was developed using `tenacity` has been removed, as this new version of `openai` has retry logic included.
- A `client` argument has been added to `OpenAILLM`. The user can use this argument to override the default `OpenAI` client that would be created by the class.

Closes #82