### PR TITLE
feat: add tests for the different tasks

### DIFF
--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -21,6 +21,7 @@ from distilabel.tasks.text_generation.base import TextGenerationTask
 
 _SELF_INSTRUCT_TEMPLATE = get_template("self-instruct.jinja2")
 
+
 @dataclass
 class SelfInstructTask(TextGenerationTask):
     """A `TextGenerationTask` following the Self-Instruct specification for building
@@ -69,7 +70,7 @@ class SelfInstructTask(TextGenerationTask):
         """
         render_kwargs = {
             "application_description": self.application_description,
-            "num_instructions": self.num_instructions,
+            "num_examples": self.num_instructions,
             "input": input,
         }
         return Prompt(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,17 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 
 prompt_default_format = re.compile(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+import re
+
+prompt_default_format = re.compile(
+    r"(?P<system_prompt>.+)\n(?P<formatted_prompt>.+)", re.MULTILINE
+)
+
+prompt_llama2_format = re.compile(
+    r"<s>\[INST] <<SYS>>\n(?P<system_prompt>.+)<<\/SYS>>\n\n(?P<formatted_prompt>.+) \[\/INST]"
+)
+
+prompt_chatml_format = re.compile(
+    r"<\|im_start\|>system\n(?P<system_prompt>.+)<\|im_end\|>\n<\|im_start\|>user\n(?P<formatted_prompt>.+)<\|im_end\|>\n<\|im_start\|>assistant\n"
+)
+
+prompt_zephyr_format = re.compile(
+    r"<\|system\|>\n(?P<system_prompt>.+)</s>\n<\|user\|>\n(?P<formatted_prompt>.+)</s>\n<\|assistant\|>\n"
+)

--- a/tests/tasks/text_generation/test_tasks.py
+++ b/tests/tasks/text_generation/test_tasks.py
@@ -1,0 +1,68 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+import pytest
+from distilabel.tasks.prompt import Prompt
+from distilabel.tasks.text_generation.llama import Llama2TextGenerationTask
+from distilabel.tasks.text_generation.openai import OpenAITextGenerationTask
+from distilabel.tasks.text_generation.self_instruct import SelfInstructTask
+
+from tests.helpers import prompt_llama2_format
+
+if TYPE_CHECKING:
+    import re
+
+    from distilabel.tasks.text_generation.base import TextGenerationTask
+
+
+@pytest.mark.parametrize(
+    "task, pattern",
+    [
+        (
+            Llama2TextGenerationTask(system_prompt="You are a helpful assistant."),
+            prompt_llama2_format,
+        ),
+        (
+            OpenAITextGenerationTask(system_prompt="You are a helpful assistant."),
+            None,
+        ),
+        (
+            SelfInstructTask(),
+            None,
+        ),
+    ],
+)
+def test_tasks(task: "TextGenerationTask", pattern: "re.Pattern"):
+    input = "Generate something my boy"
+    prompt = task.generate_prompt(input=input)
+    if isinstance(task, OpenAITextGenerationTask):
+        assert len(prompt) == 2
+        for p in prompt:
+            assert isinstance(p, dict)
+            assert set(p.keys()) == {"role", "content"}
+
+    elif isinstance(task, Llama2TextGenerationTask):
+        assert isinstance(prompt, str)
+        match = pattern.match(prompt)
+        assert match.group("system_prompt") == "You are a helpful assistant."
+        assert match.group("formatted_prompt") == "Generate something my boy"
+
+    elif isinstance(task, SelfInstructTask):
+        assert isinstance(prompt, Prompt)
+        prompt_text = prompt.formatted_prompt
+        assert "Develop 5 user queries" in prompt_text
+        assert "# AI Application\nAI assistant" in prompt_text
+        assert "# Context\nGenerate something my boy\n\n# Output" in prompt_text

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,3 +1,17 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import re
 from typing import Optional, get_args
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,48 @@
+import re
+from typing import Optional, get_args
+
+import pytest
+from distilabel.tasks.prompt import Prompt, SupportedFormats
+
+from tests.helpers import (
+    prompt_chatml_format,
+    prompt_default_format,
+    prompt_llama2_format,
+    prompt_zephyr_format,
+)
+
+
+@pytest.mark.parametrize(
+    "format, pattern",
+    [
+        ("default", prompt_default_format),
+        ("openai", None),
+        ("llama2", prompt_llama2_format),
+        ("chatml", prompt_chatml_format),
+        ("zephyr", prompt_zephyr_format),
+        ("unkn", None),
+    ],
+)
+def test_prompt_formats(format: str, pattern: Optional[re.Pattern]):
+    prompt = Prompt(
+        system_prompt="You are a helpful assistant.",
+        formatted_prompt="What are the first 5 Fibonacci numbers?",
+    )
+    if format not in get_args(SupportedFormats):
+        with pytest.raises(ValueError):
+            prompt.format_as(format)
+        return
+    prompt_text = prompt.format_as(format)
+    if format == "openai":
+        assert isinstance(prompt_text, list)
+        assert len(prompt_text) == 2
+        for p in prompt_text:
+            assert isinstance(p, dict)
+            assert set(p.keys()) == {"role", "content"}
+
+    else:
+        match = pattern.match(prompt_text)
+        assert match.group("system_prompt") == "You are a helpful assistant."
+        assert (
+            match.group("formatted_prompt") == "What are the first 5 Fibonacci numbers?"
+        )


### PR DESCRIPTION
# Description

Add tests for the different tasks and prompts.

**Work in progress.**

Closes #135 

Includes tests for the following tasks:

- [x] prompts
- [x] text_generation
    - [x] base (already existed)
    - [x] llama
    - [x] openai
    - [x] self_instruct
- [ ] preference
    - [ ] base
    - [ ] judgelm
    - [ ] ultrafeedback
    - [ ] ultrajudge

