### PR TITLE
Update `LLM` to return `Future[List[List[LLMOutput]]]`

### DIFF
--- a/examples/pipeline-pool-llm.py
+++ b/examples/pipeline-pool-llm.py
@@ -39,7 +39,7 @@ def load_openai(task):
     return OpenAILLM(
         model="gpt-3.5-turbo",
         task=task,
-        openai_api_key="<OPENAI_API_KEY>",
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
         max_new_tokens=512,
     )
 

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -21,7 +21,6 @@ import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, ThreadPoolExecutor
 from ctypes import c_char
-from enum import Enum, auto
 from functools import cached_property
 from threading import Thread
 from typing import (
@@ -37,7 +36,7 @@ from typing import (
 
 from distilabel.logger import get_logger
 from distilabel.tasks.prompt import Prompt
-from distilabel.utils.types import is_list_of_futures
+from distilabel.utils.futures import when_all_complete
 
 if TYPE_CHECKING:
     from distilabel.llm.utils import LLMOutput
@@ -45,22 +44,6 @@ if TYPE_CHECKING:
     from distilabel.tasks.prompt import SupportedFormats
 
 logger = get_logger()
-
-
-class LLMFutures(Enum):
-    """An enum used to indicate whether the `LLM` returns futures or not, and if so
-    what the futures contains.
-
-    Attributes:
-        CONTAINS_ROWS: used to indicate that the `LLM` will return `Future`s that
-            contains a `List[List[LLMOutput]]`. The first list just contains 1 element
-            (the row) and the second list contains the generations for that row.
-        CONTAINS_BATCHES: used to indicate that the `LLM` will return `Future`s that
-            contains a `List[List[LLMOutput]]`.
-    """
-
-    CONTAINS_ROWS = auto()
-    CONTAINS_BATCHES = auto()
 
 
 class LLM(ABC):
@@ -198,7 +181,7 @@ class LLM(ABC):
         inputs: List[Dict[str, Any]],
         num_generations: int = 1,
         progress_callback_func: Union[Callable, None] = None,
-    ) -> Union[List[Future[List["LLMOutput"]]], List[List["LLMOutput"]]]:
+    ) -> Union[List[List["LLMOutput"]], Future[List[List["LLMOutput"]]]]:
         """Generates the outputs for the given inputs using the LLM.
 
         Args:
@@ -214,12 +197,7 @@ class LLM(ABC):
 
         def _progress():
             if progress_callback_func is not None:
-                advance = (
-                    num_generations * len(inputs)
-                    if self.return_futures is not None
-                    else num_generations
-                )
-                progress_callback_func(advance=advance)
+                progress_callback_func(advance=num_generations * len(inputs))
 
         if self.thread_pool_executor is not None:
             futures = []
@@ -227,19 +205,19 @@ class LLM(ABC):
                 future = self.thread_pool_executor.submit(
                     self._generate, [input], num_generations
                 )
-                future.add_done_callback(lambda _: _progress())
                 futures.append(future)
-            return futures
+            future = when_all_complete(futures)
+            future.add_done_callback(lambda _: _progress())
+            return future
 
         generations = self._generate(inputs, num_generations)
         _progress()
         return generations
 
     @property
-    def return_futures(self) -> Union[LLMFutures, None]:
-        """Returns whether the LLM returns futures or not, and if so what the futures
-        contains."""
-        return LLMFutures.CONTAINS_ROWS
+    def return_futures(self) -> bool:
+        """Whether the `LLM` returns futures"""
+        return True
 
 
 MAX_MODEL_NAME_LENGTH = 256
@@ -339,13 +317,7 @@ class _GenerationProcess(mp.Process):
                 inputs=request.inputs, num_generations=request.num_generations
             )
 
-            # Generations are a list of `Future`s because the `LLM` is using a thread pool
-            if is_list_of_futures(results):
-                generations = []
-                for future in results:
-                    generations.extend(future.result())
-            else:
-                generations = results
+            generations = results.result() if isinstance(results, Future) else results
 
             self._result_queue.put(_TextGenerationResult(generations))
 
@@ -591,10 +563,9 @@ class ProcessLLM:
             return "".join([c.decode() for c in self._model_name if c != b"\0"])
 
     @property
-    def return_futures(self) -> Union[LLMFutures, None]:
-        """Returns whether the LLM returns futures or not, and if so what the futures
-        contains."""
-        return LLMFutures.CONTAINS_BATCHES
+    def return_futures(self) -> bool:
+        """Whether the `LLM` returns futures"""
+        return True
 
 
 class LLMPool:
@@ -719,5 +690,6 @@ class LLMPool:
         return self.llms[0].task
 
     @property
-    def return_futures(self) -> Union[LLMFutures, None]:
-        return None
+    def return_futures(self) -> bool:
+        """Whether the `LLM` returns futures"""
+        return False

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -33,7 +33,7 @@ from typing import (
 from datasets import Dataset, Split
 
 from distilabel.dataset import CustomDataset
-from distilabel.llm.base import LLM, LLMFutures, LLMPool, ProcessLLM
+from distilabel.llm.base import LLM, LLMPool, ProcessLLM
 from distilabel.llm.utils import LLMOutput
 from distilabel.logger import get_logger
 from distilabel.progress_bar import (
@@ -42,7 +42,7 @@ from distilabel.progress_bar import (
     use_progress_bar,
 )
 from distilabel.utils.dicts import combine_dicts
-from distilabel.utils.types import is_list_of_futures
+from distilabel.utils.types import is_future
 
 logger = get_logger()
 
@@ -225,27 +225,6 @@ class Pipeline:
                         for _ in range(num_batches)
                     ]
                 )
-        elif is_list_of_futures(outputs):
-            for future in outputs:
-                # Result of future is `List[List[LLMOutput]]` (first list contains 1
-                # element, and the second list contains `num_generations` elements)
-                try:
-                    batch_generations.extend(future.result())
-                except Exception as e:
-                    logger.error(
-                        f"An error ocurred when getting the result of a future from the generator: {e}"
-                    )
-                    batch_generations.extend(
-                        [
-                            LLMOutput(
-                                model_name=self.generator.model_name,
-                                prompt_used=None,
-                                raw_output=None,
-                                parsed_output=None,
-                            )
-                            for _ in range(num_generations)
-                        ]
-                    )
         else:
             batch_generations = outputs
         return self._process_batch_generations(batch_generations=batch_generations)
@@ -254,11 +233,7 @@ class Pipeline:
         self,
         inputs: List[Dict[str, Any]],
         progress_callback_func: Union[Callable, None] = None,
-    ) -> Union[
-        Future[List[List["LLMOutput"]]],
-        List[Future[List[List["LLMOutput"]]]],
-        List[List["LLMOutput"]],
-    ]:
+    ) -> Union[List[List["LLMOutput"]], Future[List[List["LLMOutput"]]]]:
         """Gets the batch labels for the given inputs.
 
         Args:
@@ -269,7 +244,7 @@ class Pipeline:
                 to `None`.
 
         Returns:
-            Union[Future[List["LLMOutput"]], List[Future], List["LLMOutput"]]: the batch
+            Union[List[List["LLMOutput"]], Future[List[List["LLMOutput"]]]]: the batch
                 labels.
         """
 
@@ -430,9 +405,8 @@ class Pipeline:
         dataset: Dataset,
         generations: List[Dict[str, Any]],
         labels: Union[
-            Future[List[List["LLMOutput"]]],
-            List[Future[List[List["LLMOutput"]]]],
             List[List["LLMOutput"]],
+            Future[List[List["LLMOutput"]]],
         ],
         batch_size: int,
     ) -> CustomDataset:
@@ -442,8 +416,8 @@ class Pipeline:
         Args:
             dataset (Dataset): the original dataset.
             generations (List[Dict[str, Any]]): the processed generations.
-            labels (Union[List[Future["LLMOutput"]], List["LLMOutput"]]): the processed
-                labels.
+            labels (Union[List[List[LLMOutput]], Future[List[List[LLMOutput]]]]): the
+                processed labels.
 
         Returns:
             CustomDataset: the final dataset.
@@ -478,7 +452,7 @@ class Pipeline:
             processed_labels = [{} for _ in range(len(dataset))]  # type: ignore
         else:
             batch_labels = []
-            if self.labeller.return_futures is not None:
+            if self.labeller.return_futures:
                 for i, future in enumerate(labels, start=1):  # type: ignore
                     try:
                         batch_labels.extend(future.result())
@@ -486,16 +460,8 @@ class Pipeline:
                         logger.error(
                             f"An error occurred when getting the result from the labeller: {e}"
                         )
-                        # If the LLM returned a list of futures (`LLM` with thread pool
-                        # executor), and each future contains just the result for a single
-                        # row, then we need to create an empty LLMOutput for each future.
-                        # If the LLM returns a future containing `batch_size` rows in the
-                        # result (`ProcessLLM`), then we need to create a list of empty
-                        # LLMOutputs with the length of the `batch_size`
                         num_outputs = (
-                            1
-                            if self.labeller.return_futures == LLMFutures.CONTAINS_ROWS
-                            else batch_size
+                            batch_size
                             if i * batch_size <= len(dataset)
                             else len(dataset) % batch_size
                         )
@@ -624,9 +590,8 @@ class Pipeline:
 
         generations: List[Dict[str, Any]] = []
         labels: Union[
-            Future[List[List["LLMOutput"]]],
-            List[Future[List[List["LLMOutput"]]]],
             List[List["LLMOutput"]],
+            Future[List[List["LLMOutput"]]],
         ] = []
 
         (
@@ -677,8 +642,8 @@ class Pipeline:
                         inputs=inputs, progress_callback_func=labelling_progress_func
                     )
 
-                    if isinstance(batch_labels, Future):
-                        labels.append(batch_labels)
+                    if is_future(batch_labels):
+                        labels.append(batch_labels)  # type: ignore
                     else:
                         labels.extend(batch_labels)  # type: ignore
                 except Exception as e:
@@ -702,6 +667,38 @@ class Pipeline:
             dataset, generations=generations, labels=labels, batch_size=batch_size
         )
 
+    def dry_run(self, dataset: Dataset) -> CustomDataset:
+        """Performs a dry run over the provided dataset, which consists on generating the
+        outputs for the first row of the dataset, to ensure that the `Pipeline` will be
+        able to generate the outputs for the whole dataset.
+
+        Args:
+            dataset (Dataset): the dataset to be used for generation. Just the first row
+                will be used for the dry run.
+
+        Returns:
+            CustomDataset: the dataset containing the outputs for the first row.
+        """
+        try:
+            # First we generate a `Dataset` only with the first row from the whole dataset
+            subset = Dataset.from_dict(
+                {key: [value] for key, value in dataset[0].items()}
+            )
+            # Then we call the `_generate` method with it
+            return self._generate(
+                dataset=subset,
+                # Default kwargs to make the process as simple as possible
+                num_generations=1,
+                batch_size=1,
+                enable_checkpoints=False,
+                display_progress_bar=False,
+            )
+        except Exception as e:
+            self._teardown()
+            raise RuntimeError(
+                f"`Pipeline.generate` failed during the dry run over {dataset[0]} with exception: {e}"
+            ) from e
+
     def generate(
         self,
         dataset: Dataset,
@@ -709,6 +706,7 @@ class Pipeline:
         batch_size: int = 1,
         enable_checkpoints: bool = True,
         display_progress_bar: bool = False,
+        skip_dry_run: bool = False,
     ) -> CustomDataset:
         """Generates the outputs for the given dataset using the LLMs provided to the `Pipeline`.
 
@@ -719,6 +717,7 @@ class Pipeline:
             batch_size (int, optional): the batch size to be used for generation. Defaults to `1`.
             enable_checkpoints (bool, optional): whether to enable checkpoints or not. Defaults to `True`.
             display_progress_bar (bool, optional): whether to display the progress bar or not. Defaults to `False`.
+            skip_dry_run (bool, optional): whether to skip the dry run or not. Defaults to `False`.
 
         Returns:
             CustomDataset: the final dataset.
@@ -747,30 +746,12 @@ class Pipeline:
             >>> pipeline = Pipeline(generator=generator, labeller=labeller)
             >>> dataset = pipeline.generate(dataset=..., num_generations=1, batch_size=1)
         """
-        try:
+        if not skip_dry_run:
             logger.info("Executing dry-run...")
-            # First we generate a `Dataset` only with the first row from the whole dataset
-            subset = Dataset.from_dict(
-                {key: [value] for key, value in dataset[0].items()}
+            self.dry_run(dataset)
+            logger.info(
+                "Dry-run executed with no issues. Starting the actual generation..."
             )
-            # Then we call the `_generate` method with it
-            _ = self._generate(
-                dataset=subset,
-                # Default kwargs to make the process as simple as possible
-                num_generations=1,
-                batch_size=1,
-                enable_checkpoints=False,
-                display_progress_bar=False,
-            )
-        except Exception as e:
-            self._teardown()
-            raise RuntimeError(
-                f"`Pipeline.generate` failed during the dry run over {dataset[0]} with exception: {e}"
-            ) from e
-
-        logger.info(
-            "Dry-run executed with no issues. Starting the actual generation..."
-        )
 
         dataset = use_progress_bar(self._generate)(
             dataset=dataset,

--- a/src/distilabel/utils/futures.py
+++ b/src/distilabel/utils/futures.py
@@ -1,0 +1,48 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from concurrent.futures import Future, wait
+from typing import List
+
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+
+
+def when_all_complete(futures: List[Future[T]]) -> Future[T]:
+    """Returns a `Future` that will be completed when all the provided `futures` are
+    completed, and it will contain the results of the `futures`.
+
+    Args:
+        futures (List[Future]): the `Future`s to wait for.
+
+    Returns:
+        Future: the `Future` that will be completed when all the provided `futures` are
+            completed, and it will contain the results of the `futures`.
+    """
+    all_done_future = Future()
+    results = []
+
+    def check_all_done(future: Future) -> None:
+        results.extend(future.result())
+        _, not_done = wait(futures, return_when="FIRST_COMPLETED")
+        if len(not_done) == 0:
+            all_done_future.set_result(results)
+
+    for future in futures:
+        future.add_done_callback(check_all_done)
+
+    return all_done_future

--- a/src/distilabel/utils/types.py
+++ b/src/distilabel/utils/types.py
@@ -15,23 +15,20 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
-from typing import List, Union
+from typing import Any, Union
 
 from typing_extensions import TypeGuard, TypeVar
 
-T = TypeVar("FutureResult")  # type: ignore
+T = TypeVar("T")
 
 
-def is_list_of_futures(
-    results: Union[List[Future[T]], List[List[T]]],
-) -> TypeGuard[List[Future[T]]]:
-    """Check if results is a list of futures. This function narrows the type of
-    `results` to `List[Future[T]]` if it is a list of futures.
+def is_future(obj: Union[Future[T], Any]) -> TypeGuard[Future[T]]:
+    """Checks if an object is a future narrowing the type.
 
     Args:
-        results: A list of futures.
+        obj (Future[T]): Object to check
 
     Returns:
-        `True` if `results` is a list of futures, `False` otherwise.
+        TypeGuard[Future[T]]: True if it is a future
     """
-    return isinstance(results, list) and isinstance(results[0], Future)
+    return isinstance(obj, Future)


### PR DESCRIPTION
## Description

This PR updates the `LLM.generate` method when a `ThreadPoolExecutor` is used. Before, we were returning a `List[Future[List[LLMOutput]]]` which was complicating a bit the code of the `Pipeline`. Now, a `Future[List[List[LLMOutput]]]` is returned instead, making things more easy. To do so, a new `Future` is created that will be finished when the list of `Future`s created using the `submit` method of the pool are finished.

In addition this PR, moves the dry-run logic to a separate method that can be used by the user, and adds a `skip_dry_run` argument to the `Pipeline.generate` method.