### PR TITLE
Implement a JSON responding OpenAI LLM as JSONOpenAILLM

### DIFF
--- a/docs/snippets/technical-reference/llm/openai_json_generate.py
+++ b/docs/snippets/technical-reference/llm/openai_json_generate.py
@@ -1,0 +1,18 @@
+import os
+
+from distilabel.llm import JSONOpenAILLM
+from distilabel.tasks import TextGenerationTask
+
+openaillm = JSONOpenAILLM(
+    model="gpt-3.5-turbo-1106",  # json response is a limited feature
+    task=TextGenerationTask(),
+    prompt_format="openai",
+    max_new_tokens=256,
+    api_key=os.getenv("OPENAI_API_KEY", None),
+    temperature=0.3,
+)
+result = openaillm.generate(
+    [{"input": "write a json object with a key 'city' and value 'Madrid'"}]
+)
+# >>> print(result[0][0]["parsed_output"]["generations"])
+# {"answer": "Madrid"}

--- a/docs/technical-reference/llms.md
+++ b/docs/technical-reference/llms.md
@@ -131,6 +131,14 @@ For the API reference visit [OpenAILLM][distilabel.llm.openai.OpenAILLM].
 --8<-- "docs/snippets/technical-reference/llm/openai_generate.py"
 ```
 
+To generate JSON objects with OpenAI's `json_response` feature you can use the `JSONOpenAILLM` class:
+
+```python
+--8<-- "docs/snippets/technical-reference/llm/openai_json_generate.py"
+```
+
+Refer to the [Open AI API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format) for more information.
+
 ### Llama.cpp
 
 Applicable for local execution of Language Models (LLMs). Use this LLM when you have access to the quantized weights of your selected model for interaction.

--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -20,7 +20,7 @@ from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
 from distilabel.llm.mistralai import MistralAILLM
 from distilabel.llm.ollama import OllamaLLM
-from distilabel.llm.openai import OpenAILLM, JSONOpenAILLM
+from distilabel.llm.openai import JSONOpenAILLM, OpenAILLM
 from distilabel.llm.together import TogetherInferenceLLM
 from distilabel.llm.vllm import vLLM
 

--- a/src/distilabel/llm/__init__.py
+++ b/src/distilabel/llm/__init__.py
@@ -20,7 +20,7 @@ from distilabel.llm.huggingface.transformers import TransformersLLM
 from distilabel.llm.llama_cpp import LlamaCppLLM
 from distilabel.llm.mistralai import MistralAILLM
 from distilabel.llm.ollama import OllamaLLM
-from distilabel.llm.openai import OpenAILLM
+from distilabel.llm.openai import OpenAILLM, JSONOpenAILLM
 from distilabel.llm.together import TogetherInferenceLLM
 from distilabel.llm.vllm import vLLM
 
@@ -36,6 +36,7 @@ __all__ = [
     "MistralAILLM",
     "TogetherInferenceLLM",
     "OpenAILLM",
+    "JSONOpenAILLM",
     "OllamaLLM",
     "vLLM",
     "AnyscaleLLM",

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -267,21 +267,19 @@ class JSONOpenAILLM(OpenAILLM):
             prompt_format=prompt_format,
             prompt_formatting_fn=prompt_formatting_fn,
         )
-        self.json_supporting_models = [
+
+    @cached_property
+    def available_models(self) -> List[str]:
+        """Returns the list of available models in your OpenAI account."""
+        all_available_models = [model.id for model in self.client.models.list().data]
+        json_supporting_models = [
             "gpt-4-0125-preview",
             "gpt-4-turbo-preview",
             "gpt-4-1106-preview",
             "gpt-3.5-turbo-1106",
         ]
-        assert model in self.json_supporting_models, f"Provided `model` does not support JSON input, \
-            available models are {self.available_models}"
-
-    @cached_property
-    def available_models(self) -> List[str]:
-        """Returns the list of available models in your OpenAI account."""
-        all_available_models = super().available_models
         available_json_supporting_models = list(
-            set(all_available_models) & set(self.json_supporting_models)
+            set(all_available_models) & set(json_supporting_models)
         )
         return available_json_supporting_models
 

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -314,7 +314,7 @@ class JSONOpenAILLM(OpenAILLM):
                     json.loads(chat_completion.message.content)
                 except json.JSONDecodeError:
                     warnings.warn(
-                        "The response is not a valid JSON."
+                        "The response is not a valid JSON.", UserWarning, stacklevel=2
                     )
                     parsed_response = None
                 output.append(

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -250,7 +250,7 @@ class JSONOpenAILLM(OpenAILLM):
         Examples:
             >>> from distilabel.tasks import TextGenerationTask
             >>> from distilabel.llm import JSONOpenAILLM
-            >>> llm = OpenAILLM(task=TextGenerationTask())
+            >>> llm = JSONOpenAILLM(task=TextGenerationTask())
             >>> llm.generate([{"input": "json for 'What's the capital of Spain?'"}])
         """
         super().__init__(

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Union
 
@@ -173,6 +175,147 @@ class OpenAILLM(LLM):
                     )
                 except Exception as e:
                     logger.error(f"Error parsing OpenAI response: {e}")
+                    parsed_response = None
+                output.append(
+                    LLMOutput(
+                        model_name=self.model_name,
+                        prompt_used=prompt,
+                        raw_output=chat_completion.message.content,
+                        parsed_output=parsed_response,
+                    )
+                )
+            outputs.append(output)
+        return outputs
+
+
+class JSONOpenAILLM(OpenAILLM):
+    def __init__(
+        self,
+        task: "Task",
+        model: str = "gpt-3.5-turbo-1106",
+        client: Union["OpenAI", None] = None,
+        api_key: Union[str, None] = None,
+        max_new_tokens: int = 128,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        num_threads: Union[int, None] = None,
+        prompt_format: Union["SupportedFormats", None] = None,
+        prompt_formatting_fn: Union[Callable[..., str], None] = None,
+    ) -> None:
+        """Initializes the JSONOpenAILLM class for generating JSON.
+
+        Args:
+            task (Task): the task to be performed by the LLM.
+            model (str, optional): the model to be used for generation. Defaults to "gpt-3.5-turbo".
+            client (Union[OpenAI, None], optional): an OpenAI client to be used for generation.
+                If `None`, a new client will be created. Defaults to `None`.
+            api_key (Union[str, None], optional): the OpenAI API key to be used for generation.
+                If `None`, the `OPENAI_API_KEY` environment variable will be used. Defaults to `None`.
+            max_new_tokens (int, optional): the maximum number of tokens to be generated.
+                Defaults to 128.
+            frequency_penalty (float, optional): the frequency penalty to be used for generation.
+                Defaults to 0.0.
+            presence_penalty (float, optional): the presence penalty to be used for generation.
+                Defaults to 0.0.
+            temperature (float, optional): the temperature to be used for generation.
+                Defaults to 1.0.
+            top_p (float, optional): the top-p value to be used for generation.
+                Defaults to 1.0.
+            num_threads (Union[int, None], optional): the number of threads to be used
+                for parallel generation. If `None`, no parallel generation will be performed.
+                Defaults to `None`.
+            prompt_format (Union[SupportedFormats, None], optional): the format to be used
+                for the prompt. If `None`, the default format of the task will be used, available
+                formats are `openai`, `chatml`, `llama2`, `zephyr`, and `default`. Defaults to `None`,
+                but `default` (concatenation of `system_prompt` and `formatted_prompt` with a line-break)
+                will be used if no `prompt_formatting_fn` is provided.
+            prompt_formatting_fn (Union[Callable[..., str], None], optional): a function to be
+                applied to the prompt before generation. If `None`, no formatting will be applied.
+                Defaults to `None`.
+
+        Raises:
+            AssertionError: if the provided `model` is not available in your OpenAI account.
+            AssertionError: if the provided `model` does not support JSON input.
+
+        Examples:
+            >>> from distilabel.tasks import TextGenerationTask
+            >>> from distilabel.llm import JSONOpenAILLM
+            >>> llm = OpenAILLM(task=TextGenerationTask())
+            >>> llm.generate([{"input": "json for 'What's the capital of Spain?'"}])
+        """
+        super().__init__(
+            task,
+            model=model,
+            client=client,
+            api_key=api_key,
+            max_new_tokens=max_new_tokens,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            temperature=temperature,
+            top_p=top_p,
+            num_threads=num_threads,
+            prompt_format=prompt_format,
+            prompt_formatting_fn=prompt_formatting_fn,
+        )
+        self.json_supporting_models = [
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-1106-preview",
+            "gpt-3.5-turbo-1106",
+        ]
+        assert (
+            model in self.json_supporting_models
+        ), f"Provided `model` does not support JSON input, \
+            available models are {self.json_supporting_models}"
+
+    def _generate(
+        self,
+        inputs: List[Dict[str, Any]],
+        num_generations: int = 1,
+    ) -> List[List[LLMOutput]]:
+        """Generates `num_generations` for each input in `inputs` in JSON format.
+
+        Args:
+            inputs (List[Dict[str, Any]]): the inputs to be used for generation.
+            num_generations (int, optional): the number of generations to be performed for each
+                input. Defaults to 1.
+
+        Returns:
+            List[List[LLMOutput]]: the generated outputs.
+        """
+        prompts = self._generate_prompts(inputs, default_format="openai")
+        outputs = []
+        for prompt in prompts:
+            chat_completions = self.client.chat.completions.create(
+                messages=prompt,
+                model=self.model,
+                n=num_generations,
+                max_tokens=self.max_tokens,
+                frequency_penalty=self.frequency_penalty,
+                presence_penalty=self.presence_penalty,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                timeout=50,
+                response_format={"type": "json_object"},
+            )
+
+            output = []
+            for chat_completion in chat_completions.choices:
+                try:
+                    parsed_response = self.task.parse_output(
+                        chat_completion.message.content.strip()
+                    )
+                except Exception as e:
+                    logger.error(f"Error parsing OpenAI response: {e}")
+                    parsed_response = None
+                try:
+                    json.loads(chat_completion.message.content)
+                except json.JSONDecodeError:
+                    warnings.warn(
+                        "The response is not a valid JSON."
+                    )
                     parsed_response = None
                 output.append(
                     LLMOutput(

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -273,9 +273,7 @@ class JSONOpenAILLM(OpenAILLM):
             "gpt-4-1106-preview",
             "gpt-3.5-turbo-1106",
         ]
-        assert (
-            model in self.json_supporting_models
-        ), f"Provided `model` does not support JSON input, \
+        assert model in self.json_supporting_models, f"Provided `model` does not support JSON input, \
             available models are {self.json_supporting_models}"
 
     def _generate(

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -15,7 +15,15 @@
 import json
 import warnings
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Union,
+)
 
 from distilabel.llm.base import LLM
 from distilabel.llm.utils import LLMOutput
@@ -314,7 +322,9 @@ class JSONOpenAILLM(OpenAILLM):
                     json.loads(chat_completion.message.content)
                 except json.JSONDecodeError:
                     warnings.warn(
-                        "The response is not a valid JSON.", UserWarning, stacklevel=2
+                        "The response is not a valid JSON.",
+                        UserWarning,
+                        stacklevel=2,
                     )
                     parsed_response = None
                 output.append(

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -274,7 +274,16 @@ class JSONOpenAILLM(OpenAILLM):
             "gpt-3.5-turbo-1106",
         ]
         assert model in self.json_supporting_models, f"Provided `model` does not support JSON input, \
-            available models are {self.json_supporting_models}"
+            available models are {self.available_models}"
+
+    @cached_property
+    def available_models(self) -> List[str]:
+        """Returns the list of available models in your OpenAI account."""
+        all_available_models = super().available_models
+        available_json_supporting_models = list(
+            set(all_available_models) & set(self.json_supporting_models)
+        )
+        return available_json_supporting_models
 
     def _generate(
         self,

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from distilabel.llm.openai import JSONOpenAILLM
@@ -22,30 +22,42 @@ from distilabel.tasks import TextGenerationTask
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_json_openai_llm():
+    # Mocking available models and models that support JSON
+    json_supporting_model = "gpt-3.5-turbo-1106"
+    available_models = [json_supporting_model]
+    JSONOpenAILLM.available_models = available_models
+    JSONOpenAILLM._available_models = Mock(return_value=available_models)
+
+    # Mocking the OpenAI client and chat method
     mocked_chat_return_value = Mock(
         choices=[Mock(message=Mock(content='{"answer": "Madrid"}'))]
     )
-    with patch(
-        "openai.resources.chat.Completions.create",
-        return_value=mocked_chat_return_value,
-    ):
-        JSONOpenAILLM._available_models = Mock(return_value=["gpt-3.5-turbo-1106"])
-        JSONOpenAILLM.available_models = ["gpt-3.5-turbo-1106"]
-        yield JSONOpenAILLM(
-            model="gpt-3.5-turbo-1106",
-            task=TextGenerationTask(),
-        )
+    mocked_openai_client = Mock(
+        chat=Mock(completions=Mock(create=Mock(return_value=mocked_chat_return_value))),
+        api_key="api_key",
+        organization="organization",
+        models=Mock(list=Mock(return_value=available_models)),
+    )
+    text_generation_task = TextGenerationTask()
+    yield JSONOpenAILLM(
+        model=json_supporting_model,
+        task=text_generation_task,
+        client=mocked_openai_client,
+    )
 
 
 def test_generate(mock_json_openai_llm):
-    prompt = "write a json object with a key 'answer' and value 'Paris'"
-    inputs = [{"input": prompt}]
+    # Setup inputs
+    _prompt = "write a json object with a key 'answer' and value 'Paris'"
+    inputs = [{"input": _prompt}]
     outputs = mock_json_openai_llm.generate(inputs)
+    # Asserts
     assert len(outputs) == 1
     assert isinstance(outputs[0], list)
     json_response = json.loads(outputs[0][0]["parsed_output"]["generations"])
     assert isinstance(json_response, dict)
     assert json_response["answer"] == "Madrid"
+    mock_json_openai_llm.client.chat.completions.create.assert_called_once()
 
 
 def test_available_models(mock_json_openai_llm):

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import json
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
 from distilabel.llm.openai import JSONOpenAILLM
 from distilabel.tasks import TextGenerationTask
 

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -19,14 +19,13 @@ import pytest
 from distilabel.llm.openai import JSONOpenAILLM
 from distilabel.tasks import TextGenerationTask
 
-JSON_SUPPORTING_MODEL = "gpt-3.5-turbo-1106"
-NON_JSON_SUPPORTING_MODEL = "gpt-4"
-
 
 @pytest.fixture(scope="function", autouse=True)
 def mock_json_openai_llm():
+    json_supporting_model = "gpt-3.5-turbo-1106"
+    non_json_supporting_model = "gpt-4"
     # Mocking available models and models that support JSON
-    available_models = [JSON_SUPPORTING_MODEL, NON_JSON_SUPPORTING_MODEL]
+    available_models = [json_supporting_model, non_json_supporting_model]
     JSONOpenAILLM.available_models = available_models
 
     # Mocking the OpenAI client and chat method
@@ -42,11 +41,12 @@ def mock_json_openai_llm():
     text_generation_task = TextGenerationTask()
     with pytest.raises(AssertionError):
         JSONOpenAILLM(
-            model=NON_JSON_SUPPORTING_MODEL,
+            model=non_json_supporting_model,
             task=TextGenerationTask(),
+            client=mocked_openai_client,
         )
     yield JSONOpenAILLM(
-        model=JSON_SUPPORTING_MODEL,
+        model=json_supporting_model,
         task=text_generation_task,
         client=mocked_openai_client,
     )

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -1,0 +1,64 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import Mock, patch, TestCase
+
+from distilabel.llm.openai import JSONOpenAILLM
+from distilabel.tasks import TextGenerationTask
+
+
+class TestJSONOpenAILLM(TestCase):
+    @patch("distilabel.llm.openai.OpenAILLM.available_models")
+    @patch("openai.resources.chat.Completions.create")
+    def test_generate(self, mock_create):
+        # Mock the available_models property
+        mock_create.return_value = ["gpt-3.5-turbo-1106"]
+        
+        # Mock the response from the OpenAI API
+        mock_create.return_value = Mock(
+            choices=[Mock(message=Mock(content='{"answer": "Madrid"}'))]
+        )
+
+        # Initialize the JSONOpenAILLM class
+        llm = JSONOpenAILLM(task=TextGenerationTask())
+
+        # Call the _generate method
+        inputs = [
+            {"input": "write a json object with a key 'answer' and value 'Paris'"}
+        ]
+        outputs = llm.generate(inputs)
+        json_response = json.loads(outputs[0][0]["parsed_output"]["generations"])
+
+        # Check the output
+        self.assertEqual(len(outputs), 1)
+        self.assertIsInstance(json_response, dict)
+        self.assertEqual(json_response["answer"], "Madrid")
+        self.assertEqual(llm.model, llm.json_supporting_models)
+
+        # Check if the OpenAI API was called with the correct arguments
+        prompts = llm._generate_prompts(inputs, default_format="openai")
+        prompt = prompts[0]
+        mock_create.assert_called_once_with(
+            messages=prompt,
+            model=llm.model,
+            n=1,
+            max_tokens=llm.max_tokens,
+            frequency_penalty=llm.frequency_penalty,
+            presence_penalty=llm.presence_penalty,
+            temperature=llm.temperature,
+            top_p=llm.top_p,
+            timeout=50,
+            response_format={"type": "json_object"},
+        )

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -41,8 +41,9 @@ def test_generate(mock_json_openai_llm):
     prompt = "write a json object with a key 'answer' and value 'Paris'"
     inputs = [{"input": prompt}]
     outputs = mock_json_openai_llm.generate(inputs)
-    json_response = json.loads(outputs[0][0]["parsed_output"]["generations"])
     assert len(outputs) == 1
+    assert isinstance(outputs[0], list)
+    json_response = json.loads(outputs[0][0]["parsed_output"]["generations"])
     assert isinstance(json_response, dict)
     assert json_response["answer"] == "Madrid"
 

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -40,6 +40,11 @@ def mock_json_openai_llm():
         models=Mock(list=Mock(return_value=available_models)),
     )
     text_generation_task = TextGenerationTask()
+    with pytest.raises(AssertionError):
+        JSONOpenAILLM(
+            model=NON_JSON_SUPPORTING_MODEL,
+            task=TextGenerationTask(),
+        )
     yield JSONOpenAILLM(
         model=JSON_SUPPORTING_MODEL,
         task=text_generation_task,
@@ -47,7 +52,7 @@ def mock_json_openai_llm():
     )
 
 
-def test_generate(mock_json_openai_llm):
+def test_generate_json(mock_json_openai_llm):
     # Setup inputs
     _prompt = "write a json object with a key 'answer' and value 'Paris'"
     inputs = [{"input": _prompt}]
@@ -59,11 +64,3 @@ def test_generate(mock_json_openai_llm):
     assert isinstance(json_response, dict)
     assert json_response["answer"] == "Madrid"
     mock_json_openai_llm.client.chat.completions.create.assert_called_once()
-
-
-def test_json_openai_llm_with_non_json_model(mock_json_openai_llm):
-    with pytest.raises(AssertionError):
-        JSONOpenAILLM(
-            model=NON_JSON_SUPPORTING_MODEL,
-            task=TextGenerationTask(),
-        )

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from unittest.mock import Mock, patch, TestCase
+from unittest.mock import Mock, TestCase, patch
 
 from distilabel.llm.openai import JSONOpenAILLM
 from distilabel.tasks import TextGenerationTask
@@ -30,13 +30,13 @@ class TestJSONOpenAILLM(TestCase):
 
         # Check the available_models property
         self.assertEqual(llm.available_models, ["gpt-3.5-turbo-1106"])
-        
+
     @patch("distilabel.llm.openai.OpenAILLM.available_models")
     @patch("openai.resources.chat.Completions.create")
     def test_generate(self, mock_create):
         # Mock the available_models property
         mock_create.return_value = ["gpt-3.5-turbo-1106"]
-        
+
         # Mock the response from the OpenAI API
         mock_create.return_value = Mock(
             choices=[Mock(message=Mock(content='{"answer": "Madrid"}'))]

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -21,7 +21,7 @@ from distilabel.tasks import TextGenerationTask
 
 class TestJSONOpenAILLM(TestCase):
     @patch("distilabel.llm.openai.OpenAILLM.available_models")
-    def test_avaailable_models(self, mock_available_models):
+    def test_available_models(self, mock_available_models):
         # Mock the available_models property
         mock_available_models.return_value = ["gpt-3.5-turbo-1106"]
 

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -21,6 +21,17 @@ from distilabel.tasks import TextGenerationTask
 
 class TestJSONOpenAILLM(TestCase):
     @patch("distilabel.llm.openai.OpenAILLM.available_models")
+    def test_avaailable_models(self, mock_available_models):
+        # Mock the available_models property
+        mock_available_models.return_value = ["gpt-3.5-turbo-1106"]
+
+        # Initialize the JSONOpenAILLM class
+        llm = JSONOpenAILLM(task=TextGenerationTask())
+
+        # Check the available_models property
+        self.assertEqual(llm.available_models, ["gpt-3.5-turbo-1106"])
+        
+    @patch("distilabel.llm.openai.OpenAILLM.available_models")
     @patch("openai.resources.chat.Completions.create")
     def test_generate(self, mock_create):
         # Mock the available_models property
@@ -45,7 +56,6 @@ class TestJSONOpenAILLM(TestCase):
         self.assertEqual(len(outputs), 1)
         self.assertIsInstance(json_response, dict)
         self.assertEqual(json_response["answer"], "Madrid")
-        self.assertEqual(llm.model, llm.json_supporting_models)
 
         # Check if the OpenAI API was called with the correct arguments
         prompts = llm._generate_prompts(inputs, default_format="openai")

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -61,7 +61,7 @@ def test_generate(mock_json_openai_llm):
     mock_json_openai_llm.client.chat.completions.create.assert_called_once()
 
 
-def test_json_openai_llm_with_non_json_model():
+def test_json_openai_llm_with_non_json_model(mock_json_openai_llm):
     with pytest.raises(AssertionError):
         JSONOpenAILLM(
             model=NON_JSON_SUPPORTING_MODEL,


### PR DESCRIPTION
This pr implements a new class in `distilabel.llm.openai` named `JSONOpenAILLM`. 

The class uses the `json_response` feature from Open AI and validates that the model selected is present in a hard coded list of models that support this feature.