### PR TITLE
Fix accessing `Task`s class attributes

### DIFF
--- a/src/distilabel/tasks/preference/judgelm.py
+++ b/src/distilabel/tasks/preference/judgelm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
+from typing import ClassVar, List
 
 from typing_extensions import TypedDict
 
@@ -40,7 +40,7 @@ class JudgeLMTask(PreferenceTask):
         task_description (Union[str, None], optional): the description of the task. Defaults to `None`.
     """
 
-    __jinja2_template__: str = _JUDGELM_TEMPLATE
+    __jinja2_template__: ClassVar[str] = _JUDGELM_TEMPLATE
 
     task_description: str = (
         "We would like to request your feedback on the performance of {num_responses} AI assistants in response to the"

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass, field
 from textwrap import dedent
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from typing_extensions import TypedDict
 
@@ -52,20 +52,16 @@ class UltraFeedbackTask(PreferenceTask):
     ratings: List[Rating]
     task_description: str
 
-    __jinja2_template__: str = field(
+    __jinja2_template__: ClassVar[str] = field(
         default=_ULTRAFEEDBACK_TEMPLATE, init=False, repr=False
     )
-    __subtasks__: List[str] = field(
-        default_factory=lambda: [
-            "text-quality",
-            "helpfulness",
-            "truthfulness",
-            "honesty",
-            "instruction-following",
-        ],
-        init=False,
-        repr=False,
-    )
+    __subtasks__: ClassVar[List[str]] = [
+        "text-quality",
+        "helpfulness",
+        "truthfulness",
+        "honesty",
+        "instruction-following",
+    ]
 
     system_prompt: (
         str

--- a/src/distilabel/tasks/preference/ultrajudge.py
+++ b/src/distilabel/tasks/preference/ultrajudge.py
@@ -14,7 +14,7 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, TypedDict
+from typing import Any, ClassVar, Dict, List, TypedDict
 
 from distilabel.tasks.base import Prompt, get_template
 from distilabel.tasks.preference.base import PreferenceTask
@@ -76,7 +76,7 @@ class UltraJudgeTask(PreferenceTask):
         ]
     )
 
-    __jinja2_template__: str = field(
+    __jinja2_template__: ClassVar[str] = field(
         default=_ULTRAJUDGE_TEMPLATE, init=False, repr=False
     )
 


### PR DESCRIPTION
## Description

This PR adds the `ClassVar` type hint to the class attributes of the `Task`s (decorated with `dataclass`) that should be accesible without instantiating the class.

This fix a bug that was introduced when the `Task`s classes were migrated to be dataclasses, not allowing to access class attributes like `UltraFeedbackTask.__subtasks__`.