### PR TITLE
Randomise generations order

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 import os
+import random
 import warnings
 from concurrent.futures import Future
 from typing import (
@@ -276,6 +277,7 @@ class Pipeline:
                 "generation_prompt": [],
                 "raw_generation_responses": [],
             }
+            random.shuffle(generations)
             for generation in generations:
                 processed_generation["generation_model"].append(
                     generation["model_name"]


### PR DESCRIPTION
## Description

This PR updates the `Pipeline._process_batch_generations` method to randomise the order of the generations for a given input. This way, we avoid adding prompt positional bias for the labeller, that could lead to certain model getting better/worse scores by the labeller by the position of its text generation in the prompt.