### PR TITLE
Add extra check in llmpool to ensure all the tasks share the same parent class

### DIFF
--- a/tests/llm/test_base.py
+++ b/tests/llm/test_base.py
@@ -59,6 +59,14 @@ class DummySubtask(TextGenerationTask):
         )
 
 
+class SubtaskOne(TextGenerationTask):
+    pass
+
+
+class SubtaskTwo(TextGenerationTask):
+    pass
+
+
 class TestLLM:
     def test_get_valid_inputs(self) -> None:
         llm = DummyLLM(task=TextGenerationTask())
@@ -134,6 +142,7 @@ class TestLLMPool:
             (TextGenerationTask(), DummySubtask()),
             (TextGenerationTask(), TextGenerationTask(), DummySubtask()),
             (TextGenerationTask(), DummySubtask(), DummySubtask()),
+            (SubtaskOne(), SubtaskOne(), SubtaskTwo()),
         ],
     )
     def test_llmpool_with_subclass_of_tasks(self, tasks: Tuple[Task]) -> None:


### PR DESCRIPTION
## Description

This PR fixes the following error:

```python
 ValueError: All the `ProcessLLM` in `llms` must share the same task (either as the instance or the parent class).
```

That appears with multiple tasks that all inherit from the same parent. We now check they all share the same parent class (we go one only one class in the hierarchy up, in case there are higher hierarchies we should update the check)
