### PR TITLE
Align `typing` and `typing_extensions` with supported Python versions

### DIFF
--- a/src/distilabel/llm/utils.py
+++ b/src/distilabel/llm/utils.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
-
-from typing_extensions import TypedDict
+from typing import Any, Optional, TypedDict
 
 
 class LLMOutput(TypedDict):

--- a/src/distilabel/progress_bar.py
+++ b/src/distilabel/progress_bar.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import wraps
-from typing import Any, Callable, ParamSpec, Tuple, TypeVar, Union
+from typing import Any, Callable, Tuple, TypeVar, Union
 
 from rich.progress import (
     BarColumn,
@@ -22,6 +22,7 @@ from rich.progress import (
     TaskProgressColumn,
     TextColumn,
 )
+from typing_extensions import ParamSpec
 
 _pipeline_progress = Progress(
     TextColumn("[progress.description]{task.description}"),

--- a/src/distilabel/tasks/critique/ultracm.py
+++ b/src/distilabel/tasks/critique/ultracm.py
@@ -14,9 +14,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import ClassVar
-
-from typing_extensions import TypedDict
+from typing import ClassVar, TypedDict
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.critique.base import CritiqueTask

--- a/src/distilabel/tasks/preference/judgelm.py
+++ b/src/distilabel/tasks/preference/judgelm.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import ClassVar, List
-
-from typing_extensions import TypedDict
+from typing import ClassVar, List, TypedDict
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.preference.base import PreferenceTask

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -14,9 +14,7 @@
 
 from dataclasses import dataclass, field
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
-
-from typing_extensions import TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, TypedDict
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.preference.base import PreferenceTask

--- a/src/distilabel/tasks/prompt.py
+++ b/src/distilabel/tasks/prompt.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Literal, Union
-
-from typing_extensions import TypedDict
+from typing import List, Literal, TypedDict, Union
 
 
 class ChatCompletion(TypedDict):

--- a/src/distilabel/utils/types.py
+++ b/src/distilabel/utils/types.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 from concurrent.futures import Future
-from typing import List, TypeGuard, TypeVar, Union
+from typing import List, Union
 
-T = TypeVar("FutureResult")
+from typing_extensions import TypeGuard, TypeVar
+
+T = TypeVar("FutureResult")  # type: ignore
 
 
 def is_list_of_futures(


### PR DESCRIPTION
## Description

This PR aligns the usage of `typing` in the codebase to be compliant with the allowed Python versions i.e. greater or equal to 3.8, using `typing_extensions` when needed to avoid import errors from `typing`.

See the reference used to identify those at https://typing-extensions.readthedocs.io/en/latest/

Closes #155 