### PR TITLE
Add missing VertexAI information within `README.md` and `docs/index.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In addition, the following extras are available:
 - `vllm`: for using [vllm](https://github.com/vllm-project/vllm) serving engine via the `vLLM` integration.
 - `llama-cpp`: for using [llama-cpp-python](https://github.com/abetlen/llama-cpp-python) as Python bindings for `llama.cpp`.
 - `together`: for using [Together Inference](https://www.together.ai/products) via their Python client.
+- `vertexai`: for using both [Google Vertex AI](https://cloud.google.com/vertex-ai/?&gad_source=1&hl=es) offerings: their proprietary models and endpoints via their Python client [`google-cloud-aiplatform`](https://github.com/googleapis/python-aiplatform).
 - `argilla`: for exporting the generated datasets to [Argilla](https://argilla.io/).
 
 ## Example

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ In addition, the following extras are available:
 - `vllm`: for using [vllm](https://github.com/vllm-project/vllm) serving engine via the `vLLM` integration.
 - `llama-cpp`: for using [llama-cpp-python](https://github.com/abetlen/llama-cpp-python) as Python bindings for `llama.cpp`.
 - `together`: for using [Together Inference](https://www.together.ai/products) via their Python client.
+- `vertexai`: for using both [Google Vertex AI](https://cloud.google.com/vertex-ai/?&gad_source=1&hl=es) offerings: their proprietary models and endpoints via their Python client [`google-cloud-aiplatform`](https://github.com/googleapis/python-aiplatform).
 - `argilla`: for exporting the generated datasets to [Argilla](https://argilla.io/).
 
 ## Quick example

--- a/src/distilabel/llm/google/vertexai.py
+++ b/src/distilabel/llm/google/vertexai.py
@@ -324,8 +324,7 @@ class VertexAIEndpointLLM(LLM):
     """An `LLM` which uses a Vertex AI Online prediction endpoint for the generation.
 
     More information about Vertex AI Endpoints can be found here:
-
-        - https://cloud.google.com/vertex-ai/docs/general/deployment#deploy_a_model_to_an_endpoint
+    https://cloud.google.com/vertex-ai/docs/general/deployment#deploy_a_model_to_an_endpoint
     """
 
     def __init__(


### PR DESCRIPTION
## Description

This PR adds the missing extra within the list displayed on both the `README.md` and `docs/index.md`, where all the extras available in `distilabel` are presented. Additionally, this PR also fixes the style in a URL in `VextexAILLM` docstring.