### PR TITLE
Split Hugging Face LLMs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["black ==23.10.0", "ruff ==0.1.0", "pre-commit >=3.5.0"]
-hf-transformers = ["transformers >=4.34.1"]
+hf-transformers = ["transformers >=4.34.1", "torch>=2.0.0"]
 hf-inference-endpoints = ["huggingface_hub >= 1.19.0", "tenacity >=8"]
 openai = ["openai >=1.0.0"]
 vllm = ["vllm>=0.2.1"]


### PR DESCRIPTION
## Description

This PR splits the `huggingface` extra dependencies in two extras `hf-transformers` and `hf-inference-endpoints`. 