### PR TITLE
Review `OllamaLLM` and `TogetherInferenceLLM`

### DIFF
--- a/src/distilabel/llm/ollama.py
+++ b/src/distilabel/llm/ollama.py
@@ -59,7 +59,7 @@ class OllamaLLM(LLM):
         prompt_formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
         """
-        Initializes the OllamaLLM class and align with https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+        Initializes the OllamaLLM class and aligns with https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
 
         Args:
             model (str): the model to be used for generation.

--- a/src/distilabel/llm/together.py
+++ b/src/distilabel/llm/together.py
@@ -49,7 +49,7 @@ class TogetherInferenceLLM(LLM):
         prompt_format: Union["SupportedFormats", None] = None,
         prompt_formatting_fn: Union[Callable[..., str], None] = None,
     ) -> None:
-        """Initializes the OpenAILLM class.
+        """Initializes the TogetherInferenceLLM class.
 
         Args:
             task (Task): the task to be performed by the LLM.
@@ -96,7 +96,7 @@ class TogetherInferenceLLM(LLM):
             AssertionError: if the provided `model` is not available in Together Inference.
 
         Examples:
-            >>> from distilabel.tasks.text_generation import TextGenerationTask as Task
+            >>> from distilabel.tasks import TextGenerationTask as Task
             >>> from distilabel.llm import TogetherInferenceLLM
             >>> task = Task()
             >>> llm = TogetherInferenceLLM(model="togethercomputer/llama-2-7b", task=task, prompt_format="llama2")

--- a/src/distilabel/llm/together.py
+++ b/src/distilabel/llm/together.py
@@ -152,8 +152,11 @@ class TogetherInferenceLLM(LLM):
     @cached_property
     def available_models(self) -> List[str]:
         """Returns the list of available models in Together Inference."""
-        # TODO: exclude the image models
-        return [model["name"] for model in together.Models.list()]
+        return [
+            model["name"]
+            for model in together.Models.list()
+            if model["display_type"] != "image"
+        ]
 
     @property
     def model_name(self) -> str:

--- a/tests/llm/test_together.py
+++ b/tests/llm/test_together.py
@@ -23,7 +23,9 @@ from distilabel.tasks.text_generation.base import TextGenerationTask
 class TestTogetherInferenceLLM:
     def test_available_models(self) -> None:
         together.Models.list = mock.MagicMock(
-            return_value=[{"name": "togethercomputer/llama-2-7b"}]
+            return_value=[
+                {"name": "togethercomputer/llama-2-7b", "display_type": "chat"}
+            ]
         )
         llm = TogetherInferenceLLM(
             model="togethercomputer/llama-2-7b",
@@ -34,7 +36,9 @@ class TestTogetherInferenceLLM:
 
     def test_inference_kwargs(self) -> None:
         together.Models.list = mock.MagicMock(
-            return_value=[{"name": "togethercomputer/llama-2-7b"}]
+            return_value=[
+                {"name": "togethercomputer/llama-2-7b", "display_type": "chat"}
+            ]
         )
         llm = TogetherInferenceLLM(
             model="togethercomputer/llama-2-7b",
@@ -60,7 +64,9 @@ class TestTogetherInferenceLLM:
 
     def test__generate_single_output(self) -> None:
         together.Models.list = mock.MagicMock(
-            return_value=[{"name": "togethercomputer/llama-2-7b"}]
+            return_value=[
+                {"name": "togethercomputer/llama-2-7b", "display_type": "chat"}
+            ]
         )
         llm = TogetherInferenceLLM(
             model="togethercomputer/llama-2-7b",
@@ -87,7 +93,9 @@ class TestTogetherInferenceLLM:
 
     def test__generate(self) -> None:
         together.Models.list = mock.MagicMock(
-            return_value=[{"name": "togethercomputer/llama-2-7b"}]
+            return_value=[
+                {"name": "togethercomputer/llama-2-7b", "display_type": "chat"}
+            ]
         )
         llm = TogetherInferenceLLM(
             model="togethercomputer/llama-2-7b",


### PR DESCRIPTION
## Description

This PR reviews the recently included `OllamaLLM` fixing some type-hints and making the URLs to GitHub point to `ollama/ollama` instead of `jmorganca/ollama`, and removes the image models within Together in `TogetherInferenceLLM`.