### PR TITLE
Add `PrometheusTask`

### DIFF
--- a/examples/pipeline-prometheus.py
+++ b/examples/pipeline-prometheus.py
@@ -1,0 +1,63 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import torch
+from datasets import Dataset
+from distilabel.llm import TransformersLLM
+from distilabel.pipeline import Pipeline
+from distilabel.tasks.critique.prometheus import PrometheusTask
+from transformers import AutoTokenizer, LlamaForCausalLM
+
+if __name__ == "__main__":
+    model = LlamaForCausalLM.from_pretrained(
+        "kaist-ai/Prometheus-7b-v1.0", torch_dtype=torch.float16, device_map="auto"
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        "meta-llama/Llama-2-7b-chat-hf", token=os.getenv("HF_TOKEN")
+    )
+    pipeline = Pipeline(
+        labeller=TransformersLLM(
+            model=model,  # type: ignore
+            tokenizer=tokenizer,
+            task=PrometheusTask(
+                scoring_criteria="Is the provided completion accurate based on the given instruction?",
+                score_descriptions={
+                    0: "Totaly off-topic and inaccurate",
+                    1: "Incorrect and inaccurate",
+                    2: "Almost correct, but partially inaccurate",
+                    3: "Correct but badly phrased",
+                    4: "Correct and accurate",
+                },
+            ),
+            temperature=1.0,
+            top_p=1.0,
+            max_new_tokens=512,
+        ),
+    )
+
+    dataset = Dataset.from_dict(
+        {
+            "instruction": ["What's the capital of Spain?"],
+            "completion": ["Paris"],
+            "ref_completion": ["Madrid"],
+        }
+    )
+
+    dataset = pipeline.generate(
+        dataset,  # type: ignore
+        display_progress_bar=True,
+        skip_dry_run=True,
+    )

--- a/src/distilabel/tasks/_templates/prometheus.jinja2
+++ b/src/distilabel/tasks/_templates/prometheus.jinja2
@@ -1,0 +1,25 @@
+###Task Description:
+An instruction (might include an Input inside it), a response to evaluate, a reference answer that gets a score of 5, and a score rubric representing a evaluation criteria are given.
+1. Write a detailed feedback that assess the quality of the response strictly based on the given score rubric, not evaluating in general.
+2. After writing a feedback, write a score that is an integer between 1 and 5. You should refer to the score rubric.
+3. The output format should look as follows: \"Feedback: (write a feedback for criteria) [RESULT] (an integer number between 1 and 5)\"
+4. Please do not generate any other opening, closing, and explanations.
+
+###The instruction to evaluate:
+{{ instruction }}
+
+###Response to evaluate:
+{{ completion }}
+
+###Reference Answer (Score 5):
+{{ ref_completion }}
+
+###Score Rubrics:
+[{{ scoring_criteria }}]
+Score 1: {{ score_descriptions[0] }}
+Score 2: {{ score_descriptions[1] }}
+Score 3: {{ score_descriptions[2] }}
+Score 4: {{ score_descriptions[3] }}
+Score 5: {{ score_descriptions[4] }}
+
+###Feedback: 

--- a/src/distilabel/tasks/critique/base.py
+++ b/src/distilabel/tasks/critique/base.py
@@ -15,6 +15,8 @@
 from dataclasses import dataclass
 from typing import List
 
+from typing_extensions import TypedDict
+
 from distilabel.tasks.base import Task
 
 
@@ -36,3 +38,10 @@ class CritiqueTask(Task):
     def output_args_names(self) -> List[str]:
         """Returns the names of the output arguments of the task."""
         return ["critique", "score"]
+
+
+class CritiqueTaskOutput(TypedDict):
+    """A `TypedDict` matching the output format of any `CritiqueTask`."""
+
+    score: float
+    critique: str

--- a/src/distilabel/tasks/critique/prometheus.py
+++ b/src/distilabel/tasks/critique/prometheus.py
@@ -56,10 +56,12 @@ class PrometheusTask(CritiqueTask):
 
     def parse_output(self, output: str) -> CritiqueTaskOutput:  # type: ignore
         """Parses the output of the model into the desired format."""
-        pattern = r"(\d+(?:\.\d+)?)\s*(.*)"
+        # We use a regex instead of splitting by the delimiter because the
+        # critique may contain the delimiter, and using the regex is safer.
+        pattern = r"(.+?)\. \[RESULT\] (\d+)"
         match = re.match(pattern, output)
         if match:
             return CritiqueTaskOutput(
-                score=float(match.group(1)),
-                critique=match.group(2).strip(),
+                score=float(match.group(2)),
+                critique=match.group(1).strip(),
             )

--- a/src/distilabel/tasks/critique/prometheus.py
+++ b/src/distilabel/tasks/critique/prometheus.py
@@ -1,0 +1,65 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar, Dict, List
+
+from distilabel.tasks.base import get_template
+from distilabel.tasks.critique.base import CritiqueTask, CritiqueTaskOutput
+from distilabel.tasks.prompt import Prompt
+
+_PROMETHEUS_TEMPLATE = get_template("prometheus.jinja2")
+
+
+@dataclass
+class PrometheusTask(CritiqueTask):
+    scoring_criteria: str
+    score_descriptions: Dict[int, str]
+
+    system_prompt: str = "You are a fair evaluator language model."
+
+    __jinja2_template__: ClassVar[str] = _PROMETHEUS_TEMPLATE
+
+    @property
+    def input_args_names(self) -> List[str]:
+        return super().input_args_names + ["ref_completion"]
+
+    def generate_prompt(
+        self,
+        instruction: str,
+        completion: str,
+        ref_completion: str,
+    ) -> str:
+        render_kwargs = {
+            "instruction": instruction,
+            "completion": completion,
+            "ref_completion": ref_completion,
+            "scoring_criteria": self.scoring_criteria,
+            "score_descriptions": self.score_descriptions,
+        }
+        return Prompt(
+            system_prompt=self.system_prompt,
+            formatted_prompt=self.template.render(**render_kwargs),
+        ).format_as(format="llama2")  # type: ignore
+
+    def parse_output(self, output: str) -> CritiqueTaskOutput:  # type: ignore
+        """Parses the output of the model into the desired format."""
+        pattern = r"(\d+(?:\.\d+)?)\s*(.*)"
+        match = re.match(pattern, output)
+        if match:
+            return CritiqueTaskOutput(
+                score=float(match.group(1)),
+                critique=match.group(2).strip(),
+            )

--- a/src/distilabel/tasks/critique/ultracm.py
+++ b/src/distilabel/tasks/critique/ultracm.py
@@ -16,19 +16,10 @@ import re
 from dataclasses import dataclass
 from typing import ClassVar
 
-from typing_extensions import TypedDict
-
 from distilabel.tasks.base import get_template
-from distilabel.tasks.critique.base import CritiqueTask
+from distilabel.tasks.critique.base import CritiqueTask, CritiqueTaskOutput
 
 _ULTRACM_TEMPLATE = get_template("ultracm.jinja2")
-
-
-class UltraCMOutput(TypedDict):
-    """A `TypedDict` matching the output format of UltraCM."""
-
-    score: float
-    critique: str
 
 
 @dataclass
@@ -48,12 +39,12 @@ class UltraCMTask(CritiqueTask):
         }
         return f"{self.system_prompt}\nUser: {self.template.render(**render_kwargs)}</s>\nAssistant: ### Feedback\nOverall Score: "
 
-    def parse_output(self, output: str) -> UltraCMOutput:  # type: ignore
+    def parse_output(self, output: str) -> CritiqueTaskOutput:  # type: ignore
         """Parses the output of the model into the desired format."""
         pattern = r"(\d+(?:\.\d+)?)\s*(.*)"
         match = re.match(pattern, output)
         if match:
-            return UltraCMOutput(
+            return CritiqueTaskOutput(
                 score=float(match.group(1)),
                 critique=match.group(2).strip(),
             )


### PR DESCRIPTION
## Description

This PR adds the `PrometheusTask` powered by https://huggingface.co/kaist-ai/prometheus-7b-v1.0, inheriting from the recently introduced `CritiqueTask`.

## Disclaimer

After some testing of the Prometheus models I'm still a bit skeptical about the quality of the critiques and how those can extend to any scenario i.e. using different score rubrics, and also due to the fact that it needs a reference answer to generate the critique, since in some cases the reference answer may not be perfect (score 5) either. Also formatting sometimes is a bit off, and their model card is not clear at all, including some inconsistencies in the examples that they provide.