### PR TITLE
Add `ProcessLLM` class

### DIFF
--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from distilabel.llm.base import LLM, ProcessLLM
 from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
 from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
@@ -24,4 +25,6 @@ __all__ = [
     "vLLM",
     "InferenceEndpointsLLM",
     "TransformersLLM",
+    "ProcessLLM",
+    "LLM",
 ]

--- a/src/distilabel/logger.py
+++ b/src/distilabel/logger.py
@@ -15,7 +15,17 @@
 import logging
 import os
 
+from rich.logging import RichHandler
+
 DISTILABEL_LOG_LEVEL = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO").upper()
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[PID: %(process)d] %(message)s",
+    datefmt="%X",
+    handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)],
+)
 
 
 def _get_root_logger() -> logging.Logger:

--- a/src/distilabel/tasks/__init__.py
+++ b/src/distilabel/tasks/__init__.py
@@ -31,5 +31,5 @@ __all__ = [
     "TextGenerationTask",
     "OpenAITextGenerationTask",
     "Llama2TextGenerationTask",
-    "SelfInstructTask"
+    "SelfInstructTask",
 ]

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -21,6 +21,7 @@ from distilabel.tasks.text_generation.base import TextGenerationTask
 
 _SELF_INSTRUCT_TEMPLATE = get_template("self-instruct.jinja2")
 
+
 @dataclass
 class SelfInstructTask(TextGenerationTask):
     """A `TextGenerationTask` following the Self-Instruct specification for building

--- a/src/distilabel/utils/types.py
+++ b/src/distilabel/utils/types.py
@@ -1,0 +1,19 @@
+from concurrent.futures import Future
+from typing import List, TypeGuard, TypeVar, Union
+
+T = TypeVar("FutureResult")
+
+
+def is_list_of_futures(
+    results: Union[List[Future[T]], List[List[T]]],
+) -> TypeGuard[List[Future[T]]]:
+    """Check if results is a list of futures. This function narrows the type of
+    `results` to `List[Future[T]]` if it is a list of futures.
+
+    Args:
+        results: A list of futures.
+
+    Returns:
+        `True` if `results` is a list of futures, `False` otherwise.
+    """
+    return isinstance(results, list) and isinstance(results[0], Future)


### PR DESCRIPTION
## Description

This PR adds a new class called `ProcessLLM` which allows to run an `LLM` in a different process. This class is quite useful as it allows the generator and the labeller to use a different GIL, and therefore to not get blocked the `generator` because of the `labeller` (we don't really care about the results of the labeller until the generation loop has finished).