### PR TITLE
Add support for dedicated and serverless inference endpoints via inference API

### DIFF
--- a/docs/snippets/technical-reference/llm/inference_endpoint_generate.py
+++ b/docs/snippets/technical-reference/llm/inference_endpoint_generate.py
@@ -8,7 +8,7 @@ endpoint_namespace = "argilla" or os.getenv("HF_NAMESPACE")
 token = os.getenv("HF_TOKEN")  # hf_...
 
 llm = InferenceEndpointsLLM(
-    endpoint_name=endpoint_name,
+    endpoint_name_or_model_id=endpoint_name,
     endpoint_namespace=endpoint_namespace,
     token=token,
     task=TextGenerationTask(),

--- a/docs/snippets/technical-reference/pipeline/pipe_1.py
+++ b/docs/snippets/technical-reference/pipeline/pipe_1.py
@@ -8,7 +8,7 @@ pipe = pipeline(
     "preference",
     "text-quality",
     generator=InferenceEndpointsLLM(
-        endpoint_name=endpoint_name,
+        endpoint_name_or_model_id=endpoint_name,
         endpoint_namespace=endpoint_namespace,
         token=token,
         task=TextGenerationTask(),

--- a/docs/snippets/technical-reference/pipeline/pipeline_generator_1.py
+++ b/docs/snippets/technical-reference/pipeline/pipeline_generator_1.py
@@ -9,7 +9,7 @@ endpoint_namespace = "argilla" or os.getenv("HF_NAMESPACE")
 
 pipe_generation = Pipeline(
     generator=InferenceEndpointsLLM(
-        endpoint_name=endpoint_name,  # The name given of the deployed model
+        endpoint_name_or_model_id=endpoint_name,  # The name given of the deployed model
         endpoint_namespace=endpoint_namespace,  # This usually corresponds to the organization, in this case "argilla"
         token=os.getenv("HF_TOKEN"),  # hf_...
         task=TextGenerationTask(),

--- a/docs/snippets/technical-reference/pipeline/pipeline_labeller_generator_1.py
+++ b/docs/snippets/technical-reference/pipeline/pipeline_labeller_generator_1.py
@@ -6,9 +6,8 @@ from distilabel.tasks import TextGenerationTask, UltraFeedbackTask
 
 pipe_full = Pipeline(
     generator=InferenceEndpointsLLM(
-        endpoint_name=endpoint_name,
+        endpoint_name_or_model_id=endpoint_name,
         endpoint_namespace=endpoint_namespace,
-        token=token,
         task=TextGenerationTask(
             system_prompt="You are an expert writer of XKCD, a webcomic of romance, sarcasm, math, and language."
         ),

--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "llm = InferenceEndpointsLLM(\n",
-    "    endpoint_name=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
+    "    endpoint_name_or_model_id=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
     "    endpoint_namespace=os.getenv(\"HF_NAMESPACE\"),  # type: ignore\n",
     "    token=os.getenv(\"HF_TOKEN\") or None,\n",
     "    task=QuestionAnsweringTask(),\n",
@@ -410,7 +410,7 @@
    "outputs": [],
    "source": [
     "instructions_generator = InferenceEndpointsLLM(\n",
-    "    endpoint_name=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
+    "    endpoint_name_or_model_id=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
     "    endpoint_namespace=os.getenv(\"HF_NAMESPACE\"),  # type: ignore\n",
     "    token=os.getenv(\"HF_TOKEN\") or None,\n",
     "    task=instructions_task,\n",
@@ -602,7 +602,7 @@
     "    \"preference\",\n",
     "    \"text-quality\",\n",
     "    generator=InferenceEndpointsLLM(\n",
-    "        endpoint_name=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
+    "        endpoint_name_or_model_id=os.getenv(\"HF_INFERENCE_ENDPOINT_NAME\"),  # type: ignore\n",
     "        endpoint_namespace=os.getenv(\"HF_NAMESPACE\", None),\n",
     "        task=Llama2TextGenerationTask(),\n",
     "        max_new_tokens=256,\n",

--- a/examples/inference-endpoints-llm-custom-task.py
+++ b/examples/inference-endpoints-llm-custom-task.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         )
 
     llm = InferenceEndpointsLLM(
-        endpoint_name=os.getenv("HF_INFERENCE_ENDPOINT_NAME"),  # type: ignore
+        endpoint_name_or_model_id=os.getenv("HF_INFERENCE_ENDPOINT_NAME"),  # type: ignore
         endpoint_namespace=os.getenv("HF_NAMESPACE"),  # type: ignore
         token=os.getenv("HF_TOKEN", None),
         task=Llama2QuestionAnsweringTask(),

--- a/examples/pipeline-fn-ultrafeedback.py
+++ b/examples/pipeline-fn-ultrafeedback.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         "preference",
         "text-quality",
         generator=InferenceEndpointsLLM(
-            endpoint_name=os.getenv("HF_INFERENCE_ENDPOINT_NAME"),  # type: ignore
+            endpoint_name_or_model_id=os.getenv("HF_INFERENCE_ENDPOINT_NAME"),  # type: ignore
             endpoint_namespace=os.getenv("HF_NAMESPACE", None),
             task=TextGenerationTask(),
             prompt_format="llama2",

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -61,6 +61,8 @@ def is_serverless_endpoint_available(model_id: str) -> bool:
     # 1. First we check if input includes a "/" which is indicative of a model name
     if "/" not in model_id:
         return False
+    if model_id.startswith("https:"):
+        return False
     # 2. Then we check if the model is currently deployed
     try:
         client = InferenceClient()

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -31,10 +31,9 @@ from distilabel.utils.imports import _HUGGINGFACE_HUB_AVAILABLE
 
 if _HUGGINGFACE_HUB_AVAILABLE:
     from huggingface_hub import (
+        InferenceClient,
         InferenceTimeoutError,
         get_inference_endpoint,
-        InferenceClient,
-        model_info,
     )
     from huggingface_hub.inference._text_generation import TextGenerationError
 

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -61,7 +61,6 @@ logger = get_logger()
 def is_serverless_endpoint_available(model_id: str) -> bool:
     """Checks input is a valid Hugging Face model and if there is a serverless endpoint available for it."""
     # 1. First we check if input includes a "/" which is indicative of a model name
-    print(model_id)
     if "/" not in model_id:
         return False
     # 2. Then we check if the model is currently deployed

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -58,7 +58,7 @@ _INFERENCE_ENDPOINTS_API_WAIT_RANDOM_EXPONENTIAL_MAX = 10
 logger = get_logger()
 
 
-def is_severless_endpoint_available(model_id: str) -> bool:
+def is_serverless_endpoint_available(model_id: str) -> bool:
     """Checks input is a valid Hugging Face model and if there is a serverless endpoint available for it."""
     # 1. First we check if input includes a "/" which is indicative of a model name
     print(model_id)

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -123,16 +123,7 @@ class InferenceEndpointsLLM(LLM):
             >>> from distilabel.llm import InferenceEndpointsLLM
             >>> task = Task()
             >>> llm = InferenceEndpointsLLM(
-            ...     endpoint_name_or_model_id="<INFERENCE_ENDPOINT_NAME>",
-            ...     task=task,
-            ... )
-            >>>
-            >>> # Inference API example
-            >>> from distilabel.tasks.text_generation import TextGenerationTask as Task
-            >>> from distilabel.llm import InferenceEndpointsLLM
-            >>> task = Task()
-            >>> llm = InferenceEndpointsLLM(
-            ...     endpoint_name_or_model_id="<MODEL_ID>",
+            ...     endpoint_name_or_model_id="<MODEL_ID_OR_INFERENCE_ENDPOINT>",
             ...     task=task,
             ... )
         """

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -157,7 +157,7 @@ class InferenceEndpointsLLM(LLM):
         self.top_p = top_p
         self.typical_p = typical_p
 
-        if is_severless_endpoint_available(model_id=endpoint_name_or_model_id):
+        if is_serverless_endpoint_available(model_id=endpoint_name_or_model_id):
             logger.info("Using Serverless Inference Endpoint")
             self.client = InferenceClient(model=endpoint_name_or_model_id, token=token)
             self._model_name = endpoint_name_or_model_id

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -198,7 +198,6 @@ class InferenceEndpointsLLM(LLM):
     )
     def _text_generation_with_backoff(self, **kwargs: Any) -> Any:
         """Performs text generation with backoff in case of an error."""
-        print(kwargs)
         return self.client.text_generation(**kwargs)  # type: ignore
 
     def _generate(

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -168,7 +168,7 @@ class InferenceEndpointsLLM(LLM):
                 namespace=endpoint_namespace,
                 token=token,
             )
-            inference_endpoint.wait(timeout=30)
+            inference_endpoint.resume().wait(timeout=30)
 
             self.client = inference_endpoint.client
             self._model_name = inference_endpoint.repository

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -14,7 +14,6 @@
 
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Union
-import requests
 
 from tenacity import (
     after_log,

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -161,7 +161,9 @@ class InferenceEndpointsLLM(LLM):
                 namespace=endpoint_namespace,
                 token=token,
             )
-            inference_endpoint.resume().wait(timeout=30)
+            if inference_endpoint.status in ["paused", "scaledToZero"]:
+                logger.info("Waiting for Inference Endpoint to be ready...")
+                inference_endpoint.resume().wait(timeout=30)
 
             self.client = inference_endpoint.client
             self._model_name = inference_endpoint.repository

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -92,6 +92,7 @@ class InferenceEndpointsLLM(LLM):
         top_k: Union[int, None] = None,
         top_p: Union[float, None] = None,
         typical_p: Union[float, None] = None,
+        stop_sequences: Union[List[str], None] = None,
         num_threads: Union[int, None] = None,
         prompt_format: Union["SupportedFormats", None] = None,
         prompt_formatting_fn: Union[Callable[..., str], None] = None,
@@ -111,6 +112,7 @@ class InferenceEndpointsLLM(LLM):
             top_k (Union[int, None]): The top_k for generation. Defaults to None.
             top_p (Union[float, None]): The top_p for generation. Defaults to None.
             typical_p (Union[float, None]): The typical_p for generation. Defaults to None.
+            stop_sequences (Union[List[str], None]): The stop sequences for generation. Defaults to None.
             num_threads (Union[int, None]): The number of threads. Defaults to None.
             prompt_format (Union["SupportedFormats", None]): The format of the prompt. Defaults to None.
             prompt_formatting_fn (Union[Callable[..., str], None]): The function for formatting the prompt. Defaults to None.
@@ -155,6 +157,7 @@ class InferenceEndpointsLLM(LLM):
         self.top_k = top_k
         self.top_p = top_p
         self.typical_p = typical_p
+        self.stop_sequences = stop_sequences
 
         if is_serverless_endpoint_available(model_id=endpoint_name_or_model_id):
             logger.info("Using Serverless Inference Endpoint")
@@ -185,6 +188,7 @@ class InferenceEndpointsLLM(LLM):
                 "top_k": self.top_k,
                 "top_p": self.top_p,
                 "typical_p": self.typical_p,
+                "stop_sequences": self.stop_sequences,
             },
         )
 
@@ -205,6 +209,7 @@ class InferenceEndpointsLLM(LLM):
     )
     def _text_generation_with_backoff(self, **kwargs: Any) -> Any:
         """Performs text generation with backoff in case of an error."""
+        print(kwargs)
         return self.client.text_generation(**kwargs)  # type: ignore
 
     def _generate(
@@ -234,6 +239,7 @@ class InferenceEndpointsLLM(LLM):
                     top_k=self.top_k,
                     top_p=self.top_p,
                     typical_p=self.typical_p,
+                    stop_sequences=self.stop_sequences,
                 )
                 for _ in range(num_generations)
             ]

--- a/src/distilabel/tasks/critique/prometheus.py
+++ b/src/distilabel/tasks/critique/prometheus.py
@@ -106,7 +106,7 @@ class PrometheusTask(CritiqueTask):
         # We use a regex instead of splitting by the delimiter because the
         # critique may contain the delimiter, and using the regex is safer.
         pattern = r"(.+?)\. \[RESULT\] (\d+)"
-        match = re.match(pattern, output)
+        match = re.search(pattern, output)
         if match:
             return CritiqueTaskOutput(
                 score=float(match.group(2)),


### PR DESCRIPTION
# What does this PR do? 

This PR currently adds a dirty implementation of how we could support dedicated Inference Endpoints and serverless Inference Endpoints via the Inference API. 

On init we try to check if the provided "endpoint_name_or_model_id" (happy to revert back to endpoint_name) is available serverless using the `list_deployed_models` method. 

example
```python
import os

from distilabel.llm import InferenceEndpointsLLM
from distilabel.tasks import TextGenerationTask

token = os.getenv("HF_TOKEN")  # hf_...

llm = InferenceEndpointsLLM(
    "openchat/openchat-3.5-0106",
    token=token,
    task=TextGenerationTask(),
    max_new_tokens=512,
)


result = llm.generate([{"input": "What are critique LLMs?"}])
result
```


_Note: didn't work on docs yet._
