### PR TITLE
Fix `rating` parsing in `RatingToArgillaMixin.to_argilla_record`

### DIFF
--- a/src/distilabel/tasks/critique/base.py
+++ b/src/distilabel/tasks/critique/base.py
@@ -67,12 +67,14 @@ class CritiqueTask(RatingToArgillaMixin, Task):
         generations_column: str = "generations",
         score_column: str = "score",
         critique_column: str = "critique",
+        score_values: Optional[List[int]] = None,
     ) -> Union["FeedbackRecord", List["FeedbackRecord"]]:
         return super().to_argilla_record(
             dataset_row=dataset_row,
             generations_column=generations_column,
             ratings_column=score_column,
             rationale_column=critique_column,
+            ratings_values=score_values or [1, 2, 3, 4, 5],
         )
 
 

--- a/src/distilabel/tasks/mixins.py
+++ b/src/distilabel/tasks/mixins.py
@@ -136,6 +136,7 @@ class RatingToArgillaMixin:
         generations_column: str = "generations",
         ratings_column: str = "rating",
         rationale_column: str = "rationale",
+        ratings_values: Optional[List[int]] = None,
     ) -> "FeedbackRecord":
         """Converts a dataset row to an Argilla `FeedbackRecord`."""
         # We start off with the fields, which are the inputs of the LLM, but also
@@ -189,7 +190,12 @@ class RatingToArgillaMixin:
                             "value": 1
                             if value < 1
                             else int(value)
-                            if value < 10
+                            if value
+                            <= (
+                                max(ratings_values)
+                                if ratings_values is not None
+                                else 10
+                            )
                             else None,
                         }
                     )

--- a/src/distilabel/tasks/preference/ultrafeedback.py
+++ b/src/distilabel/tasks/preference/ultrafeedback.py
@@ -29,7 +29,7 @@ from distilabel.tasks.preference.base import PreferenceTask
 from distilabel.tasks.prompt import Prompt
 
 if TYPE_CHECKING:
-    from argilla import FeedbackDataset
+    from argilla import FeedbackDataset, FeedbackRecord
 
 _ULTRAFEEDBACK_TEMPLATE = get_template("ultrafeedback.jinja2")
 
@@ -134,6 +134,25 @@ class UltraFeedbackTask(PreferenceTask):
         ratings_values: Optional[List[int]] = None,
     ) -> "FeedbackDataset":
         return super().to_argilla_dataset(
+            dataset_row=dataset_row,
+            generations_column=generations_column,
+            ratings_column=ratings_column,
+            rationale_column=rationale_column,
+            ratings_values=ratings_values or [1, 2, 3, 4, 5],
+        )
+
+    # Override the default `to_argilla_record` method to provide the `ratings_values` of
+    # UltraFeedback, as the default goes from 1-10 while UltraFeedback's default is 1-5
+    # (0-4 actually, but Argilla doesn't support 0s).
+    def to_argilla_record(
+        self,
+        dataset_row: Dict[str, Any],
+        generations_column: str = "generations",
+        ratings_column: str = "rating",
+        rationale_column: str = "rationale",
+        ratings_values: Optional[List[int]] = None,
+    ) -> "FeedbackRecord":
+        return super().to_argilla_record(
             dataset_row=dataset_row,
             generations_column=generations_column,
             ratings_column=ratings_column,


### PR DESCRIPTION
## Description

This PR solves a bug internally reported by @dvsrepo which was affecting the Argilla export of both the `CritiqueTask` and `PreferenceTask` when the max rating was equal or higher to 10, as those were not parsed into `int` and replaced with `None` instead. So on, this PR fixes that to pass the `ratings_values` over to the `to_argilla_record` within `RatingToArgillaMixin` so that the max rating value is calculated from it, as well as ensuring that the parsing to `int` is performed when the value is lower or equal to the max rating (before it was ignoring the equal ratings).

Kudos to @dvsrepo for reporting internally.