### PR TITLE
Filter examples for which len generations != len ratings

### DIFF
--- a/src/distilabel/utils/dataset.py
+++ b/src/distilabel/utils/dataset.py
@@ -284,12 +284,22 @@ def prepare_dataset(
         "raw_labelling_response",
         "rationale",
     ]
+
     # Remove the rows for which there is no rating
+    def remove_incomplete_rows(example):
+        if not example["rating"]:
+            return False
+        if len(example["generations"]) != len(example["rating"]):
+            return False
+        # TODO(plaguss): Maybe we should remove the examples with less than 2 generations
+        # instead of checking after the filtering
+        return True
+
     initial_length = len(dataset)
-    dataset = dataset.filter(lambda example: example["rating"])
+    dataset = dataset.filter(remove_incomplete_rows)
     if len(dataset) != initial_length:
         logger.info(
-            f"Found {initial_length - len(dataset)} examples with no rating, removing them."
+            f"Found {initial_length - len(dataset)} examples with no rating or different number of ratings than generations, removing them."
         )
 
     if len(dataset[0]["generations"]) < 2:


### PR DESCRIPTION
## Description

This PR removes the examples for which `len(generations) != len(ratings)` in `prepare_dataset` as noted by @dvsrepo.

Closes #280 