### PR TITLE
Fix `llama_cpp_python` dependency check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ htmlcov/
 *.swp
 .DS_Store
 site/
+
+# Jupyter Notebook
+*.ipynb_checkpoints

--- a/src/distilabel/utils/imports.py
+++ b/src/distilabel/utils/imports.py
@@ -98,7 +98,7 @@ _OPENAI_AVAILABLE = _check_package_is_available(
     "openai", min_version="1.0.0", greater_or_equal=True
 )
 _LLAMA_CPP_AVAILABLE = _check_package_is_available(
-    "llama_cpp", min_version="0.2.0", greater_or_equal=True
+    "llama_cpp_python", min_version="0.2.0", greater_or_equal=True
 )
 _VLLM_AVAILABLE = _check_package_is_available(
     "vllm", min_version="0.2.1", greater_or_equal=True


### PR DESCRIPTION
There is a small naming problem with `llama_cpp` library that doesn't allow importing it. It should be named `llama_cpp_python`, otherwise the following evaluates to `False` even if the library is available:

```python
>>> from distilabel.utils.imports import _LLAMA_CPP_AVAILABLE
>>> _LLAMA_CPP_AVAILABLE
False
```