### PR TITLE
fix: typo in clean an existing preference dataset

### DIFF
--- a/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
+++ b/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
@@ -519,7 +519,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Optional: Post-process the dataset"
+        "### Optional: Post-process the dataset"
       ]
     },
     {
@@ -622,7 +622,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Optional: Find duplicated examples"
+        "### Optional: Find duplicated examples"
       ]
     },
     {

--- a/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
+++ b/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
@@ -132,7 +132,7 @@
         "id": "X_zKNbOdQYWw"
       },
       "source": [
-        "# Prepare the Dataset"
+        "## Prepare the Dataset"
       ]
     },
     {


### PR DESCRIPTION
The # typo is now handled and fixes the rendering issue as shown below:

![image](https://github.com/argilla-io/distilabel/assets/127759186/505a13cf-d52a-47a3-ae93-9fdc8ecc3036)
