### PR TITLE
Update README.md - load_from_disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ pipeline = pipeline("preference", "instruction-following", generator=generator)
 dataset = pipeline.generate(dataset)
 ```
 
+Then you can load dataset from checkpoint persisted on disk:
+
+```
+from distilabel.dataset import CustomDataset
+from pathlib import Path
+
+dataset = CustomDataset.load_from_disk(Path('./ckpt'))
+```
+
 Additionally, you can push the generated dataset to Argilla for further exploration and annotation:
 
 ```python


### PR DESCRIPTION
I think it's important to know how to load dataset from local file after it's been generated, particularly in case if remote uploading failed, user wants to avoid regenerating dataset.