### PR TITLE
Add `ReplicateLLM`

### DIFF
--- a/examples/pipeline-replicate.py
+++ b/examples/pipeline-replicate.py
@@ -1,0 +1,54 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from datasets import Dataset
+from distilabel.llm.replicate import ReplicateLLM
+from distilabel.pipeline import Pipeline
+from distilabel.tasks import TextGenerationTask
+
+if __name__ == "__main__":
+    dataset = Dataset.from_dict(
+        {
+            "input": ["What are the tallest buildings on earth?"],
+        }
+    )
+
+    generator = ReplicateLLM(
+        endpoint_name="titocosta/notus-7b-v1",
+        endpoint_revision="dbcd2277b32873525e618545e13e64c3ba121b681cbd2b5f0ee7f95325e7a395",
+        replicate_api_token=os.getenv("REPLICATE_API_TOKEN", None),
+        task=TextGenerationTask(),
+        generation_kwargs={
+            "top_k": 1,
+            "top_p": 0.95,
+            "temperature": 0.2,
+            "max_new_tokens": 512,
+            "system_message": "You are a helpful AI assistant",
+            "prompt_template": "<|system|>\n{system_message}</s>\n<|user|>\n{prompt}</s>\n<|assistant|>\n",
+        },
+        prompt_format=None,
+    )
+
+    pipeline = Pipeline(generator=generator)
+    dataset = pipeline.generate(
+        dataset=dataset,
+        shuffle_before_labelling=False,
+        num_generations=2,
+        skip_dry_run=True,
+        display_progress_bar=True,
+    )  # type: ignore
+
+    print(dataset[0])

--- a/src/distilabel/llm/replicate.py
+++ b/src/distilabel/llm/replicate.py
@@ -1,0 +1,159 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Union
+
+from distilabel.llm.base import LLM
+from distilabel.llm.utils import LLMOutput
+from distilabel.logger import get_logger
+from distilabel.utils.imports import _REPLICATE_AVAILABLE
+
+if _REPLICATE_AVAILABLE:
+    import replicate
+
+if TYPE_CHECKING:
+    from distilabel.tasks.base import Task
+    from distilabel.tasks.prompt import SupportedFormats
+
+logger = get_logger()
+
+
+class ReplicateLLM(LLM):
+    def __init__(
+        self,
+        task: "Task",
+        endpoint_name: str,
+        endpoint_revision: Union[str, None] = None,
+        replicate_api_token: Union[str, None] = None,
+        generation_kwargs: Union[Dict[str, Any], None] = None,
+        num_threads: Union[int, None] = None,
+        prompt_format: Union["SupportedFormats", None] = None,
+        prompt_formatting_fn: Union[Callable[..., str], None] = None,
+    ) -> None:
+        """Initializes the OpenAILLM class.
+
+        Args:
+            task (Task): the task to be performed by the LLM.
+            endpoint_name (str): the name of the Replicate endpoint to be used for generation.
+            endpoint_revision (Union[str, None], optional): the revision of the Replicate endpoint
+                to be used for generation. If `None`, the main revision will be used. Defaults to `None`.
+            replicate_api_token (Union[str, None], optional): the Replicate API token to be used for generation.
+                If `None`, the `REPLICATE_API_KEY` environment variable will be used. Defaults to `None`.
+            generation_kwargs (Dict[str, Any], optional): the keyword arguments to be used for inference.
+                Defined within the specification of the Replicate endpoint. Defaults to `{}`.
+            num_threads (Union[int, None], optional): the number of threads to be used
+                for parallel generation. If `None`, no parallel generation will be performed.
+                Defaults to `None`.
+            prompt_format (Union[SupportedFormats, None], optional): the format to be used
+                for the prompt. If `None`, the default format of the task will be used, available
+                formats are `openai`, `chatml`, `llama2`, `zephyr`, and `default`. Defaults to `None`,
+                but `default` (concatenation of `system_prompt` and `formatted_prompt` with a line-break)
+                will be used if no `prompt_formatting_fn` is provided.
+            prompt_formatting_fn (Union[Callable[..., str], None], optional): a function to be
+                applied to the prompt before generation. If `None`, no formatting will be applied.
+                Defaults to `None`.
+
+        Raises:
+            AssertionError: if the provided `model` is not available in your OpenAI account.
+
+        Examples:
+            >>> from distilabel.tasks.text_generation import TextGenerationTask as Task
+            >>> from distilabel.llm import ReplicateLLM
+            >>> task = Task()
+            >>> llm = ReplicateLLM(endpoint_name="<ORG>/<REPO>", endpoint_revision="latest", task=task)
+        """
+        super().__init__(
+            task=task,
+            num_threads=num_threads,
+            prompt_format=prompt_format,
+            prompt_formatting_fn=prompt_formatting_fn,
+        )
+
+        if not _REPLICATE_AVAILABLE:
+            raise ImportError(
+                "`ReplicateLLM` cannot be used as `replicate` is not installed, please "
+                " install it with `pip install replicate`."
+            )
+
+        if replicate_api_token is not None:
+            os.environ["REPLICATE_API_TOKEN"] = replicate_api_token
+
+        if os.getenv("REPLICATE_API_TOKEN") is None:
+            raise ValueError(
+                "`REPLICATE_API_TOKEN` environment variable must be set in order to use the"
+                " `ReplicateLLM` class."
+            )
+
+        self.endpoint_name = endpoint_name
+        self.endpoint_revision = endpoint_revision or "main"
+        self.generation_kwargs = generation_kwargs
+
+    def __rich_repr__(self) -> Generator[Any, None, None]:
+        yield from super().__rich_repr__()
+        yield (
+            "parameters",
+            self.generation_kwargs,
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Returns the name of the Replicate Endpoint."""
+        return f"{self.endpoint_name}:{self.endpoint_revision}"
+
+    def _generate(
+        self,
+        inputs: List[Dict[str, Any]],
+        num_generations: int = 1,
+    ) -> List[List[LLMOutput]]:
+        """Generates `num_generations` for each input in `inputs`.
+
+        Args:
+            inputs (List[Dict[str, Any]]): the inputs to be used for generation.
+            num_generations (int, optional): the number of generations to be performed for each
+                input. Defaults to 1.
+
+        Returns:
+            List[List[LLMOutput]]: the generated outputs.
+        """
+        prompts = self._generate_prompts(inputs)
+        outputs = []
+        for prompt in prompts:
+            parsed_outputs = []
+            for _ in range(num_generations):
+                output = list(
+                    replicate.run(
+                        f"{self.endpoint_name}:{self.endpoint_revision}",
+                        input={
+                            "prompt": prompt,
+                            **(self.generation_kwargs or {}),
+                        },
+                        stream=False,
+                    )
+                )
+                try:
+                    parsed_response = self.task.parse_output("".join(output))
+                except Exception as e:
+                    logger.error(f"Error parsing Replicate Endpoint's response: {e}")
+                    parsed_response = None
+                parsed_outputs.append(
+                    LLMOutput(
+                        model_name=self.model_name,
+                        prompt_used=prompt,
+                        raw_output=output,
+                        parsed_output=parsed_response,
+                    )
+                )
+            outputs.append(parsed_outputs)
+        return outputs

--- a/src/distilabel/utils/imports.py
+++ b/src/distilabel/utils/imports.py
@@ -47,9 +47,9 @@ def _check_package_is_available(
     try:
         installed_version = version_parser.parse(version(name))
         if min_version is not None:
-            min_version = version_parser.parse(min_version)
-            if (greater_or_equal and installed_version < min_version) or (
-                not greater_or_equal and installed_version <= min_version
+            min_version = version_parser.parse(min_version)  # type: ignore
+            if (greater_or_equal and installed_version < min_version) or (  # type: ignore
+                not greater_or_equal and installed_version <= min_version  # type: ignore
             ):
                 # warnings.warn(
                 #     f"`{name}` is installed, but the installed version is {installed_version}, while "
@@ -61,9 +61,9 @@ def _check_package_is_available(
                 # )
                 return False
         if max_version is not None:
-            max_version = version_parser.parse(max_version)
-            if (lower_or_equal and installed_version > max_version) or (
-                not lower_or_equal and installed_version >= max_version
+            max_version = version_parser.parse(max_version)  # type: ignore
+            if (lower_or_equal and installed_version > max_version) or (  # type: ignore
+                not lower_or_equal and installed_version >= max_version  # type: ignore
             ):
                 # warnings.warn(
                 #     f"`{name}` is installed, but the installed version is {installed_version}, while "
@@ -75,8 +75,8 @@ def _check_package_is_available(
                 # )
                 return False
         if excluded_versions is not None:
-            excluded_versions = [version_parser.parse(v) for v in excluded_versions]
-            if installed_version in excluded_versions:
+            excluded_versions = [version_parser.parse(v) for v in excluded_versions]  # type: ignore
+            if installed_version in excluded_versions:  # type: ignore
                 # warnings.warn(
                 #     f"`{name}` is installed, but the installed version is {installed_version}, which is "
                 #     "an excluded version because it's not compatible with `distilabel`. If you are "
@@ -109,3 +109,4 @@ _HUGGINGFACE_HUB_AVAILABLE = _check_package_is_available(
 _TRANSFORMERS_AVAILABLE = _check_package_is_available(
     "transformers", min_version="4.31.1", greater_or_equal=True
 ) and _check_package_is_available("torch", min_version="2.0.0", greater_or_equal=True)
+_REPLICATE_AVAILABLE = _check_package_is_available("replicate")


### PR DESCRIPTION
## Description

This PR adds the `ReplicateLLM` class to easily use Replicate Endpoints within `distilabel`.

Closes #122 (as a follow up of #47)

## Things to discuss before merging

* Generation kwargs definition is poor, because it's constrained to the `cog` container used, and it's most of the times different per each model hosted in Replicate, which makes it harder to use via kwargs
* The fact that the pre/post processing happens internally in the `cog` container, the formatting of the prompt is tricky as sometimes that's expected to come pre-formatted on the client side, while other times that's handled by the container, but as that's controlled with kwargs, it's impossible to tell
* After some testing I think that the latency is better in other competitors, so maybe we can keep this PR as a draft until we figure out whether there's a clean way we can make it work fine with `distilabel` because as of now, it's really messy