### PR TITLE
Fix `PrometheusTask` could not be imported

### DIFF
--- a/examples/pipeline-prometheus.py
+++ b/examples/pipeline-prometheus.py
@@ -18,7 +18,7 @@ import torch
 from datasets import Dataset
 from distilabel.llm import TransformersLLM
 from distilabel.pipeline import Pipeline
-from distilabel.tasks.critique.prometheus import PrometheusTask
+from distilabel.tasks import PrometheusTask
 from transformers import AutoTokenizer, LlamaForCausalLM
 
 if __name__ == "__main__":

--- a/src/distilabel/tasks/__init__.py
+++ b/src/distilabel/tasks/__init__.py
@@ -14,6 +14,7 @@
 
 from distilabel.tasks.base import Task
 from distilabel.tasks.critique.base import CritiqueTask
+from distilabel.tasks.critique.prometheus import PrometheusTask
 from distilabel.tasks.critique.ultracm import UltraCMTask
 from distilabel.tasks.preference.judgelm import JudgeLMTask
 from distilabel.tasks.preference.ultrafeedback import UltraFeedbackTask
@@ -27,6 +28,7 @@ from distilabel.tasks.text_generation.self_instruct import SelfInstructTask
 __all__ = [
     "Task",
     "CritiqueTask",
+    "PrometheusTask",
     "UltraCMTask",
     "JudgeLMTask",
     "UltraFeedbackTask",

--- a/src/distilabel/tasks/critique/base.py
+++ b/src/distilabel/tasks/critique/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Literal
+from typing import ClassVar, List, Literal
 
 from typing_extensions import TypedDict
 
@@ -29,7 +29,7 @@ class CritiqueTask(Task):
         task_description (Union[str, None], optional): the description of the task. Defaults to `None`.
     """
 
-    __type__: Literal["labelling"] = "labelling"
+    __type__: ClassVar[Literal["labelling"]] = "labelling"
 
     @property
     def input_args_names(self) -> List[str]:

--- a/src/distilabel/tasks/preference/base.py
+++ b/src/distilabel/tasks/preference/base.py
@@ -14,7 +14,7 @@
 
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional
 
 from distilabel.tasks.base import Task
 from distilabel.utils.argilla import (
@@ -39,6 +39,8 @@ class PreferenceTask(Task):
         system_prompt (str): the system prompt to be used for generation.
         task_description (Union[str, None], optional): the description of the task. Defaults to `None`.
     """
+
+    __type__: ClassVar[Literal["labelling"]] = "labelling"
 
     @property
     def input_args_names(self) -> List[str]:

--- a/src/distilabel/tasks/preference/judgelm.py
+++ b/src/distilabel/tasks/preference/judgelm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import ClassVar, List, Literal, TypedDict
+from typing import ClassVar, List, TypedDict
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.preference.base import PreferenceTask
@@ -51,7 +51,6 @@ class JudgeLMTask(PreferenceTask):
     system_prompt: str = "You are a helpful and precise assistant for checking the quality of the answer."
 
     __jinja2_template__: ClassVar[str] = _JUDGELM_TEMPLATE
-    __type__: Literal["labelling"] = "labelling"
 
     def generate_prompt(self, input: str, generations: List[str]) -> Prompt:
         """Generates a prompt following the JudgeLM specification.

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -20,7 +20,6 @@ from typing import (
     ClassVar,
     Dict,
     List,
-    Literal,
     Optional,
     TypedDict,
 )
@@ -76,7 +75,6 @@ class UltraFeedbackTask(PreferenceTask):
         "honesty",
         "instruction-following",
     ]
-    __type__: Literal["labelling"] = "labelling"
 
     def generate_prompt(self, input: str, generations: List[str]) -> Prompt:
         """Generates a prompt following the ULTRAFEEDBACK specification.

--- a/src/distilabel/tasks/preference/ultrajudge.py
+++ b/src/distilabel/tasks/preference/ultrajudge.py
@@ -14,7 +14,7 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Literal, TypedDict
+from typing import Any, ClassVar, Dict, List, TypedDict
 
 from distilabel.tasks.base import Prompt, get_template
 from distilabel.tasks.preference.base import PreferenceTask
@@ -79,7 +79,6 @@ class UltraJudgeTask(PreferenceTask):
     __jinja2_template__: ClassVar[str] = field(
         default=_ULTRAJUDGE_TEMPLATE, init=False, repr=False
     )
-    __type__: Literal["labelling"] = "labelling"
 
     @property
     def output_args_names(self) -> List[str]:


### PR DESCRIPTION
## Description

`PrometheusTask` couldn't be imported after a bug that was introduced in #177, in which a `__type__` attribute with a default value (either `"labelling"` or `"generator"`) was added to the `Task`s base classes (`PreferenceTask` and `CritiqueTask`) which should be a `ClassVar`.

This was not allowing to the `dataclass`es inheriting from these classes to define non-default attributes causing the error described in #184.

In addition this PR have added `PrometheusTask` to `distilabel.tasks.__init__`, so it can be imported using `from distilabel.tasks import PrometheusTask`.