### PR TITLE
Remove learn section from docs until developed

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,18 +44,6 @@ For a more complete example, check out our awesome notebook on Google Colab:
 
 <div class="grid cards" markdown>
 
--   <p align="center"> [**Tutorials**](./learn/tutorials/)</p>
-
-    ---
-
-    End to end project lessons.
-
--   <p align="center"> [**User Guides**](./learn/user-guides/)</p>
-
-    ---
-
-    Practical guides to achieve specific tasks with `distilabel`.
-
 -   <p align="center"> [**Concept Guides**](./technical-reference/llms.md)</p>
 
     ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,12 +78,6 @@ plugins:
 nav:
   - Getting started: index.md
   - Concepts: concepts.md
-  - Learn:
-      - learn/index.md
-      - Tutorials:
-          - learn/tutorials/index.md
-      - User Guides:
-          - learn/user-guides/index.md
   - Technical References:
       - Concept Guides:
           - technical-reference/index.md


### PR DESCRIPTION
## Description

Closes #181. The folders are still in the docs just in case we want to reuse them, but not shown.
