### PR TITLE
Add `docs` workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - main
+      - gh-pages
+    tags:
+      - "**"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set git credentials
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.name "${{ github.actor }}@users.noreply.github.com"
+
+      - run: mike deploy dev --push
+        if: github.ref == 'refs/heads/main'
+
+      - run: mike deploy latest ${{ github.ref_name }} --push
+        if: startsWith(github.ref, 'refs/tags/')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ extra_css:
 theme:
   name: material
   logo: assets/logo.svg
-  favicon: assets/distilabel-icon.svg
+  favicon: assets/logo.svg
   features:
     - navigation.instant
     - navigation.tabs


### PR DESCRIPTION
## Description

This PR adds a new workflow that will be automatically executed every time there is a push to `main` or `gh-pages`:

1. If the workflows gets triggered because a push to `main`, then a new version of the docs with the `dev` alias will be build and published.
2. If the workflows get triggered because a new tag is pushed, then a new version of the docs with the `latest` alias and the name of the tag will be published.