### PR TITLE
Add `verbose` parameter to `Pipeline.generate` method

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -447,6 +447,7 @@ class Pipeline:
         batch_size: int = 1,
         enable_checkpoints: bool = True,
         display_progress_bar: bool = False,
+        verbose: bool = True,
     ) -> CustomDataset:
         """Generates the outputs for the given dataset using the LLMs provided to the `Pipeline`.
 
@@ -457,6 +458,7 @@ class Pipeline:
             batch_size (int, optional): the batch size to be used for generation. Defaults to `1`.
             enable_checkpoints (bool, optional): whether to enable checkpoints or not. Defaults to `True`.
             display_progress_bar (bool, optional): whether to display the progress bar or not. Defaults to `False`.
+            verbose (bool, optional): whether to display the logs or not. Defaults to `True`.
 
         Returns:
             CustomDataset: the final dataset.
@@ -485,6 +487,9 @@ class Pipeline:
             >>> pipeline = Pipeline(generator=generator, labeller=labeller)
             >>> dataset = pipeline.generate(dataset=..., num_generations=1, batch_size=1)
         """
+        if not verbose:
+            logger.setLevel("ERROR")
+
         if (
             self.labeller is not None
             and self.generator is not None


### PR DESCRIPTION
## Description

This PR adds a new `verbose` parameter that allows to enable/disable the log messages.

Closes #102