### PR TITLE
Fix logging visualization of labeller pipelines

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -555,6 +555,7 @@ class Pipeline:
             display_progress_bar=display_progress_bar,
             has_labeller=True if self.labeller else False,
             has_generator=True if self.generator else False,
+            batch_size=batch_size,
         )
 
         num_batches = math.ceil(len(dataset) / batch_size)

--- a/src/distilabel/progress_bar.py
+++ b/src/distilabel/progress_bar.py
@@ -68,15 +68,17 @@ def get_progress_bars_for_pipeline(
     display_progress_bar: bool,
     has_generator: bool,
     has_labeller: bool,
+    batch_size: int,
 ) -> Tuple[ProgressFunc, ProgressFunc]:
     if display_progress_bar:
         # Generator progress bar is generated in a function if there's a generator
         # in pipeline.py. Else, is None.
         _generation_progress_func = None
-
+        quotient, remainder = divmod(num_rows, batch_size)
+        total_rows = quotient + remainder
         if has_generator:
             generation_progress_bar = get_progress_bar(
-                description="Texts Generated", total=num_rows * num_generations
+                description="Texts Generated", total=total_rows * num_generations
             )
 
             def _generation_progress_func(advance=None) -> None:
@@ -87,13 +89,12 @@ def get_progress_bars_for_pipeline(
         _labelling_progress_func = None
         if has_labeller:
             labelling_progress_bar = get_progress_bar(
-                description="Rows labelled", total=num_rows
+                description="Rows labelled", total=total_rows
             )
 
             def _labelling_progress_func(advance=None) -> None:
                 labelling_progress_bar(advance=1)
 
-            # Start the labelling progress bar from 1 instead of 0 to ensure it ends
             _labelling_progress_func()
 
         return _generation_progress_func, _labelling_progress_func

--- a/src/distilabel/progress_bar.py
+++ b/src/distilabel/progress_bar.py
@@ -93,6 +93,9 @@ def get_progress_bars_for_pipeline(
             def _labelling_progress_func(advance=None) -> None:
                 labelling_progress_bar(advance=1)
 
+            # Start the labelling progress bar from 1 instead of 0 to ensure it ends
+            _labelling_progress_func()
+
         return _generation_progress_func, _labelling_progress_func
 
     return None, None


### PR DESCRIPTION
## Description

Fixes the problem with the logging of labelling pipelines mentioned in #274.

Also another problem with the  `rich` progress bar:
![image](https://github.com/argilla-io/distilabel/assets/56895847/3be696f8-8dcc-491a-8af8-7289609627e8)
It takes into account the rows, but should take into account the `batch_size` to ensure it finishes