### PR TITLE
Add `{generation,labelling}_model` column as metadata in Argilla

### DIFF
--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -82,7 +82,7 @@ class CustomDataset(Dataset):
                 continue
             try:
                 rg_dataset.add_records(
-                    self.task.to_argilla_record(dataset_row=dataset_row)
+                    self.task.to_argilla_record(dataset_row=dataset_row)  # type: ignore
                 )  # type: ignore
             except Exception as e:
                 warnings.warn(

--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -81,8 +81,9 @@ class CustomDataset(Dataset):
             ):
                 continue
             try:
-                records = self.task.to_argilla_record(dataset_row=dataset_row)  # type: ignore
-                rg_dataset.add_records(records)  # type: ignore
+                rg_dataset.add_records(
+                    self.task.to_argilla_record(dataset_row=dataset_row)
+                )  # type: ignore
             except Exception as e:
                 warnings.warn(
                     f"Error while converting a row into an Argilla `FeedbackRecord` instance: {e}",

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -200,7 +200,7 @@ class Pipeline:
         Returns:
             List[Dict[str, Any]]: the processed batch generations.
         """
-        outputs = self.generator.generate(
+        outputs = self.generator.generate(  # type: ignore
             inputs=inputs,
             num_generations=num_generations,
             progress_callback_func=progress_callback_func,

--- a/src/distilabel/tasks/base.py
+++ b/src/distilabel/tasks/base.py
@@ -27,7 +27,7 @@ from jinja2 import Template
 from distilabel.tasks.prompt import Prompt
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.dataset.local.dataset import FeedbackDataset
+    from argilla import FeedbackDataset
     from argilla.client.feedback.schemas.records import FeedbackRecord
 
 

--- a/src/distilabel/tasks/preference/base.py
+++ b/src/distilabel/tasks/preference/base.py
@@ -17,7 +17,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from distilabel.tasks.base import Task
-from distilabel.utils.argilla import infer_fields_from_dataset_row
+from distilabel.utils.argilla import (
+    infer_fields_from_dataset_row,
+    model_metadata_from_dataset_row,
+)
 from distilabel.utils.imports import _ARGILLA_AVAILABLE
 
 if _ARGILLA_AVAILABLE:
@@ -202,6 +205,10 @@ class PreferenceTask(Task):
                 metadata[f"distance-best-{ratings_column}"] = (
                     sorted_ratings[0] - sorted_ratings[1]
                 )
+        # Then we add the model metadata from the `generation_model` and `labelling_model`
+        # columns of the dataset, if they exist.
+        metadata.update(model_metadata_from_dataset_row(dataset_row=dataset_row))
+        # Finally, we return the `FeedbackRecord` with the fields and the metadata
         return rg.FeedbackRecord(
             fields=fields, suggestions=suggestions, metadata=metadata
         )

--- a/src/distilabel/tasks/preference/base.py
+++ b/src/distilabel/tasks/preference/base.py
@@ -24,7 +24,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.dataset.local.dataset import FeedbackDataset
+    from argilla import FeedbackDataset
     from argilla.client.feedback.schemas.records import FeedbackRecord
 
 

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -21,7 +21,7 @@ from distilabel.tasks.preference.base import PreferenceTask
 from distilabel.tasks.prompt import Prompt
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.dataset.local.dataset import FeedbackDataset
+    from argilla import FeedbackDataset
 
 _ULTRAFEEDBACK_TEMPLATE = get_template("ultrafeedback.jinja2")
 

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -20,7 +20,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 from distilabel.tasks.base import Task
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.principles import UltraFeedbackPrinciples
-from distilabel.utils.argilla import infer_fields_from_dataset_row
+from distilabel.utils.argilla import (
+    infer_fields_from_dataset_row,
+    model_metadata_from_dataset_row,
+)
 from distilabel.utils.imports import _ARGILLA_AVAILABLE
 
 if _ARGILLA_AVAILABLE:
@@ -235,4 +238,8 @@ class TextGenerationTask(Task):
                     UserWarning,
                     stacklevel=2,
                 )
+        # Then we add the model metadata from the `generation_model` and `labelling_model`
+        # columns of the dataset, if they exist.
+        metadata.update(model_metadata_from_dataset_row(dataset_row=dataset_row))
+        # Finally, we return the `FeedbackRecord` with the fields and the metadata
         return rg.FeedbackRecord(fields=fields, metadata=metadata)

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -27,7 +27,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.dataset.local.dataset import FeedbackDataset
+    from argilla import FeedbackDataset
     from argilla.client.feedback.schemas.records import FeedbackRecord
 
 

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -27,7 +27,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.dataset.local.dataset import FeedbackDataset
+    from argilla import FeedbackDataset
     from argilla.client.feedback.schemas.records import FeedbackRecord
 
 _SELF_INSTRUCT_TEMPLATE = get_template("self-instruct.jinja2")

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -20,7 +20,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from distilabel.tasks.base import get_template
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.base import TextGenerationTask
-from distilabel.utils.argilla import infer_fields_from_dataset_row
+from distilabel.utils.argilla import (
+    infer_fields_from_dataset_row,
+    model_metadata_from_dataset_row,
+)
 from distilabel.utils.imports import _ARGILLA_AVAILABLE
 
 if _ARGILLA_AVAILABLE:
@@ -181,6 +184,13 @@ class SelfInstructTask(TextGenerationTask):
                         )
                 fields["instruction"] = instruction
                 metadata["length-instruction"] = len(instruction)
+
+                # Then we add the model metadata from the `generation_model` and `labelling_model`
+                # columns of the dataset, if they exist.
+                metadata.update(
+                    model_metadata_from_dataset_row(dataset_row=dataset_row)
+                )
+                # Finally, we append the `FeedbackRecord` with the fields and the metadata
                 records.append(rg.FeedbackRecord(fields=fields, metadata=metadata))
         if not records:
             raise ValueError(

--- a/src/distilabel/utils/argilla.py
+++ b/src/distilabel/utils/argilla.py
@@ -55,7 +55,7 @@ def infer_model_metadata_properties(
         )
     metadata_properties = []
     for column_name in ["generation_model", "labelling_model"]:
-        if column_name not in hf_dataset:
+        if column_name not in hf_dataset.column_names:
             continue
         models = []
         for item in hf_dataset[column_name]:

--- a/src/distilabel/utils/argilla.py
+++ b/src/distilabel/utils/argilla.py
@@ -74,3 +74,12 @@ def infer_model_metadata_properties(
         for metadata_property in metadata_properties:
             rg_dataset.add_metadata_property(metadata_property)
     return rg_dataset
+
+
+def model_metadata_from_dataset_row(dataset_row: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = {}
+    if "generation_model" in dataset_row:
+        metadata["generation-model"] = dataset_row["generation_model"]
+    if "labelling_model" in dataset_row:
+        metadata["labelling-model"] = dataset_row["labelling_model"]
+    return metadata


### PR DESCRIPTION
## Description

This PR adds both the `generation_model` and the `labelling_model` as `metadata_properties` in the `FeedbackDataset` in Argilla when calling the `to_argilla_dataset` methods, and also adds the relevant metadata to the `FeedbackRecord`s in `to_argilla_record`.