### PR TITLE
Add missing `CritiqueTask` and `UltraCMTask` in `__init__` and move `argilla_utils` to `utils.argilla`

### DIFF
--- a/src/distilabel/tasks/__init__.py
+++ b/src/distilabel/tasks/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from distilabel.tasks.base import Task
+from distilabel.tasks.critique.base import CritiqueTask
+from distilabel.tasks.critique.ultracm import UltraCMTask
 from distilabel.tasks.preference.judgelm import JudgeLMTask
 from distilabel.tasks.preference.ultrafeedback import UltraFeedbackTask
 from distilabel.tasks.preference.ultrajudge import UltraJudgeTask
@@ -24,6 +26,8 @@ from distilabel.tasks.text_generation.self_instruct import SelfInstructTask
 
 __all__ = [
     "Task",
+    "CritiqueTask",
+    "UltraCMTask",
     "JudgeLMTask",
     "UltraFeedbackTask",
     "UltraJudgeTask",

--- a/src/distilabel/tasks/preference/base.py
+++ b/src/distilabel/tasks/preference/base.py
@@ -16,8 +16,8 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from distilabel.tasks.argilla_utils import infer_fields_from_dataset_row
 from distilabel.tasks.base import Task
+from distilabel.utils.argilla import infer_fields_from_dataset_row
 from distilabel.utils.imports import _ARGILLA_AVAILABLE
 
 if _ARGILLA_AVAILABLE:

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -17,10 +17,10 @@ import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
-from distilabel.tasks.argilla_utils import infer_fields_from_dataset_row
 from distilabel.tasks.base import Task
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.principles import UltraFeedbackPrinciples
+from distilabel.utils.argilla import infer_fields_from_dataset_row
 from distilabel.utils.imports import _ARGILLA_AVAILABLE
 
 if _ARGILLA_AVAILABLE:

--- a/src/distilabel/utils/argilla.py
+++ b/src/distilabel/utils/argilla.py
@@ -28,7 +28,7 @@ def infer_fields_from_dataset_row(
 ) -> List["AllowedFieldTypes"]:
     if not _ARGILLA_AVAILABLE:
         raise ImportError(
-            "In order to use any of the functions defined within `argilla_utils` you must install `argilla`"
+            "In order to use any of the functions defined within `utils.argilla` you must install `argilla`"
         )
     processed_items = []
     for arg_name in field_names:
@@ -37,7 +37,7 @@ def infer_fields_from_dataset_row(
         if isinstance(dataset_row[arg_name], list):
             for idx in range(1, len(dataset_row[arg_name]) + 1):
                 processed_items.append(
-                    rg.TextField(name=f"{arg_name}-{idx}", title=f"{arg_name}-{idx}")
+                    rg.TextField(name=f"{arg_name}-{idx}", title=f"{arg_name}-{idx}")  # type: ignore
                 )  # type: ignore
         elif isinstance(dataset_row[arg_name], str):
             processed_items.append(rg.TextField(name=arg_name, title=arg_name))  # type: ignore


### PR DESCRIPTION
## Description

This PR adds the recently introduced `CritiqueTask` (see #152) and the subclass `UltraCMTask` into the `distilabel/tasks/__init__.py` so that it can be easily imported as `from distilabel.tasks import CritiqueTask, UltraCMTask`.

This PR also moves the `argilla_utils.py` file from `distilabel/tasks/argilla_utils.py` into `distilabel/utils/argilla.py`.