### PR TITLE
Add `to_argilla_{dataset,record}` methods in `TextGenerationTask`

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -525,7 +525,10 @@ class Pipeline:
         _dataset = _dataset.map(lambda _: {**generations.pop(0), **labels.pop(0)})  # type: ignore
         # Dynamically remaps the `datasets.Dataset` to be a `CustomDataset` instance
         _dataset.__class__ = CustomDataset
-        _dataset.task = self.labeller.task if self.labeller is not None else None  # type: ignore
+        if self.generator is not None and self.labeller is None:
+            _dataset.task = self.generator.task  # type: ignore
+        elif self.labeller is not None:
+            _dataset.task = self.labeller.task  # type: ignore
         return _dataset  # type: ignore
 
     def _teardown(self) -> None:

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -522,7 +522,9 @@ class Pipeline:
         _dataset = Dataset(
             arrow_table=dataset.flatten_indices().data, split=Split.TRAIN
         )
-        _dataset = _dataset.map(lambda _: {**generations.pop(0), **labels.pop(0)})  # type: ignore
+        _dataset = _dataset.map(
+            lambda _: {**generations.pop(0), **processed_labels.pop(0)}
+        )  # type: ignore
         # Dynamically remaps the `datasets.Dataset` to be a `CustomDataset` instance
         _dataset.__class__ = CustomDataset
         if self.generator is not None and self.labeller is None:

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -689,7 +689,6 @@ class Pipeline:
         batch_size: int = 1,
         enable_checkpoints: bool = True,
         display_progress_bar: bool = False,
-        verbose: bool = True,
     ) -> CustomDataset:
         """Generates the outputs for the given dataset using the LLMs provided to the `Pipeline`.
 
@@ -700,7 +699,6 @@ class Pipeline:
             batch_size (int, optional): the batch size to be used for generation. Defaults to `1`.
             enable_checkpoints (bool, optional): whether to enable checkpoints or not. Defaults to `True`.
             display_progress_bar (bool, optional): whether to display the progress bar or not. Defaults to `False`.
-            verbose (bool, optional): whether to display the logs or not. Defaults to `True`.
 
         Returns:
             CustomDataset: the final dataset.

--- a/src/distilabel/tasks/_templates/self-instruct.jinja2
+++ b/src/distilabel/tasks/_templates/self-instruct.jinja2
@@ -1,5 +1,5 @@
 # Task Description
-Develop {{ num_examples }} user queries that can be received by the given AI application and applicable to the provided context. Emphasize diversity in verbs and linguistic structures within the model's textual capabilities.
+Develop {{ num_instructions }} user queries that can be received by the given AI application and applicable to the provided context. Emphasize diversity in verbs and linguistic structures within the model's textual capabilities.
 
 # Criteria for Queries
 Incorporate a diverse range of verbs, avoiding repetition.

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -212,9 +212,16 @@ class TextGenerationTask(Task):
             arg_value = dataset_row[arg_name]
             if isinstance(arg_value, list):
                 for idx, value in enumerate(arg_value, start=1):
-                    fields[f"{arg_name}-{idx}"] = value.strip() if value else ""
+                    value = (
+                        value.strip()
+                        if isinstance(value, str)
+                        else "\n".join(value)
+                        if isinstance(value, list)
+                        else ""
+                    )
+                    fields[f"{arg_name}-{idx}"] = value
                     if value is not None:
-                        metadata[f"length-{arg_name}-{idx}"] = len(value.strip())
+                        metadata[f"length-{arg_name}-{idx}"] = len(value)
             elif isinstance(arg_value, str):
                 fields[arg_name] = arg_value.strip() if arg_value else ""
                 if arg_value is not None:

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -43,7 +43,8 @@ class SelfInstructTask(TextGenerationTask):
 
     system_prompt: str = (
         "You are an expert prompt writer, writing the best and most diverse prompts for a variety of tasks."
-        "You are given a task description and a set of instructions for how to write the prompts for a specific AI application."
+        " You are given a task description and a set of instructions for how to write the prompts for an"
+        " specific AI application."
     )
     application_description: str = "AI assistant"
     num_instructions: int = 5


### PR DESCRIPTION
## Description

This PR adds the `to_argilla_dataset` and `to_argilla_record` methods to the `TextGenerationTask` so that the generations can also be exported to Argilla.

By default those will contain `RatingQuestion`s from 1-10 on the quality of the generations based on the given inputs, and as we're not labelling anything it won't come with pre-filled suggestions as the `PreferenceTask` did.

Additionally, the `SelfInstructTask` has been fixed as the Jinja2 template used was not working as expected, the spacing was a bit off and the `num_examples` variable was not used and replaced with `num_instructions`; introduced at https://github.com/argilla-io/distilabel/pull/109.