### PR TITLE
Add new column for sft fine tuning with `prepare_dataset`

### DIFF
--- a/src/distilabel/utils/dataset.py
+++ b/src/distilabel/utils/dataset.py
@@ -182,6 +182,7 @@ def _binarize_dataset(
 def prepare_dataset(
     dataset: "CustomDataset",
     strategy: BinarizationStrategies = "random",
+    sft: bool = False,
     seed: Optional[int] = None,
     keep_ties: bool = False,
     **kwargs: Any,
@@ -214,6 +215,10 @@ def prepare_dataset(
             CustomDataset with a PreferenceTask to prepare for Direct Preference Optimization.
         strategy (BinarizationStrategies, optional):
             Strategy to binarize the data. Defaults to "random".
+        sft (bool, optional):
+            Whether to add a `messages` column to the dataset, to be used for Supervised Fine Tuning.
+            If set to True, this messages column will contain the same information as the chosen response.
+            Defaults to False.
         seed (int, optional): Seed for the random generator, in case of `random` strategy. Defaults to None.
         keep_ties (bool, optional):
             Whether to keep ties in case the binarization method generated the chosen
@@ -279,6 +284,14 @@ def prepare_dataset(
         **kwargs,
     )
 
+    if sft:
+        # Adds a column to be used for Supervised Fine Tuning based on the chosen response
+        ds = ds.map(
+            lambda example: {
+                **example,
+                "messages": example["chosen"],
+            }
+        )
     # Imported here to avoid circular imports
     from distilabel.dataset import CustomDataset
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -230,6 +230,7 @@ def test_to_argilla_with_too_many_fields(large_custom_dataset: CustomDataset):
     "with_generation_model",
     [True],
 )
+@pytest.mark.parametrize("sft", [True, False])
 @pytest.mark.parametrize(
     "strategy, chosen, rejected, chosen_model, rejected_model, keep_ties",
     [
@@ -324,16 +325,22 @@ def test_prepare_dataset(
     rejected_model: List[str],
     with_generation_model: bool,
     keep_ties: bool,
+    sft: bool,
 ):
     if not with_generation_model:
         sample_preference_dataset = sample_preference_dataset.remove_columns(
             ["generation_model"]
         )
     ds = prepare_dataset(
-        sample_preference_dataset, strategy=strategy, seed=42, keep_ties=keep_ties
+        sample_preference_dataset,
+        strategy=strategy,
+        sft=sft,
+        seed=42,
+        keep_ties=keep_ties,
     )
     assert isinstance(ds, CustomDataset)
-    assert ds.column_names == [
+
+    expected_columns = [
         "prompt",
         "chosen",
         "rejected",
@@ -342,11 +349,19 @@ def test_prepare_dataset(
         "chosen_model",
         "rejected_model",
     ]
+
+    if sft:
+        expected_columns += ["messages"]
+
+    assert set(ds.column_names) == set(expected_columns)
+
     for i, row in enumerate(ds):
         assert row["chosen"] == chosen[i]
         assert row["rejected"] == rejected[i]
         assert row["chosen_model"] == chosen_model[i]
         assert row["rejected_model"] == rejected_model[i]
+        if sft:
+            assert row["messages"] == chosen[i]
 
 
 def test_prepare_dataset_wrong_task(sample_preference_dataset: CustomDataset):


### PR DESCRIPTION
## Description

This PR adds functionality on the `prepare_dataset` function to generate a new column to be used for SFT:

```python
from distilabel.utils import prepare_dataset

dataset = load_dataset("argilla/distilabel-intel-orca-dpo-pairs", split="train")
dataset.task = JudgeLMTask()
dataset_binarized_random = prepare_dataset(dataset, strategy="random", keep_ties=True, sft=True). # 'sft' defaults to False
```

This dataset will include a new column `messages` based on the content of the `chosen` response.
Initially it's not well documented as it just offers a simple way to extend the functionality just on the **preference datasets** using the same function, but this could be more general. Once refactored, we can use a special section for the functionality.

Example of use of this column from the [alignment handbook](https://github.com/huggingface/alignment-handbook/blob/main/src/alignment/data.py#L46)

Closes #276.