### PR TITLE
Fix `PrometheusTask` and `UltraCMTask` could not be chained with `TextGenerationTask`

### DIFF
--- a/examples/pipeline-prometheus.py
+++ b/examples/pipeline-prometheus.py
@@ -50,8 +50,8 @@ if __name__ == "__main__":
 
     dataset = Dataset.from_dict(
         {
-            "instruction": ["What's the capital of Spain?"],
-            "completion": ["Paris"],
+            "input": ["What's the capital of Spain?"],
+            "generations": ["Paris"],
             "ref_completion": ["Madrid"],
         }
     )

--- a/examples/pipeline-ultracm.py
+++ b/examples/pipeline-ultracm.py
@@ -33,8 +33,8 @@ if __name__ == "__main__":
 
     dataset = Dataset.from_dict(
         {
-            "instruction": ["What's the capital of Spain?"],
-            "completion": ["Madrid"],
+            "input": ["What's the capital of Spain?"],
+            "generations": ["Madrid"],
         }
     )
 

--- a/src/distilabel/tasks/critique/base.py
+++ b/src/distilabel/tasks/critique/base.py
@@ -34,7 +34,7 @@ class CritiqueTask(Task):
     @property
     def input_args_names(self) -> List[str]:
         """Returns the names of the input arguments of the task."""
-        return ["instruction", "completion"]
+        return ["input", "generations"]
 
     @property
     def output_args_names(self) -> List[str]:

--- a/src/distilabel/tasks/critique/prometheus.py
+++ b/src/distilabel/tasks/critique/prometheus.py
@@ -14,7 +14,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.critique.base import CritiqueTask, CritiqueTaskOutput
@@ -37,10 +37,7 @@ class PrometheusTask(CritiqueTask):
         return super().input_args_names + ["ref_completion"]
 
     def generate_prompt(
-        self,
-        input: str,
-        generations: str,
-        ref_completion: str,
+        self, input: str, generations: str, ref_completion: str, **_: Any
     ) -> str:
         render_kwargs = {
             "instruction": input,

--- a/src/distilabel/tasks/critique/prometheus.py
+++ b/src/distilabel/tasks/critique/prometheus.py
@@ -38,13 +38,13 @@ class PrometheusTask(CritiqueTask):
 
     def generate_prompt(
         self,
-        instruction: str,
-        completion: str,
+        input: str,
+        generations: str,
         ref_completion: str,
     ) -> str:
         render_kwargs = {
-            "instruction": instruction,
-            "completion": completion,
+            "instruction": input,
+            "completion": generations,
             "ref_completion": ref_completion,
             "scoring_criteria": self.scoring_criteria,
             "score_descriptions": self.score_descriptions,

--- a/src/distilabel/tasks/critique/ultracm.py
+++ b/src/distilabel/tasks/critique/ultracm.py
@@ -14,7 +14,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.critique.base import CritiqueTask, CritiqueTaskOutput
@@ -32,10 +32,10 @@ class UltraCMTask(CritiqueTask):
         " the user's questions.</s>"
     )
 
-    def generate_prompt(self, instruction: str, completion: str) -> str:
+    def generate_prompt(self, input: str, generations: str, **_: Any) -> str:
         render_kwargs = {
-            "instruction": instruction,
-            "completion": completion,
+            "instruction": input,
+            "completion": generations,
         }
         return f"{self.system_prompt}\nUser: {self.template.render(**render_kwargs)}</s>\nAssistant: ### Feedback\nOverall Score: "
 

--- a/src/distilabel/tasks/preference/base.py
+++ b/src/distilabel/tasks/preference/base.py
@@ -27,8 +27,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla import FeedbackDataset
-    from argilla.client.feedback.schemas.records import FeedbackRecord
+    from argilla import FeedbackDataset, FeedbackRecord
 
 
 @dataclass

--- a/src/distilabel/tasks/preference/judgelm.py
+++ b/src/distilabel/tasks/preference/judgelm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import ClassVar, List, TypedDict
+from typing import Any, ClassVar, List, TypedDict
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.preference.base import PreferenceTask
@@ -52,7 +52,7 @@ class JudgeLMTask(PreferenceTask):
 
     __jinja2_template__: ClassVar[str] = _JUDGELM_TEMPLATE
 
-    def generate_prompt(self, input: str, generations: List[str]) -> Prompt:
+    def generate_prompt(self, input: str, generations: List[str], **_: Any) -> Prompt:
         """Generates a prompt following the JudgeLM specification.
 
         Args:

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -76,7 +76,7 @@ class UltraFeedbackTask(PreferenceTask):
         "instruction-following",
     ]
 
-    def generate_prompt(self, input: str, generations: List[str]) -> Prompt:
+    def generate_prompt(self, input: str, generations: List[str], **_: Any) -> Prompt:
         """Generates a prompt following the ULTRAFEEDBACK specification.
 
         Args:

--- a/src/distilabel/tasks/preference/ultrajudge.py
+++ b/src/distilabel/tasks/preference/ultrajudge.py
@@ -100,7 +100,7 @@ class UltraJudgeTask(PreferenceTask):
         """Returns a regex to extract the final scores from the output."""
         return r"Final scores:\s*((?:\d+(?:\.\d+)?\s*)+)"
 
-    def generate_prompt(self, input: str, generations: List[str]) -> Prompt:
+    def generate_prompt(self, input: str, generations: List[str], **_: Any) -> Prompt:
         """Generates a prompt following the UltraJudge specification.
 
         Args:

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -15,7 +15,7 @@
 import random
 import warnings
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from distilabel.tasks.base import Task
 from distilabel.tasks.prompt import Prompt
@@ -70,7 +70,7 @@ class TextGenerationTask(Task):
     )
     principles_distribution: Union[Dict[str, float], Literal["balanced"], None] = None
 
-    __type__: Literal["generation"] = "generation"
+    __type__: ClassVar[Literal["generation"]] = "generation"
 
     def __post_init__(self) -> None:
         """Validates the `principles_distribution` if it is a dict.
@@ -116,7 +116,7 @@ class TextGenerationTask(Task):
             principle_group = random.choice(list(self.principles.keys()))
         return random.choice(self.principles[principle_group])
 
-    def generate_prompt(self, input: str) -> Prompt:
+    def generate_prompt(self, input: str, **_: Any) -> Prompt:
         """Generates the prompt to be used for generation.
 
         Args:

--- a/src/distilabel/tasks/text_generation/llama.py
+++ b/src/distilabel/tasks/text_generation/llama.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.base import TextGenerationTask
 
@@ -27,7 +29,7 @@ class Llama2TextGenerationTask(TextGenerationTask):
             distribution of principles to be used for the system prompt. Defaults to `None`.
     """
 
-    def generate_prompt(self, input: str) -> str:
+    def generate_prompt(self, input: str, **_: Any) -> str:
         """Generates a prompt for the Llama2 model.
 
         Args:

--- a/src/distilabel/tasks/text_generation/openai.py
+++ b/src/distilabel/tasks/text_generation/openai.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List
 
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.base import TextGenerationTask
@@ -32,7 +32,7 @@ class OpenAITextGenerationTask(TextGenerationTask):
             distribution of principles to be used for the system prompt. Defaults to `None`.
     """
 
-    def generate_prompt(self, input: str) -> List["ChatCompletion"]:
+    def generate_prompt(self, input: str, **_: Any) -> List["ChatCompletion"]:
         """Generates a prompt for any chat-completion OpenAI model.
 
         Args:

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -65,7 +65,7 @@ class SelfInstructTask(TextGenerationTask):
 
     __jinja2_template__: str = _SELF_INSTRUCT_TEMPLATE
 
-    def generate_prompt(self, input: str) -> Prompt:
+    def generate_prompt(self, input: str, **_: Any) -> Prompt:
         """Generates a prompt following the Self-Instruct specification.
 
         Args:


### PR DESCRIPTION
## Description

The arguments of `generate_prompt` method for both `PrometheusTask` and `UltraCMTask` classes were not aligned with the ones generated by the `TextGenerationTask`, not allowing to have a `Pipeline` with a `generator` using the `TextGenerationTask` and a `labeller` using either `PrometheusTask` or `UltraCMTask`.

In addition, all the `generate_prompt` methods have been updated to accept extra keyword arguments and ignore them (`**_`). This is useful and convenient for the cases in which a `Dataset` contains more columns than the required by the task. Before if the input dataset contained additional columns not used by the task it would cause an error.

