### PR TITLE
Rename `for_text_quality` to `for_overall_quality` method in `UltraFeedbackTask`

### DIFF
--- a/docs/snippets/technical-reference/tasks/openai_for_overall_quality.py
+++ b/docs/snippets/technical-reference/tasks/openai_for_overall_quality.py
@@ -4,6 +4,6 @@ from distilabel.llm import OpenAILLM
 from distilabel.tasks import UltraFeedbackTask
 
 labeller = OpenAILLM(
-    task=UltraFeedbackTask.for_text_quality(),
+    task=UltraFeedbackTask.for_overall_quality(),
     openai_api_key=os.getenv("OPENAI_API_KEY"),
 )

--- a/docs/technical-reference/tasks.md
+++ b/docs/technical-reference/tasks.md
@@ -76,14 +76,6 @@ The following snippet can be used as a simplified UltraFeedback Task, for which 
 --8<-- "docs/snippets/technical-reference/tasks/ultrafeedback.py"
 ```
 
-=== "Text Quality"
-
-    The following example uses a `LLM` to examinate the data for text quality criteria, which includes the different criteria from UltraFeedback (Correctness & Informativeness, Honesty & Uncertainty, Truthfulness & Hallucination and Instruction Following):
-
-    ```python
-    --8<-- "docs/snippets/technical-reference/tasks/openai_for_text_quality.py"
-    ```
-
 === "Helpfulness"
 
     The following example creates a UltraFeedback task to emphasize helpfulness, that is overall quality and correctness of the output:
@@ -115,6 +107,17 @@ The following snippet can be used as a simplified UltraFeedback Task, for which 
     ```python
     --8<-- "docs/snippets/technical-reference/tasks/openai_for_instruction_following.py"
     ```
+
+Additionally, we at Argilla created a custom subtask for UltraFeedback, that generates an overall score evaluating all the aspects mentioned above but within a single subtask. Otherwise, in order to get an overall score, all the subtasks above should be run and the average of those scores to be calculated. 
+
+=== "Overall Quality"
+
+    The following example uses a `LLM` to examinate the data for our custom overall quality criteria, which includes the different criteria from UltraFeedback (Correctness & Informativeness, Honesty & Uncertainty, Truthfulness & Hallucination and Instruction Following):
+
+    ```python
+    --8<-- "docs/snippets/technical-reference/tasks/openai_for_overall_quality.py"
+    ```
+
 
 For the API reference visit [UltraFeedbackTask][distilabel.tasks.preference.ultrafeedback.UltraFeedbackTask].
 

--- a/examples/pipeline-llamacpp-and-openai-process.py
+++ b/examples/pipeline-llamacpp-and-openai-process.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     pipeline = Pipeline(
         generator=ProcessLLM(task=TextGenerationTask(), load_llm_fn=load_llama_cpp_llm),
         labeller=ProcessLLM(
-            task=UltraFeedbackTask.for_text_quality(), load_llm_fn=load_openai_llm
+            task=UltraFeedbackTask.for_overall_quality(), load_llm_fn=load_openai_llm
         ),
     )
 

--- a/examples/pipeline-llamacpp-and-openai.py
+++ b/examples/pipeline-llamacpp-and-openai.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         ),
         labeller=OpenAILLM(
             model="gpt-3.5-turbo",
-            task=UltraFeedbackTask.for_text_quality(),
+            task=UltraFeedbackTask.for_overall_quality(),
             max_new_tokens=128,
             num_threads=2,
             openai_api_key="<OPENAI_API_KEY>",

--- a/examples/pipeline-vllm-and-openai.py
+++ b/examples/pipeline-vllm-and-openai.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         ),
         labeller=OpenAILLM(
             model="gpt-3.5-turbo",
-            task=UltraFeedbackTask.for_text_quality(),
+            task=UltraFeedbackTask.for_overall_quality(),
             max_new_tokens=128,
             num_threads=2,
             openai_api_key=os.getenv("OPENAI_API_KEY", None),

--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -78,7 +78,7 @@ class Pipeline:
             ... )
             >>> labeller = OpenAILLM(
             ...     model="gpt-3.5-turbo",
-            ...     task=UltraFeedbackTask.for_text_quality(),
+            ...     task=UltraFeedbackTask.for_overall_quality(),
             ... )
             >>> pipeline = Pipeline(generator=generator, labeller=labeller)
             >>> dataset = pipeline.generate(dataset=..., num_generations=1, batch_size=1)
@@ -714,7 +714,7 @@ class Pipeline:
             ... )
             >>> labeller = OpenAILLM(
             ...     model="gpt-3.5-turbo",
-            ...     task=UltraFeedbackTask.for_text_quality(),
+            ...     task=UltraFeedbackTask.for_overall_quality(),
             ... )
             >>> pipeline = Pipeline(generator=generator, labeller=labeller)
             >>> dataset = pipeline.generate(dataset=..., num_generations=1, batch_size=1)

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -142,12 +142,16 @@ class UltraFeedbackTask(PreferenceTask):
         )
 
     @classmethod
-    def for_text_quality(
+    def for_overall_quality(
         cls,
         system_prompt: Optional[str] = None,
         task_description: Optional[str] = None,
         ratings: Optional[List[Rating]] = None,
     ) -> "UltraFeedbackTask":
+        """Classmethod for the `UltraFeedbackTask` subtask defined by Argilla, in order to
+        evaluate all the criterias originally defined in UltraFeedback at once, in a single
+        subtask.
+        """
         kwargs = {}
         if system_prompt is not None:
             kwargs.update({"system_prompt": system_prompt})

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -92,7 +92,7 @@ class UltraFeedbackTask(PreferenceTask):
 
         Examples:
             >>> from distilabel.tasks.preference import UltraFeedbackTask
-            >>> task = UltraFeedbackTask.for_text_quality()
+            >>> task = UltraFeedbackTask.for_overall_quality()
             >>> task.generate_prompt("What are the first 5 Fibonacci numbers?", ["0 1 1 2 3", "0 1 1 2 3"])
             Prompt(
                 system_prompt="Your role is to evaluate text quality based on given criteria.",


### PR DESCRIPTION
## Description

This PR renames the classmethod `for_text_quality` from `UltraFeedbackTask` to `for_overall_quality`. The reason behind this change is because, as @dvsrepo pointed out in #220, the naming is more clear, as it's not evaluating a single criteria i.e. the quality of the text, but evaluating the quality based on the rest of the criterias defined within the original implementation of UltraFeedback. So on, this PR applies the renaming and adds the context on why the rename has been done, and why it's important.

Closes #220