### PR TITLE
Fix `UltraCMTask` scoring range and align `argilla` imports

### DIFF
--- a/src/distilabel/tasks/base.py
+++ b/src/distilabel/tasks/base.py
@@ -27,8 +27,7 @@ from jinja2 import Template
 from distilabel.tasks.prompt import Prompt
 
 if TYPE_CHECKING:
-    from argilla import FeedbackDataset
-    from argilla.client.feedback.schemas.records import FeedbackRecord
+    from argilla import FeedbackDataset, FeedbackRecord
 
 
 def get_template(template_name: str) -> str:

--- a/src/distilabel/tasks/critique/ultracm.py
+++ b/src/distilabel/tasks/critique/ultracm.py
@@ -14,11 +14,14 @@
 
 import re
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
 
 from distilabel.tasks.base import get_template
 from distilabel.tasks.critique.base import CritiqueTask, CritiqueTaskOutput
 from distilabel.tasks.prompt import Prompt
+
+if TYPE_CHECKING:
+    from argilla import FeedbackDataset
 
 _ULTRACM_TEMPLATE = get_template("ultracm.jinja2")
 
@@ -52,3 +55,19 @@ class UltraCMTask(CritiqueTask):
                 score=float(match.group(1)),
                 critique=match.group(2).strip(),
             )
+
+    def to_argilla_dataset(
+        self,
+        dataset_row: Dict[str, Any],
+        generations_column: str = "generations",
+        score_column: str = "score",
+        critique_column: str = "critique",
+        score_values: Optional[List[int]] = None,
+    ) -> "FeedbackDataset":
+        return super().to_argilla_dataset(
+            dataset_row=dataset_row,
+            generations_column=generations_column,
+            score_column=score_column,
+            critique_column=critique_column,
+            score_values=score_values or [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        )

--- a/src/distilabel/tasks/text_generation/base.py
+++ b/src/distilabel/tasks/text_generation/base.py
@@ -30,8 +30,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla import FeedbackDataset
-    from argilla.client.feedback.schemas.records import FeedbackRecord
+    from argilla import FeedbackDataset, FeedbackRecord
 
 
 @dataclass

--- a/src/distilabel/tasks/text_generation/self_instruct.py
+++ b/src/distilabel/tasks/text_generation/self_instruct.py
@@ -30,8 +30,7 @@ if _ARGILLA_AVAILABLE:
     import argilla as rg
 
 if TYPE_CHECKING:
-    from argilla import FeedbackDataset
-    from argilla.client.feedback.schemas.records import FeedbackRecord
+    from argilla import FeedbackDataset, FeedbackRecord
 
 _SELF_INSTRUCT_TEMPLATE = get_template("self-instruct.jinja2")
 


### PR DESCRIPTION
## Description

This minor PR is to fix an issue with the scoring scale of `UltraCMTask` as the prompt specifies 1-10 while we were setting it to 1-5 by default, instead, we've updated the default value to be within the 1-10 range. Additionally, in this PR also the `argilla` imports have been aligned for simplicity so now the imports are as `from argilla import ...` instead of importing from submodules unless necessary.