### PR TITLE
Include rationale of the model responses on `prepare_dataset` if available

### DIFF
--- a/docs/technical-reference/pipeline.md
+++ b/docs/technical-reference/pipeline.md
@@ -252,6 +252,10 @@ This dataset processing is called binarization. In the context of `distilabel`, 
 
 - **rejected_model**: (*Optional*, only returned if the dataset contains it, otherwise it's a null string like here) The model used to generate the rejected instruction.
 
+- **chosen_rationale**: (*Optional*, only returned if the dataset contains the *rationale*, otherwise it's not added) The rationale behind the rating of the chosen response.
+
+- **rejected_rationale**: (Optional*, only returned if the dataset contains the *rationale*, otherwise it's not added) The rationale behind the rating of the rejected response.
+
 Need more information? Take a look at [argilla/ultrafeedback-binarized-preferences](https://huggingface.co/datasets/argilla/ultrafeedback-binarized-preferences) to get an idea of how [openbmb/UltraFeedback](https://huggingface.co/datasets/openbmb/UltraFeedback) can be binarized to prepare it for *DPO*.
 
 ## CustomDataset in HuggingFace hub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,5 +67,8 @@ select = ["E", "W", "F", "I", "C", "B"]
 ignore = ["E501", "B905", "B008"]
 exclude = ["docs"]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ ignore = ["E501", "B905", "B008"]
 exclude = ["docs"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 12
+max-complexity = 14
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Description

This PR updates the `dataset.utils.prepare_dataset` function to include the `rationale` of the model chosen/rejected, if the rationale is available in the original dataset (aside from the tests, tested locally it works with the disticoder-dpo dataset).

If `rationale` is available in the dataset (the `PreferenceTasks` that generate it will add it to the dataset), the binarized dataset will contain the columns `chosen_rationale` and `rejected_rationale`. 

Closes #316.