### PR TITLE
Replace `multiprocessing` with `multiprocess`

### DIFF
--- a/examples/pipeline-llamacpp-and-openai-process.py
+++ b/examples/pipeline-llamacpp-and-openai-process.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# WARNING: to run this example in Mac OS use:
+# no_proxy=* OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python examples/pipeline-llamacpp-and-openai-process.py
+# Otherwise you will get an error when loading the llama.cpp model
+
 import os
 from typing import TYPE_CHECKING
 
@@ -30,7 +34,7 @@ def load_llama_cpp_llm(task: "Task") -> "LLM":
     from distilabel.llm import LlamaCppLLM
 
     llama = Llama(
-        model_path="<PATH_TO_GGUF_MODEL>", n_gpu_layers=10, n_ctx=1024, verbose=False
+        model_path="notus-7b-v1.Q4_0.gguf", n_gpu_layers=10, n_ctx=1024, verbose=True
     )
     return LlamaCppLLM(
         model=llama, task=task, max_new_tokens=512, prompt_format="zephyr"
@@ -66,7 +70,7 @@ if __name__ == "__main__":
     dataset = pipeline.generate(
         dataset,  # type: ignore
         num_generations=2,
-        batch_size=1,
+        batch_size=2,
         enable_checkpoints=True,
         display_progress_bar=False,
     )

--- a/examples/pipeline-llamacpp-and-openai-process.py
+++ b/examples/pipeline-llamacpp-and-openai-process.py
@@ -34,7 +34,7 @@ def load_llama_cpp_llm(task: "Task") -> "LLM":
     from distilabel.llm import LlamaCppLLM
 
     llama = Llama(
-        model_path="notus-7b-v1.Q4_0.gguf", n_gpu_layers=10, n_ctx=1024, verbose=True
+        model_path="<PATH_TO_GGUF_MODEL>", n_gpu_layers=10, n_ctx=1024, verbose=False
     )
     return LlamaCppLLM(
         model=llama, task=task, max_new_tokens=512, prompt_format="zephyr"
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     dataset = pipeline.generate(
         dataset,  # type: ignore
         num_generations=2,
-        batch_size=2,
+        batch_size=1,
         enable_checkpoints=True,
         display_progress_bar=False,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "rich >= 13.5.0",
     "tenacity >= 8",
     "importlib-resources >= 6.1.1; python_version < '3.9'",
+    "multiprocess",
 ]
 dynamic = ["version"]
 

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import multiprocessing as mp
 import queue
 import random
 import warnings
@@ -33,6 +32,8 @@ from typing import (
     Type,
     Union,
 )
+
+import multiprocess as mp
 
 from distilabel.logger import get_logger
 from distilabel.tasks.prompt import Prompt


### PR DESCRIPTION
## Description

The `ProcessLLM` was not working in IPython/Notebooks because `multiprocessing` requires the `__main__` [module to be importable by the child process](https://docs.python.org/3/library/multiprocessing.html). In order to avoid this issue, `multiprocessing` has been replaced with `multiprocess`, a fork of `multiprocessing` that uses `dill` to overcome this issue.

`multiprocess` was already required by `datasets` dependency.