### PR TITLE
Fix `SelfInstructTask.{parse_output,to_argilla_record}` methods and `_build_dataset`

### DIFF
--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import TYPE_CHECKING, Union
 
 from datasets import Dataset
@@ -67,7 +68,14 @@ class CustomDataset(Dataset):
                 for input_arg_name in self.task.input_args_names
             ):
                 continue
-            rg_dataset.add_records(
-                self.task.to_argilla_record(dataset_row=dataset_row)  # type: ignore
-            )
+            try:
+                rg_dataset.add_records(
+                    self.task.to_argilla_record(dataset_row=dataset_row)  # type: ignore
+                )
+            except Exception as e:
+                warnings.warn(
+                    f"Error while converting a row into an Argilla `FeedbackRecord` instance: {e}",
+                    UserWarning,
+                    stacklevel=2,
+                )
         return rg_dataset

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -180,7 +180,6 @@ class Pipeline:
         self,
         inputs: List[Dict[str, Any]],
         num_generations: int,
-        num_batches: int,
         shuffle_before_labelling: bool = True,
         progress_callback_func: Union[Callable, None] = None,
     ) -> List[Dict[str, Any]]:
@@ -191,7 +190,6 @@ class Pipeline:
             inputs (List[Dict[str, Any]]): the inputs to be used for generation.
             num_generations (int): the number of generations to be performed for each
                 input.
-            num_batches (int): the number of batches to be processed.
             shuffle_before_labelling (bool, optional): whether to shuffle the generations
                 before labelling or not. This is useful to avoid the labelling LLM to be
                 biased by the order of the generations. Defaults to `True`.
@@ -617,7 +615,6 @@ class Pipeline:
                     batch_generations = self._get_batch_generations(
                         inputs=inputs,
                         num_generations=num_generations,
-                        num_batches=num_batches,
                         shuffle_before_labelling=shuffle_before_labelling,
                         progress_callback_func=generation_progress_func,
                     )

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -495,12 +495,12 @@ class Pipeline:
                     if key not in label:
                         label.update({key: None})
 
-        _dataset = Dataset(
-            arrow_table=dataset.flatten_indices().data, split=Split.TRAIN
-        )
-        _dataset = _dataset.map(
-            lambda _: {**generations.pop(0), **processed_labels.pop(0)}
-        )  # type: ignore
+        _flattened_dataset = dataset.flatten_indices()
+        _dataset = Dataset.from_dict({}, split=Split.TRAIN)
+        for row, generation, processed_label in zip(
+            _flattened_dataset, generations, processed_labels
+        ):
+            _dataset = _dataset.add_item({**row, **generation, **processed_label})  # type: ignore
         # Dynamically remaps the `datasets.Dataset` to be a `CustomDataset` instance
         _dataset.__class__ = CustomDataset
         if self.generator is not None and self.labeller is None:

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -182,4 +182,8 @@ class SelfInstructTask(TextGenerationTask):
                 fields["instruction"] = instruction
                 metadata["length-instruction"] = len(instruction)
                 records.append(rg.FeedbackRecord(fields=fields, metadata=metadata))
+        if not records:
+            raise ValueError(
+                f"Skipping the row {dataset_row} as the list of `FeedbackRecord` is empty as those could not be inferred."
+            )
         return records

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -96,7 +96,7 @@ class SelfInstructTask(TextGenerationTask):
 
     def parse_output(self, output: str) -> Dict[str, List[str]]:
         """Parses the output of the model into the desired format."""
-        pattern = re.compile(r"\d+\.\s+(.*?)\n")
+        pattern = re.compile(r"\d+\.\s*(.*?)\n")
         return {"instructions": pattern.findall(output)}
 
     def to_argilla_dataset(self, dataset_row: Dict[str, Any]) -> "FeedbackDataset":


### PR DESCRIPTION
## Description

This PR adds some follow-up fixes for the `SelfInstructTask` as the `parse_output` method was strict with the formatting and it was expecting spaces to be right after each numbered list identifier, which was not the case in every output, so it has been loosened so that the space is optional. Additionally, this PR also adds some more consistency and robustness to the `to_argilla` method so that if the `to_argilla_record` method fails for any task, the error is handled and it continues until the loop over all the records ends; while also raising a `ValueError` if `SelfInstructTask.to_argilla_record` fails to generate the records.

Kudos to @ignacioct for spotting the issues related to `SelfInstructTask` and reporting right away!

Additionally, this PR also fixes an issue related to the `_build_dataset` method since the `map` apparently is not merging the labels within the dataset in order, the reason is not clear yet, but could be either due to the recently included `random` import or due to some `multiprocessing` happening in the background during the `map` method of `datasets`. So on, the current approach is more consistent.