### PR TITLE
332 docs typo in docstrings to argilla metrics strategy should be metric strategy

### DIFF
--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -79,7 +79,7 @@ class CustomDataset(Dataset):
             vector_strategy (Union[bool, SentenceTransformersExtractor]): the strategy to be used for
                 adding vectors to the dataset. If `True`, the default `SentenceTransformersExtractor`
                 will be used with the `TaylorAI/bge-micro-2` model. If `False`, no vectors will be added to the dataset.
-            metrics_strategy (Union[bool, TextDescriptivesExtractor]): the strategy to be used for
+            metric_strategy (Union[bool, TextDescriptivesExtractor]): the strategy to be used for
                 adding metrics to the dataset. If `True`, the default `TextDescriptivesExtractor`
                 will be used. If `False`, no metrics will be added to the dataset.
 

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Union
 
@@ -173,6 +175,147 @@ class OpenAILLM(LLM):
                     )
                 except Exception as e:
                     logger.error(f"Error parsing OpenAI response: {e}")
+                    parsed_response = None
+                output.append(
+                    LLMOutput(
+                        model_name=self.model_name,
+                        prompt_used=prompt,
+                        raw_output=chat_completion.message.content,
+                        parsed_output=parsed_response,
+                    )
+                )
+            outputs.append(output)
+        return outputs
+
+
+class JSONOpenAILLM(OpenAILLM):
+    def __init__(
+        self,
+        task: "Task",
+        model: str = "gpt-3.5-turbo-1106",
+        client: Union["OpenAI", None] = None,
+        api_key: Union[str, None] = None,
+        max_new_tokens: int = 128,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        num_threads: Union[int, None] = None,
+        prompt_format: Union["SupportedFormats", None] = None,
+        prompt_formatting_fn: Union[Callable[..., str], None] = None,
+    ) -> None:
+        """Initializes the JSONOpenAILLM class for generating JSON.
+
+        Args:
+            task (Task): the task to be performed by the LLM.
+            model (str, optional): the model to be used for generation. Defaults to "gpt-3.5-turbo".
+            client (Union[OpenAI, None], optional): an OpenAI client to be used for generation.
+                If `None`, a new client will be created. Defaults to `None`.
+            api_key (Union[str, None], optional): the OpenAI API key to be used for generation.
+                If `None`, the `OPENAI_API_KEY` environment variable will be used. Defaults to `None`.
+            max_new_tokens (int, optional): the maximum number of tokens to be generated.
+                Defaults to 128.
+            frequency_penalty (float, optional): the frequency penalty to be used for generation.
+                Defaults to 0.0.
+            presence_penalty (float, optional): the presence penalty to be used for generation.
+                Defaults to 0.0.
+            temperature (float, optional): the temperature to be used for generation.
+                Defaults to 1.0.
+            top_p (float, optional): the top-p value to be used for generation.
+                Defaults to 1.0.
+            num_threads (Union[int, None], optional): the number of threads to be used
+                for parallel generation. If `None`, no parallel generation will be performed.
+                Defaults to `None`.
+            prompt_format (Union[SupportedFormats, None], optional): the format to be used
+                for the prompt. If `None`, the default format of the task will be used, available
+                formats are `openai`, `chatml`, `llama2`, `zephyr`, and `default`. Defaults to `None`,
+                but `default` (concatenation of `system_prompt` and `formatted_prompt` with a line-break)
+                will be used if no `prompt_formatting_fn` is provided.
+            prompt_formatting_fn (Union[Callable[..., str], None], optional): a function to be
+                applied to the prompt before generation. If `None`, no formatting will be applied.
+                Defaults to `None`.
+
+        Raises:
+            AssertionError: if the provided `model` is not available in your OpenAI account.
+            AssertionError: if the provided `model` does not support JSON input.
+
+        Examples:
+            >>> from distilabel.tasks import TextGenerationTask
+            >>> from distilabel.llm import JSONOpenAILLM
+            >>> llm = OpenAILLM(task=TextGenerationTask())
+            >>> llm.generate([{"input": "json for 'What's the capital of Spain?'"}])
+        """
+        super().__init__(
+            task,
+            model=model,
+            client=client,
+            api_key=api_key,
+            max_new_tokens=max_new_tokens,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            temperature=temperature,
+            top_p=top_p,
+            num_threads=num_threads,
+            prompt_format=prompt_format,
+            prompt_formatting_fn=prompt_formatting_fn,
+        )
+        self.json_supporting_models = [
+            "gpt-4-0125-preview",
+            "gpt-4-turbo-preview",
+            "gpt-4-1106-preview",
+            "gpt-3.5-turbo-1106",
+        ]
+        assert (
+            model in self.json_supporting_models
+        ), f"Provided `model` does not support JSON input, \
+            available models are {self.json_supporting_models}"
+
+    def _generate(
+        self,
+        inputs: List[Dict[str, Any]],
+        num_generations: int = 1,
+    ) -> List[List[LLMOutput]]:
+        """Generates `num_generations` for each input in `inputs` in JSON format.
+
+        Args:
+            inputs (List[Dict[str, Any]]): the inputs to be used for generation.
+            num_generations (int, optional): the number of generations to be performed for each
+                input. Defaults to 1.
+
+        Returns:
+            List[List[LLMOutput]]: the generated outputs.
+        """
+        prompts = self._generate_prompts(inputs, default_format="openai")
+        outputs = []
+        for prompt in prompts:
+            chat_completions = self.client.chat.completions.create(
+                messages=prompt,
+                model=self.model,
+                n=num_generations,
+                max_tokens=self.max_tokens,
+                frequency_penalty=self.frequency_penalty,
+                presence_penalty=self.presence_penalty,
+                temperature=self.temperature,
+                top_p=self.top_p,
+                timeout=50,
+                response_format={"type": "json_object"},
+            )
+
+            output = []
+            for chat_completion in chat_completions.choices:
+                try:
+                    parsed_response = self.task.parse_output(
+                        chat_completion.message.content.strip()
+                    )
+                except Exception as e:
+                    logger.error(f"Error parsing OpenAI response: {e}")
+                    parsed_response = None
+                try:
+                    json.loads(chat_completion.message.content)
+                except json.JSONDecodeError:
+                    warnings.warn(
+                        "The response is not a valid JSON."
+                    )
                     parsed_response = None
                 output.append(
                     LLMOutput(

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -1,0 +1,64 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import Mock, patch, TestCase
+
+from distilabel.llm.openai import JSONOpenAILLM
+from distilabel.tasks import TextGenerationTask
+
+
+class TestJSONOpenAILLM(TestCase):
+    @patch("distilabel.llm.openai.OpenAILLM.available_models")
+    @patch("openai.resources.chat.Completions.create")
+    def test_generate(self, mock_create):
+        # Mock the available_models property
+        mock_create.return_value = ["gpt-3.5-turbo-1106"]
+        
+        # Mock the response from the OpenAI API
+        mock_create.return_value = Mock(
+            choices=[Mock(message=Mock(content='{"answer": "Madrid"}'))]
+        )
+
+        # Initialize the JSONOpenAILLM class
+        llm = JSONOpenAILLM(task=TextGenerationTask())
+
+        # Call the _generate method
+        inputs = [
+            {"input": "write a json object with a key 'answer' and value 'Paris'"}
+        ]
+        outputs = llm.generate(inputs)
+        json_response = json.loads(outputs[0][0]["parsed_output"]["generations"])
+
+        # Check the output
+        self.assertEqual(len(outputs), 1)
+        self.assertIsInstance(json_response, dict)
+        self.assertEqual(json_response["answer"], "Madrid")
+        self.assertEqual(llm.model, llm.json_supporting_models)
+
+        # Check if the OpenAI API was called with the correct arguments
+        prompts = llm._generate_prompts(inputs, default_format="openai")
+        prompt = prompts[0]
+        mock_create.assert_called_once_with(
+            messages=prompt,
+            model=llm.model,
+            n=1,
+            max_tokens=llm.max_tokens,
+            frequency_penalty=llm.frequency_penalty,
+            presence_penalty=llm.presence_penalty,
+            temperature=llm.temperature,
+            top_p=llm.top_p,
+            timeout=50,
+            response_format={"type": "json_object"},
+        )

--- a/tests/llm/test_openai.py
+++ b/tests/llm/test_openai.py
@@ -21,6 +21,17 @@ from distilabel.tasks import TextGenerationTask
 
 class TestJSONOpenAILLM(TestCase):
     @patch("distilabel.llm.openai.OpenAILLM.available_models")
+    def test_avaailable_models(self, mock_available_models):
+        # Mock the available_models property
+        mock_available_models.return_value = ["gpt-3.5-turbo-1106"]
+
+        # Initialize the JSONOpenAILLM class
+        llm = JSONOpenAILLM(task=TextGenerationTask())
+
+        # Check the available_models property
+        self.assertEqual(llm.available_models, ["gpt-3.5-turbo-1106"])
+        
+    @patch("distilabel.llm.openai.OpenAILLM.available_models")
     @patch("openai.resources.chat.Completions.create")
     def test_generate(self, mock_create):
         # Mock the available_models property
@@ -45,7 +56,6 @@ class TestJSONOpenAILLM(TestCase):
         self.assertEqual(len(outputs), 1)
         self.assertIsInstance(json_response, dict)
         self.assertEqual(json_response["answer"], "Madrid")
-        self.assertEqual(llm.model, llm.json_supporting_models)
 
         # Check if the OpenAI API was called with the correct arguments
         prompts = llm._generate_prompts(inputs, default_format="openai")


### PR DESCRIPTION
This PR fixes the typo 'metrics_strategy'