### PR TITLE
Fix typo in docstring of to_argilla metrics_ to metric_

### DIFF
--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -79,7 +79,7 @@ class CustomDataset(Dataset):
             vector_strategy (Union[bool, SentenceTransformersExtractor]): the strategy to be used for
                 adding vectors to the dataset. If `True`, the default `SentenceTransformersExtractor`
                 will be used with the `TaylorAI/bge-micro-2` model. If `False`, no vectors will be added to the dataset.
-            metrics_strategy (Union[bool, TextDescriptivesExtractor]): the strategy to be used for
+            metric_strategy (Union[bool, TextDescriptivesExtractor]): the strategy to be used for
                 adding metrics to the dataset. If `True`, the default `TextDescriptivesExtractor`
                 will be used. If `False`, no metrics will be added to the dataset.
 


### PR DESCRIPTION
This PR fixes a typo to `metric_strategy` from `metrics_strategy`