### PR TITLE
Add checking valid `inputs` before calling `_generate`

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -281,7 +281,12 @@ class Pipeline:
             try:
                 processed_generation.update(
                     **combine_dicts(
-                        *[generation["parsed_output"] for generation in generations]
+                        *[
+                            generation["parsed_output"]
+                            if generation["parsed_output"] is not None
+                            else {}
+                            for generation in generations
+                        ]
                     )
                 )
             except Exception as e:

--- a/tests/llm/test_base.py
+++ b/tests/llm/test_base.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import re
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Tuple
 
 import pytest
 from distilabel.llm.base import LLM, LLMPool, ProcessLLM
 from distilabel.llm.utils import LLMOutput
+from distilabel.tasks.base import Task
 from distilabel.tasks.preference.ultrafeedback import UltraFeedbackTask
 from distilabel.tasks.prompt import Prompt
 from distilabel.tasks.text_generation.base import TextGenerationTask
@@ -58,71 +59,127 @@ class DummySubtask(TextGenerationTask):
         )
 
 
-def test_llmpool_errors_if_llms_less_than_two() -> None:
-    with pytest.raises(ValueError, match="The `llms` argument must contain at least 2"):
-        LLMPool(llms=[None])  # type: ignore
+class TestLLM:
+    def test_get_valid_inputs(self) -> None:
+        llm = DummyLLM(task=TextGenerationTask())
 
-
-def test_llmpool_errors_if_llm_not_instance_of_processllm() -> None:
-    with pytest.raises(
-        ValueError, match="The `llms` argument must contain only `ProcessLLM`s."
-    ):
-        LLMPool(llms=[None, None])  # type: ignore
-
-
-@pytest.mark.parametrize(
-    "tasks",
-    [
-        (TextGenerationTask(), TextGenerationTask()),
-        (TextGenerationTask(), DummySubtask()),
-        (TextGenerationTask(), TextGenerationTask(), DummySubtask()),
-        (TextGenerationTask(), DummySubtask(), DummySubtask()),
-    ],
-)
-def test_llmpool_with_subclass_of_tasks(tasks) -> None:
-    LLMPool(
-        llms=[
-            ProcessLLM(task=t, load_llm_fn=lambda task: DummyLLM(task=task))
-            for t in tasks
+        inputs = [
+            {"input": "I'm valid for text generation task"},
+            {"random": "I'm not valid"},
         ]
-    )
+        valid_inputs, invalid_inputs_indices = llm._get_valid_inputs(inputs=inputs)
+        assert valid_inputs == [{"input": "I'm valid for text generation task"}]
+        assert invalid_inputs_indices == [1]
 
+    def test_fill_missing_inputs(self) -> None:
+        llm = DummyLLM(task=TextGenerationTask())
 
-def test_llmpool_errors_if_llms_do_not_have_same_task() -> None:
-    llm1 = ProcessLLM(
-        task=TextGenerationTask(), load_llm_fn=lambda task: DummyLLM(task=task)
-    )
-    llm2 = ProcessLLM(
-        task=UltraFeedbackTask.for_honesty(),
-        load_llm_fn=lambda task: DummyLLM(task=task),
-    )
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "All the `ProcessLLM` in `llms` must share the same task (either as the instance or the parent class)."
-        ),
-    ):
-        LLMPool(llms=[llm1, llm2])
+        generations = [
+            [
+                LLMOutput(
+                    model_name=llm.model_name,
+                    prompt_used=llm.task.generate_prompt(
+                        input="I'm valid for text generation task"
+                    ).format_as("default"),
+                    raw_output="dummy",
+                    parsed_output="dummy",
+                ),
+                LLMOutput(
+                    model_name=llm.model_name,
+                    prompt_used=llm.task.generate_prompt(
+                        input="I'm valid too"
+                    ).format_as("default"),
+                    raw_output="dummy",
+                    parsed_output="dummy",
+                ),
+            ]
+        ]
 
-
-@pytest.mark.parametrize(
-    "num_generations, num_llms, expected", [(2, 4, {0, 1}), (4, 4, {1}), (9, 4, {2, 3})]
-)
-def test_llmpool_get_num_generations_per_llm(
-    num_generations: int, num_llms: int, expected: Set[int]
-) -> None:
-    llms = []
-    for _ in range(num_llms):
-        llms.append(
-            ProcessLLM(
-                task=TextGenerationTask(), load_llm_fn=lambda task: DummyLLM(task=task)
-            )
+        filled_generations = llm._fill_missing_inputs(
+            generations=generations,
+            invalid_inputs_indices=[1],
+            num_generations=2,
         )
 
-    pool = LLMPool(llms=llms)
+        assert filled_generations == generations + [
+            [
+                LLMOutput(
+                    model_name=llm.model_name,
+                    prompt_used=None,
+                    raw_output=None,
+                    parsed_output=None,
+                )
+                for _ in range(2)
+            ]
+        ]
 
-    num_generations_per_llm = pool._get_num_generations_per_llm(
-        num_generations=num_generations
+
+class TestLLMPool:
+    def test_llmpool_errors_if_llms_less_than_two(self) -> None:
+        with pytest.raises(
+            ValueError, match="The `llms` argument must contain at least 2"
+        ):
+            LLMPool(llms=[None])  # type: ignore
+
+    def test_llmpool_errors_if_llm_not_instance_of_processllm(self) -> None:
+        with pytest.raises(
+            ValueError, match="The `llms` argument must contain only `ProcessLLM`s."
+        ):
+            LLMPool(llms=[None, None])  # type: ignore
+
+    @pytest.mark.parametrize(
+        "tasks",
+        [
+            (TextGenerationTask(), TextGenerationTask()),
+            (TextGenerationTask(), DummySubtask()),
+            (TextGenerationTask(), TextGenerationTask(), DummySubtask()),
+            (TextGenerationTask(), DummySubtask(), DummySubtask()),
+        ],
     )
+    def test_llmpool_with_subclass_of_tasks(self, tasks: Tuple[Task]) -> None:
+        LLMPool(
+            llms=[
+                ProcessLLM(task=t, load_llm_fn=lambda task: DummyLLM(task=task))
+                for t in tasks
+            ]
+        )
 
-    assert set(num_generations_per_llm.values()) == expected
+    def test_llmpool_errors_if_llms_do_not_have_same_task(self) -> None:
+        llm1 = ProcessLLM(
+            task=TextGenerationTask(), load_llm_fn=lambda task: DummyLLM(task=task)
+        )
+        llm2 = ProcessLLM(
+            task=UltraFeedbackTask.for_honesty(),
+            load_llm_fn=lambda task: DummyLLM(task=task),
+        )
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "All the `ProcessLLM` in `llms` must share the same task (either as the instance or the parent class)."
+            ),
+        ):
+            LLMPool(llms=[llm1, llm2])
+
+    @pytest.mark.parametrize(
+        "num_generations, num_llms, expected",
+        [(2, 4, {0, 1}), (4, 4, {1}), (9, 4, {2, 3})],
+    )
+    def test_llmpool_get_num_generations_per_llm(
+        self, num_generations: int, num_llms: int, expected: Set[int]
+    ) -> None:
+        llms = []
+        for _ in range(num_llms):
+            llms.append(
+                ProcessLLM(
+                    task=TextGenerationTask(),
+                    load_llm_fn=lambda task: DummyLLM(task=task),
+                )
+            )
+
+        pool = LLMPool(llms=llms)
+
+        num_generations_per_llm = pool._get_num_generations_per_llm(
+            num_generations=num_generations
+        )
+
+        assert set(num_generations_per_llm.values()) == expected


### PR DESCRIPTION
## Description

This PR updates the `generate` method of the `LLM` class to:

1. Check which `inputs` are valid (have the required `task.input_args_names` keys) getting a list of the valid ones and a list containing the indices of the invalid ones.
2. Call `_generate` with the list of valid inputs
3. Fill the indices of the invalid inputs of the final list with empty `LLMOutput`s, as the `LLM` could not be executed for these inputs.

Close #208