### PR TITLE
Add `test` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          # Looks like it's not working very well for other people:
+          # https://github.com/actions/setup-python/issues/436
+          # cache: "pip"
+          # cache-dependency-path: pyproject.toml
+
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-test
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install -e .[dev,tests]
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+sources = src/distilabel tests examples
+
+.PHONY: format
+format:
+	ruff --fix $(sources)
+	ruff format $(sources)
+
+.PHONY: lint
+lint:
+	ruff $(sources)
+	ruff format --check $(sources)
+
+.PHONY: test
+test:
+	pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "Jinja2 >= 3.1.2",
     "rich >= 13.5.0",
     "tenacity >= 8",
-    "importlib-resources >=6.1.1; python_version < '3.9'",
+    "importlib-resources >= 6.1.1; python_version < '3.9'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "Jinja2 >= 3.1.2",
     "rich >= 13.5.0",
     "tenacity >= 8",
+    "importlib-resources >=6.1.1; python_version < '3.9'",
 ]
 dynamic = ["version"]
 

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -500,7 +500,7 @@ class ProcessLLM:
         # This thread will create text generation requests
         self.pending_text_generation_request: Dict[int, _TextGenerationRequest] = {}
         self.text_generation_request_count = 0
-        self.text_generation_request_ids_queue = queue.Queue[int]()
+        self.text_generation_request_ids_queue: queue.Queue[int] = queue.Queue()
 
         # Queues for the communication between the `_BridgeThread` and the `_GenerationProcess`
         self._call_queue = mp.Queue()

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import math
 import os
 import warnings

--- a/src/distilabel/tasks/base.py
+++ b/src/distilabel/tasks/base.py
@@ -18,6 +18,7 @@ if sys.version_info < (3, 9):
     import importlib_resources
 else:
     import importlib.resources as importlib_resources
+
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Union
 

--- a/src/distilabel/tasks/base.py
+++ b/src/distilabel/tasks/base.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib.resources as importlib_resources
+import sys
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Union
 

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -132,17 +132,17 @@ class TextGenerationTask(Task):
             system_prompt += " " + principle
         return Prompt(system_prompt=system_prompt, formatted_prompt=input)
 
-    def parse_output(self, output: str) -> dict[str, str]:
+    def parse_output(self, output: str) -> Dict[str, str]:
         """Parses the output of the LLM into the desired format."""
         return {"generations": output}
 
     @property
-    def input_args_names(self) -> list[str]:
+    def input_args_names(self) -> List[str]:
         """Returns the input args names for the task."""
         return ["input"]
 
     @property
-    def output_args_names(self) -> list[str]:
+    def output_args_names(self) -> List[str]:
         """Returns the output args names for the task."""
         return ["generations"]
 

--- a/src/distilabel/utils/types.py
+++ b/src/distilabel/utils/types.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from concurrent.futures import Future
 from typing import List, Union
 


### PR DESCRIPTION
## Description

Add a simple `test` workflow, that will check that the lint and format is correct and then it will run the tests. In addition, fix some issues with type hints impeding to use the package with `python<3.9`