### PR TITLE
Docs/binders anchors

### DIFF
--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -6,6 +6,9 @@
    "source": [
     "# 🤗 Use Notus on inference endpoints to create a legal preference dataset\n",
     "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/argilla-io/distilabel/blob/main/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb) [![Open Source in Github](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/argilla-io/distilabel/blob/main/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb)\n",
+    "\n",
+    "\n",
     "In this tutorial, you will learn how to use the Notus model on Inference Endpoints to create a legal preference dataset based on RAG instructions from the European AI Act. A full end-to-end example of how to use distilabel to leverage LLMs!\n",
     "\n",
     "[distilabel](https://github.com/argilla-io/distilabel) is an AI Feedback (AIF) framework that can generate and label datasets using LLMs, and can be used for many different use cases. Implemented with robustness, efficiency and scalability in mind, it allows anyone to build their synthetic datasets that can be used in many different scenarios. This tutorial shows an end-to-end example in which we will create a model expert in the new AI Act, to which we can make different types of questions and requests.\n",
@@ -20,13 +23,6 @@
     "- Generating a preference dataset using an `UltraFeedback` text quality task.\n",
     "\n",
     "You can use the Open in Colab button at the top of this page. This option allows you to run the notebook directly on Google Colab. Don't forget to change the runtime type to GPU for faster model training and inference."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/argilla-io/distilabel/blob/main/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb)"
    ]
   },
   {

--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -17,7 +17,9 @@
     "- Defining a custom generating task for a `distilabel` pipeline.\n",
     "- Creating a RAG pipeline using Haystack for the EU AI Act.\n",
     "- Generating an instruction dataset with `SelfInstructTask`.\n",
-    "- Generating a preference dataset using an `UltraFeedback` text quality task."
+    "- Generating a preference dataset using an `UltraFeedback` text quality task.\n",
+    "\n",
+    "You can use the Open in Colab button at the top of this page. This option allows you to run the notebook directly on Google Colab. Don't forget to change the runtime type to GPU for faster model training and inference."
    ]
   },
   {

--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://drive.google.com/file/d/1sXOHbAScXk9QbnojHhjWb4pRf3s8YEM6/view?usp=sharing)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/argilla-io/distilabel/blob/main/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb)"
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - footnotes
+  - toc:
+      permalink: true
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - footnotes
+  # activating permalink: true makes the anchor link works in the notebooks
   - toc:
       permalink: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ plugins:
 nav:
   - Getting started: index.md
   - Concepts: concepts.md
+  - Tutorials:
+      - Use Notus on inference endpoints to create a legal preference dataset: tutorials/pipeline-notus-instructions-preferences-legal.ipynb
   - Technical References:
       - Concept Guides:
           - technical-reference/index.md
@@ -90,5 +92,3 @@ nav:
           - Tasks: technical-reference/tasks.md
           - Pipelines: technical-reference/pipeline.md
       - API Reference: reference/
-  - Tutorials:
-      - Use Notus on inference endpoints to create a legal preference dataset: tutorials/pipeline-notus-instructions-preferences-legal.ipynb


### PR DESCRIPTION
Closes #234 and #233 

As suggested by @dvsrepo , we have included clickable anchors to easily navigate and share URLs. I've also fixed the Open In Colab button using https://openincolab.com/ to generate the mirror URLs, now it opens directly the tutorial. 

I've been also looking into putting the Open In Colab button in the top-right corner, like in Argilla, but I think that is automatically generated by readthedocs, and I've been able to find any option similar in mkdocs. If somebody knows how to do it, I'll be super happy to implement it. 

Once this PR is pushed, I'll merge main into 0.3.0 to make the tutorial available, as suggested by @davidberenstein1957.

Thanks again to @plaguss for his help fighting the Conda 🐍