### PR TITLE
Add markdown to fields by default

### DIFF
--- a/src/distilabel/utils/argilla.py
+++ b/src/distilabel/utils/argilla.py
@@ -42,7 +42,9 @@ def infer_fields_from_dataset_row(
                     rg.TextField(name=f"{arg_name}-{idx}", title=f"{arg_name}-{idx}")  # type: ignore
                 )  # type: ignore
         elif isinstance(dataset_row[arg_name], str):
-            processed_items.append(rg.TextField(name=arg_name, title=arg_name))  # type: ignore
+            processed_items.append(
+                rg.TextField(name=arg_name, title=arg_name, use_markdown=True)
+            )  # type: ignore
     return processed_items
 
 


### PR DESCRIPTION
## Description

As @dvsrepo noted markdown wasn't added by default to fields, now we have nicely rendered code when pushing datasets to argilla:
![image](https://github.com/argilla-io/distilabel/assets/56895847/b33f1f9d-e24c-4ce3-9c0b-d5d39eb09029)

Closes #180.


