### PR TITLE
Fix `results` didn't have same order as `futures`

### DIFF
--- a/src/distilabel/utils/futures.py
+++ b/src/distilabel/utils/futures.py
@@ -34,10 +34,14 @@ def when_all_complete(futures: List[Future[T]]) -> Future[T]:
             completed, and it will contain the results of the `futures`.
     """
     all_done_future = Future()
-    results = []
+    results = [None] * len(futures)
 
     def check_all_done(future: Future) -> None:
-        results.extend(future.result())
+        # This is done to preserve the order of the results with respect to the order
+        # of the futures.
+        index = futures.index(future)
+        results[index] = future.result()[0]
+
         _, not_done = wait(futures, return_when="FIRST_COMPLETED")
         if len(not_done) == 0:
             all_done_future.set_result(results)


### PR DESCRIPTION
## Description

This PR fix a bug that was introduced in #164. The order of the `results` with respect of the `futures` was not being preserver in the `when_all_complete` function (kudos to @alvarobartt for spotting the issue).