### PR TITLE
Add `VertexAILLM` & `VertexAIEndpointLLM` classes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -e .[dev,tests]
+        run: pip install -e .[dev,tests,vertexai]
 
       - name: Lint
         run: make lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ hf-inference-endpoints = ["huggingface_hub >= 0.19.0"]
 llama-cpp = ["llama-cpp-python >= 0.2.0"]
 openai = ["openai >= 1.0.0"]
 vllm = ["vllm >= 0.2.1"]
+vertexai = ["google-cloud-aiplatform >= 1.38.0"]
 argilla = ["argilla >= 1.18.0"]
 tests = ["pytest >= 7.4.0"]
 docs = [

--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from distilabel.llm.base import LLM, LLMPool, ProcessLLM
+from distilabel.llm.google.vertexai import VertexGenerativeModelLLM
 from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
 from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
@@ -28,4 +29,5 @@ __all__ = [
     "ProcessLLM",
     "LLM",
     "LLMPool",
+    "VertexGenerativeModelLLM",
 ]

--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from distilabel.llm.base import LLM, LLMPool, ProcessLLM
-from distilabel.llm.google.vertexai import VertexGenerativeModelLLM
+from distilabel.llm.google.vertexai import VertexAILLM
 from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
 from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
@@ -29,5 +29,5 @@ __all__ = [
     "ProcessLLM",
     "LLM",
     "LLMPool",
-    "VertexGenerativeModelLLM",
+    "VertexAILLM",
 ]

--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from distilabel.llm.base import LLM, LLMPool, ProcessLLM
-from distilabel.llm.google.vertexai import VertexAILLM
+from distilabel.llm.google.vertexai import VertexAIEndpointLLM, VertexAILLM
 from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
 from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
@@ -21,13 +21,14 @@ from distilabel.llm.openai import OpenAILLM
 from distilabel.llm.vllm import vLLM
 
 __all__ = [
-    "OpenAILLM",
-    "LlamaCppLLM",
-    "vLLM",
-    "InferenceEndpointsLLM",
-    "TransformersLLM",
-    "ProcessLLM",
     "LLM",
     "LLMPool",
+    "ProcessLLM",
+    "VertexAIEndpointLLM",
     "VertexAILLM",
+    "InferenceEndpointsLLM",
+    "TransformersLLM",
+    "LlamaCppLLM",
+    "OpenAILLM",
+    "vLLM",
 ]

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -29,7 +29,6 @@ from typing import (
     Dict,
     Generator,
     List,
-    Type,
     Union,
 )
 
@@ -118,7 +117,6 @@ class LLM(ABC):
         self,
         inputs: List[Dict[str, Any]],
         default_format: Union["SupportedFormats", None] = None,
-        expected_output_type: Type = str,
     ) -> List[Any]:
         """Generates the prompts to be used for generation.
 
@@ -126,7 +124,6 @@ class LLM(ABC):
             inputs (List[Dict[str, Any]]): the inputs to be used for generation.
             default_format (Union["SupportedFormats", None], optional): the default format to be used
                 for the prompt if no `prompt_format` is specified. Defaults to `None`.
-            expected_output_type (Type, optional): the expected type of the prompt. Defaults to `str`.
 
         Returns:
             List[Any]: the generated prompts.
@@ -161,13 +158,6 @@ class LLM(ABC):
                         stacklevel=2,
                     )
                     prompt = prompt.format_as(format="default")
-            if not isinstance(prompt, expected_output_type):
-                raise ValueError(
-                    f"The provided `prompt={prompt}` is of `type={type(prompt)}`, but it must be of"
-                    f" `type={expected_output_type}`, so make sure that `task.generate_prompt` returns"
-                    f" a `{expected_output_type}` or that the `formatting_fn` formats the prompt as a "
-                    f" `{expected_output_type}`."
-                )
             prompts.append(prompt)
         return prompts
 

--- a/src/distilabel/llm/google/__init__.py
+++ b/src/distilabel/llm/google/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/distilabel/llm/google/vertexai.py
+++ b/src/distilabel/llm/google/vertexai.py
@@ -443,7 +443,9 @@ class VertexAIEndpointLLM(LLM):
     def _call_vertexai_endpoint(self, instances: List[Any]) -> Any:
         return self.client.predict(endpoint=self.endpoint_path, instances=instances)
 
-    def _prepare_instances(self, prompts: List[str], num_generations: int) -> List[Any]:
+    def _prepare_instances(
+        self, prompts: List[str], num_generations: int
+    ) -> List["Value"]:
         """Prepares the instances to be sent to the Vertex AI endpoint.
 
         Args:
@@ -451,7 +453,7 @@ class VertexAIEndpointLLM(LLM):
             num_generations (int): the number of generations to be performed for each prompt.
 
         Returns:
-            List[Any]: the instances to be sent to the Vertex AI endpoint.
+            The instances to be sent to the Vertex AI endpoint.
         """
         instances = []
         for prompt in prompts:
@@ -512,9 +514,4 @@ class VertexAIEndpointLLM(LLM):
         instances = self._prepare_instances(
             prompts=prompts, num_generations=num_generations
         )
-
-        outputs = []
-        for instance in instances:
-            outputs.append(self._single_output(instance))
-
-        return outputs
+        return [self._single_output(instance) for instance in instances]

--- a/src/distilabel/llm/google/vertexai.py
+++ b/src/distilabel/llm/google/vertexai.py
@@ -1,0 +1,152 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from distilabel.llm import LLM
+from distilabel.llm.utils import LLMOutput
+from distilabel.logger import get_logger
+from distilabel.utils.imports import _VERTEXAI_AVAILABLE
+
+if _VERTEXAI_AVAILABLE:
+    from vertexai.preview.generative_models import GenerationConfig, GenerativeModel
+
+if TYPE_CHECKING:
+    from vertexai.preview.generative_models import GenerationResponse
+
+    from distilabel.tasks.base import Task
+
+logger = get_logger()
+
+
+class VertexGenerativeModelLLM(LLM):
+    """An `LLM` which allows to use models from the Gemini API of Vertex AI."""
+
+    def __init__(
+        self,
+        task: "Task",
+        model: str = "gemini-pro",
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        max_new_tokens: int = 128,
+        stop_sequences: Optional[List[str]] = None,
+        num_threads: Union[int, None] = None,
+    ) -> None:
+        """Initializes the `VertexGenerativeModelLLM` class.
+
+        Args:
+            task (Task): the task to be performed by the LLM.
+            model (str, optional): the model to be used for generation. Defaults to "gemini-pro".
+            temperature (float, optional): the temperature to be used for generation.
+                Defaults to 1.0.
+            top_p (float, optional): the top-p value to be used for generation.
+                Defaults to 1.0.
+            top_k (int, optional): the top-k value to be used for generation.
+                Defaults to 40.
+            max_new_tokens (int, optional): the maximum number of tokens to be generated.
+                Defaults to 128.
+            num_threads (Union[int, None], optional): the number of threads to be used
+                for parallel generation. If `None`, no parallel generation will be performed.
+                Defaults to `None`.
+        """
+        super().__init__(task=task, num_threads=num_threads)
+
+        if not _VERTEXAI_AVAILABLE:
+            raise ImportError(
+                "`VertexAILLM` cannot be used as `google-cloud-aiplatform` is not installed,"
+                " please install it with `pip install google-cloud-aiplatform`"
+            )
+
+        self.temperature = temperature
+        self.top_p = top_p
+        self.top_k = top_k
+        self.max_output_tokens = max_new_tokens
+        self.stop_sequences = stop_sequences
+
+        # TODO: check if there's any endpoint to get available models
+        if model not in ["gemini-pro", "gemini-pro-vision"]:
+            raise ValueError(
+                f"Model '{model}' is not available in the Gemini API of Vertex AI."
+            )
+        self.model = GenerativeModel(model)
+
+    @property
+    def model_name(self) -> str:
+        """Returns the name of the model used for generation."""
+        return self.model._model_name
+
+    def _generate_contents(
+        self, inputs: List[Dict[str, Any]]
+    ) -> List[List[Dict[str, Any]]]:
+        """Generates a list of valid dicts that can be parsed to `vertexai.preview.generative_models.Content`
+        objects for each input.
+
+        Args:
+            inputs (List[Dict[str, Any]]): the inputs to be used for generation.
+
+        Returns:
+            List[List[Dict[str, Any]]]: the list of valid `vertexai.preview.generative_models.Content`
+                objects.
+        """
+        contents = []
+        for input in inputs:
+            prompt = self.task.generate_prompt(**input)
+            contents.append(
+                [
+                    {"role": "user", "parts": [{"text": prompt.system_prompt}]},
+                    {"role": "model", "parts": [{"text": "Understood."}]},
+                    {"role": "user", "parts": [{"text": prompt.formatted_prompt}]},
+                ]
+            )
+        return contents
+
+    def _generate(
+        self, inputs: List[Dict[str, Any]], num_generations: int = 1
+    ) -> List[List["LLMOutput"]]:
+        inputs_contents = self._generate_contents(inputs)
+        outputs = []
+        for contents in inputs_contents:
+            output = []
+            # TODO: remove this for-loop once `GenerationConfig.candidate_count` valid range is not [1, 2)
+            for _ in range(num_generations):
+                response: "GenerationResponse" = self.model.generate_content(  # type: ignore
+                    contents=contents,
+                    generation_config=GenerationConfig(
+                        temperature=self.temperature,
+                        top_p=self.top_p,
+                        top_k=self.top_k,
+                        # TODO: update this parameter to have `num_generations` as value once `GenerationConfig.candidate_count` valid range is not [1, 2)
+                        candidate_count=1,
+                        max_output_tokens=self.max_output_tokens,
+                        stop_sequences=self.stop_sequences,
+                    ),
+                )
+
+                try:
+                    parsed_response = self.task.parse_output(response.text)
+                except Exception as e:
+                    logger.error(f"Error parsing OpenAI response: {e}")
+                    parsed_response = None
+
+                output.append(
+                    LLMOutput(
+                        model_name=self.model_name,
+                        prompt_used=contents,
+                        raw_output=response.text,
+                        parsed_output=parsed_response,
+                    )
+                )
+            outputs.append(output)
+        return outputs

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -174,9 +174,7 @@ class InferenceEndpointsLLM(LLM):
         Returns:
             List[List[LLMOutput]]: the outputs of the LLM.
         """
-        prompts = self._generate_prompts(
-            inputs, default_format=None, expected_output_type=str
-        )
+        prompts = self._generate_prompts(inputs, default_format=None)
         outputs = []
         for prompt in prompts:
             raw_responses = [

--- a/src/distilabel/llm/huggingface/transformers.py
+++ b/src/distilabel/llm/huggingface/transformers.py
@@ -151,9 +151,7 @@ class TransformersLLM(LLM):
         Returns:
             List[List[LLMOutput]]: the outputs of the LLM.
         """
-        prompts = self._generate_prompts(
-            inputs, default_format=None, expected_output_type=str
-        )
+        prompts = self._generate_prompts(inputs, default_format=None)
         encodings = self.tokenizer(prompts, padding=True, return_tensors="pt")
         encodings = encodings.to(self.model.device)
         with torch.inference_mode():

--- a/src/distilabel/llm/llama_cpp.py
+++ b/src/distilabel/llm/llama_cpp.py
@@ -131,9 +131,7 @@ class LlamaCppLLM(LLM):
         Returns:
             List[List[LLMOutput]]: the generated outputs.
         """
-        prompts = self._generate_prompts(
-            inputs, default_format=None, expected_output_type=str
-        )
+        prompts = self._generate_prompts(inputs, default_format=None)
         outputs = []
         for prompt in prompts:
             output = []

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -150,9 +150,7 @@ class OpenAILLM(LLM):
         Returns:
             List[List[LLMOutput]]: the generated outputs.
         """
-        prompts = self._generate_prompts(
-            inputs, default_format="openai", expected_output_type=list
-        )
+        prompts = self._generate_prompts(inputs, default_format="openai")
         outputs = []
         for prompt in prompts:
             chat_completions = self.client.chat.completions.create(

--- a/src/distilabel/llm/vllm.py
+++ b/src/distilabel/llm/vllm.py
@@ -131,9 +131,7 @@ class vLLM(LLM):
         Returns:
             List[List[LLMOutput]]: the outputs of the LLM.
         """
-        prompts = self._generate_prompts(
-            inputs, default_format=None, expected_output_type=str
-        )
+        prompts = self._generate_prompts(inputs, default_format=None)
         requests = self.vllm.generate(
             prompts,
             SamplingParams(  # type: ignore

--- a/src/distilabel/utils/imports.py
+++ b/src/distilabel/utils/imports.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import warnings
 from importlib.metadata import PackageNotFoundError, version
 from typing import List, Union
 
@@ -109,3 +108,9 @@ _HUGGINGFACE_HUB_AVAILABLE = _check_package_is_available(
 _TRANSFORMERS_AVAILABLE = _check_package_is_available(
     "transformers", min_version="4.31.1", greater_or_equal=True
 ) and _check_package_is_available("torch", min_version="2.0.0", greater_or_equal=True)
+_VERTEXAI_AVAILABLE = _check_package_is_available(
+    "google-cloud-aiplatform", min_version="1.38.1", greater_or_equal=True
+)
+_AISTUDIO_AVAILABLE = _check_package_is_available(
+    "google-generativeai", min_version="0.3.2", greater_or_equal=True
+)

--- a/tests/llm/google/__init__.py
+++ b/tests/llm/google/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/llm/google/test_vertexai.py
+++ b/tests/llm/google/test_vertexai.py
@@ -1,0 +1,308 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Generator
+from unittest import mock
+
+import pytest
+from distilabel.llm.google.vertexai import VertexAIEndpointLLM, VertexAILLM
+from distilabel.tasks.text_generation.base import TextGenerationTask
+from vertexai.language_models._language_models import (
+    MultiCandidateTextGenerationResponse,
+    TextGenerationResponse,
+)
+from vertexai.preview.generative_models import GenerationResponse
+
+
+@pytest.fixture
+def generative_model_mock() -> Generator[None, None, None]:
+    """Mocks the VertexAI `GenerativeModel` class, so no Google auth is needed."""
+    with mock.patch("distilabel.llm.google.vertexai.GenerativeModel") as mock_obj:
+        mock_obj.return_value = mock.MagicMock()
+        yield
+
+
+@pytest.fixture
+def text_generation_model_mock() -> Generator[None, None, None]:
+    """Mocks the VertexAI `TextGenerationModel.from_pretrained` method, so no Google auth
+    is needed."""
+    with mock.patch(
+        "distilabel.llm.google.vertexai.TextGenerationModel.from_pretrained"
+    ) as mock_obj:
+        mock_obj.return_value = mock.MagicMock()
+        yield
+
+
+@pytest.fixture
+def prediction_service_client_mock() -> Generator[None, None, None]:
+    with mock.patch(
+        "distilabel.llm.google.vertexai.PredictionServiceClient"
+    ) as mock_obj:
+        mock_obj.return_value = mock.MagicMock()
+        yield
+
+
+@pytest.mark.usefixtures("generative_model_mock")
+class TestVertexAILLMGenerativeModel:
+    def test_generate_contents(self) -> None:
+        llm = VertexAILLM(task=TextGenerationTask())
+
+        contents = llm._generate_contents(
+            inputs=[
+                {"input": "Gemini Pro is cool"},
+                {"input": "but OSS LLMs are even cooler"},
+            ]
+        )
+
+        assert contents == [
+            [
+                {"role": "user", "parts": [{"text": llm.task.system_prompt}]},
+                {"role": "model", "parts": [{"text": "Understood."}]},
+                {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
+            ],
+            [
+                {"role": "user", "parts": [{"text": llm.task.system_prompt}]},
+                {"role": "model", "parts": [{"text": "Understood."}]},
+                {"role": "user", "parts": [{"text": "but OSS LLMs are even cooler"}]},
+            ],
+        ]
+
+    def test_generative_model_single_output(self) -> None:
+        llm = VertexAILLM(task=TextGenerationTask())
+        type(llm).model_name = mock.PropertyMock(return_value="gemini-pro")
+        generation_response = mock.MagicMock(spec=GenerationResponse)
+        generation_response.text = "Yes, I'm cool"
+        llm._call_generative_model_with_backoff = mock.MagicMock(
+            return_value=generation_response
+        )
+
+        contents = [
+            {
+                "role": "user",
+                "parts": [{"text": "You're an educated AI assistant."}],
+            },
+            {"role": "model", "parts": [{"text": "Understood."}]},
+            {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
+        ]
+
+        llm_output = llm._generative_model_single_output(contents)
+
+        assert llm_output == {
+            "model_name": llm.model_name,
+            "parsed_output": {"generations": "Yes, I'm cool"},
+            "prompt_used": contents,
+            "raw_output": "Yes, I'm cool",
+        }
+
+    def test_generative_model_single_output_raise_value_error(self) -> None:
+        llm = VertexAILLM(task=TextGenerationTask())
+        type(llm).model_name = mock.PropertyMock(return_value="gemini-pro")
+        generation_response = mock.MagicMock(spec=GenerationResponse)
+        type(generation_response).text = mock.PropertyMock(
+            side_effect=ValueError("Content has no parts.")
+        )
+        llm._call_generative_model_with_backoff = mock.MagicMock(
+            return_value=generation_response
+        )
+        contents = [
+            {
+                "role": "user",
+                "parts": [{"text": "You're an educated AI assistant."}],
+            },
+            {"role": "model", "parts": [{"text": "Understood."}]},
+            {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
+            {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
+        ]
+
+        llm_output = llm._generative_model_single_output(contents)
+
+        assert llm_output == {
+            "model_name": llm.model_name,
+            "prompt_used": contents,
+            "raw_output": None,
+            "parsed_output": None,
+        }
+
+    def test_generative_model_single_output_raise_exception(self) -> None:
+        llm = VertexAILLM(task=TextGenerationTask())
+        generation_response = mock.MagicMock(spec=GenerationResponse)
+        generation_response.text = "Yes, I'm cool"
+        llm.task.parse_output = mock.MagicMock(
+            side_effect=Exception("Could not parse output")
+        )
+        llm._call_generative_model_with_backoff = mock.MagicMock(
+            return_value=generation_response
+        )
+        contents = [
+            {
+                "role": "user",
+                "parts": [{"text": "You're an educated AI assistant."}],
+            },
+            {"role": "model", "parts": [{"text": "Understood."}]},
+            {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
+        ]
+
+        llm_output = llm._generative_model_single_output(contents)
+
+        assert llm_output == {
+            "model_name": llm.model_name,
+            "prompt_used": contents,
+            "raw_output": "Yes, I'm cool",
+            "parsed_output": None,
+        }
+
+
+@pytest.mark.usefixtures("text_generation_model_mock")
+class TestVertexAILLMTextGenerationModel:
+    def test_text_generation_model_single_output(self) -> None:
+        llm = VertexAILLM(model="text-bison", task=TextGenerationTask())
+
+        # mock calling the text generation model
+        text_generation_response = mock.MagicMock(spec=TextGenerationResponse)
+        text_generation_response.text = "Yes, it's cool"
+        response = mock.MagicMock(spec=MultiCandidateTextGenerationResponse)
+        type(response).candidates = mock.PropertyMock(
+            return_value=[text_generation_response]
+        )
+        llm._call_text_generation_model = mock.MagicMock(return_value=response)
+
+        llm_output = llm._text_generation_model_single_output(
+            prompt="Gemini Pro is cool", num_generations=1
+        )
+
+        assert llm_output == [
+            {
+                "model_name": llm.model_name,
+                "prompt_used": "Gemini Pro is cool",
+                "raw_output": "Yes, it's cool",
+                "parsed_output": {"generations": "Yes, it's cool"},
+            }
+        ]
+
+    def test_text_generation_model_single_output_raise_exception(self) -> None:
+        llm = VertexAILLM(model="text-bison", task=TextGenerationTask())
+
+        # mock calling the text generation model
+        text_generation_response = mock.MagicMock(spec=TextGenerationResponse)
+        text_generation_response.text = "Yes, it's cool"
+        response = mock.MagicMock(spec=MultiCandidateTextGenerationResponse)
+        type(response).candidates = mock.PropertyMock(
+            return_value=[text_generation_response]
+        )
+
+        llm._call_text_generation_model = mock.MagicMock(return_value=response)
+
+        # simulate an exception when parsing the output
+        llm.task.parse_output = mock.MagicMock(
+            side_effect=Exception("Could not parse output")
+        )
+
+        llm_output = llm._text_generation_model_single_output(
+            prompt="Gemini Pro is cool", num_generations=1
+        )
+
+        assert llm_output == [
+            {
+                "model_name": llm.model_name,
+                "prompt_used": "Gemini Pro is cool",
+                "raw_output": "Yes, it's cool",
+                "parsed_output": None,
+            }
+        ]
+
+
+@pytest.mark.usefixtures("prediction_service_client_mock")
+class TestVertexAIEndpointLLM:
+    def test_prepare_instances(self) -> None:
+        llm = VertexAIEndpointLLM(
+            task=TextGenerationTask(),
+            endpoint_id="12345678",
+            project="unit-test",
+            location="us-central1",
+            generation_kwargs={
+                "temperature": 1.0,
+                "max_tokens": 512,
+                "top_p": 1.0,
+                "top_k": 10,
+            },
+        )
+
+        instances = llm._prepare_instances(
+            ["Gemini Pro is cool", "but OSS LLMs are even cooler"], num_generations=3
+        )
+
+        assert len(instances) == 2
+
+        assert instances[0].struct_value["prompt"] == "Gemini Pro is cool"
+        assert instances[0].struct_value["n"] == 3
+        assert instances[0].struct_value["temperature"] == 1.0
+        assert instances[0].struct_value["max_tokens"] == 512
+        assert instances[0].struct_value["top_p"] == 1.0
+        assert instances[0].struct_value["top_k"] == 10
+
+    def test_prepare_instances_with_custom_arguments(self) -> None:
+        llm = VertexAIEndpointLLM(
+            task=TextGenerationTask(),
+            endpoint_id="12345678",
+            project="unit-test",
+            location="us-central1",
+            generation_kwargs={
+                "temperature": 1.0,
+                "max_tokens": 512,
+                "top_p": 1.0,
+                "top_k": 10,
+            },
+            prompt_argument="PROMPT",
+            num_generations_argument="N_GENERATIONS",
+        )
+
+        instances = llm._prepare_instances(["Gemini Pro is cool"], num_generations=3)
+
+        assert instances[0].struct_value["PROMPT"] == "Gemini Pro is cool"
+        assert instances[0].struct_value["N_GENERATIONS"] == 3
+
+    def test_single_output(self) -> None:
+        llm = VertexAIEndpointLLM(
+            task=TextGenerationTask(),
+            endpoint_id="12345678",
+            project="unit-test",
+            location="us-central1",
+            generation_kwargs={
+                "temperature": 1.0,
+                "max_tokens": 512,
+                "top_p": 1.0,
+                "top_k": 10,
+            },
+        )
+        type(llm).model_name = mock.PropertyMock(return_value="unit-test-model")
+
+        # mock calling the prediction service
+        response = mock.MagicMock()
+        type(response).predictions = mock.PropertyMock(
+            return_value=["Prompt:\nGemini Pro is cool\nOutput:\nYes, it's cool"]
+        )
+        llm._call_vertexai_endpoint = mock.MagicMock(return_value=response)
+
+        llm_output = llm._single_output(
+            llm._prepare_instances(["Gemini Pro is cool"], num_generations=1)[0]
+        )
+
+        assert llm_output == [
+            {
+                "model_name": llm.model_name,
+                "prompt_used": "Gemini Pro is cool",
+                "raw_output": "Yes, it's cool",
+                "parsed_output": {"generations": "Yes, it's cool"},
+            }
+        ]

--- a/tests/llm/google/test_vertexai.py
+++ b/tests/llm/google/test_vertexai.py
@@ -59,21 +59,17 @@ class TestVertexAILLMGenerativeModel:
         llm = VertexAILLM(task=TextGenerationTask())
 
         contents = llm._generate_contents(
-            inputs=[
-                {"input": "Gemini Pro is cool"},
-                {"input": "but OSS LLMs are even cooler"},
+            prompts=[
+                "Gemini Pro is cool",
+                "but OSS LLMs are even cooler",
             ]
         )
 
         assert contents == [
             [
-                {"role": "user", "parts": [{"text": llm.task.system_prompt}]},
-                {"role": "model", "parts": [{"text": "Understood."}]},
                 {"role": "user", "parts": [{"text": "Gemini Pro is cool"}]},
             ],
             [
-                {"role": "user", "parts": [{"text": llm.task.system_prompt}]},
-                {"role": "model", "parts": [{"text": "Understood."}]},
                 {"role": "user", "parts": [{"text": "but OSS LLMs are even cooler"}]},
             ],
         ]

--- a/tests/llm/test_base.py
+++ b/tests/llm/test_base.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, List, Set
+from typing import Any, Dict, List, Set
 
 import pytest
 from distilabel.llm.base import LLM, LLMPool, ProcessLLM
 from distilabel.llm.utils import LLMOutput
 from distilabel.tasks.preference.ultrafeedback import UltraFeedbackTask
 from distilabel.tasks.text_generation.base import TextGenerationTask
-
-if TYPE_CHECKING:
-    pass
 
 
 class DummyLLM(LLM):


### PR DESCRIPTION
## Description

This PR adds or modifies:

- `VertexAILLM` class, which allows to use an LLM from the Gemini API or Text/Code Generation API
- `VertexAIEndpointLLM` class, which allows to use a Vertex AI Endpoint (users can deploy Llama2, Mistral, etc or any model on this endpoints)
- Remove the `expected_output_type ` from `LLM._generate_prompts` method