### PR TITLE
docs: update tutorials avoid argilla installation error

### DIFF
--- a/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
+++ b/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
@@ -61,7 +61,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Let’s start by installing the required dependencies to run distilabel, Argilla, and the remainder of this tutorial."
+        "Let’s start by installing the required dependencies to run distilabel and the remainder of this tutorial."
       ]
     },
     {
@@ -70,7 +70,17 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install \"distilabel[openai]\" --upgrade"
+        "%pip install -q -U \"distilabel[openai]\" --upgrade"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install Argilla for a better visualization and curation of the results\n",
+        "%pip install -q -U \"distilabel[argilla]\" --upgrade"
       ]
     },
     {
@@ -144,9 +154,9 @@
         "First, we will load the original [orca_dpo_pairs](https://huggingface.co/datasets/Intel/orca_dpo_pairs), which consists of 12,859 preference pairs.\n",
         "\n",
         "> Note: To enhance performance while using this tutorial as a guide, consider selecting a subset of samples from the original dataset.\n",
-        "> ```python\n",
-        "> subsample = dataset.select(range(500))\n",
-        "> ```"
+        "```python\n",
+        "subsample = dataset.select(range(500))\n",
+        "```"
       ]
     },
     {
@@ -436,22 +446,6 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "First, install it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!pip install \"distilabel[argilla]\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
         "If you are running Argilla using the Docker quickstart image or Hugging Face Spaces, you need to init the Argilla client with the URL and API_KEY:"
       ]
     },
@@ -476,7 +470,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "You can now push the dataset to Argilla as follows:"
+        "You can now push the dataset to Argilla as follows and start annotating it:"
       ]
     },
     {

--- a/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
+++ b/docs/tutorials/clean-preference-dataset-judgelm-gpt.ipynb
@@ -61,7 +61,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Let’s start by installing the required dependencies to run distilabel and the remainder of this tutorial."
+        "Let’s start by installing the required dependencies to run **distilabel** and the remainder of this tutorial. Install **Argilla** for a better visualization and curation of the results"
       ]
     },
     {
@@ -70,17 +70,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install -q -U \"distilabel[openai]\" --upgrade"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Install Argilla for a better visualization and curation of the results\n",
-        "%pip install -q -U \"distilabel[argilla]\" --upgrade"
+        "%pip install -q -U \"distilabel[openai,argilla]\" --upgrade"
       ]
     },
     {

--- a/docs/tutorials/create-a-math-preference-dataset.ipynb
+++ b/docs/tutorials/create-a-math-preference-dataset.ipynb
@@ -74,31 +74,20 @@
     "id": "IpO8CKrn0hFL",
     "outputId": "ab57f5fd-72de-495a-f7b8-98ac39915f9c"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.1/60.1 kB\u001b[0m \u001b[31m2.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m521.2/521.2 kB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m2.9/2.9 MB\u001b[0m \u001b[31m17.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m220.8/220.8 kB\u001b[0m \u001b[31m20.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m75.7/75.7 kB\u001b[0m \u001b[31m9.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m115.3/115.3 kB\u001b[0m \u001b[31m14.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m17.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.6/1.6 MB\u001b[0m \u001b[31m27.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.0/76.0 kB\u001b[0m \u001b[31m9.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m7.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "llmx 0.0.15a0 requires cohere, which is not installed.\n",
-      "llmx 0.0.15a0 requires tiktoken, which is not installed.\u001b[0m\u001b[31m\n",
-      "\u001b[0mtime: 330 µs (started: 2023-11-28 13:21:16 +00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install distilabel[openai] ipython-autotime -qqq\n",
     "%load_ext autotime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install Argilla for a better visualization and curation of the results\n",
+    "%pip install -q -U \"distilabel[argilla]\" --upgrade"
    ]
   },
   {
@@ -454,123 +443,7 @@
     "id": "PtUfJ-ryzrcu",
     "outputId": "06e717bd-3e4f-4163-80c7-8db5a7a0ef29"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b689c54bb1584819a688a3a5ddadc244",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:distilabel:Processing batch 1 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 1...\n",
-      "INFO:distilabel:Processing batch 2 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 2...\n",
-      "INFO:distilabel:Processing batch 3 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 3...\n",
-      "INFO:distilabel:Processing batch 4 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 4...\n",
-      "INFO:distilabel:Processing batch 5 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 5...\n",
-      "INFO:distilabel:Processing batch 6 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 6...\n",
-      "INFO:distilabel:Processing batch 7 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 7...\n",
-      "INFO:distilabel:Processing batch 8 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 8...\n",
-      "INFO:distilabel:Processing batch 9 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 9...\n",
-      "INFO:distilabel:Processing batch 10 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 10...\n",
-      "INFO:distilabel:Processing batch 11 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 11...\n",
-      "INFO:distilabel:Processing batch 12 of 12...\n",
-      "INFO:distilabel:Calling generator for batch 12...\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8ae3a7625ea84b19a2addf4eb1ffb8cc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Flattening the indices:   0%|          | 0/46 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d11504d1e86c444b9dbc11272288005d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/46 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "time: 2min 13s (started: 2023-11-28 13:21:58 +00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "distiset = pipeline.generate(\n",
     "    dataset=dataset,\n",
@@ -759,57 +632,7 @@
     "id": "Y-i23xECc_J7",
     "outputId": "6bf3f81b-fa02-40ff-cf7f-a94a38b18db2"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a70c3be9900c41dea86c85490cb77c2d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Uploading the dataset shards:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6db7a2e6384e4d44a9fc8c58cad4606a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Creating parquet from Arrow format:   0%|          | 0/5 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f86181ec9ffa4ef29ee3b1c16415d93e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "README.md:   0%|          | 0.00/444 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "time: 1.15 s (started: 2023-11-23 13:55:36 +00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dataset.push_to_hub(\"argilla/distilabel-math-instructions\")"
    ]
@@ -909,85 +732,7 @@
     "id": "kseAeAZf0P9n",
     "outputId": "a782e83d-2722-4ff2-ab65-60be3ec7c0c6"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43c4a6e7a7434f37b6304d95ca2037be",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading readme:   0%|          | 0.00/461 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ed6bb95873274484935129f6a4cdaa4d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "725fa9cb841948f8abb96a2af2b60aab",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading data:   0%|          | 0.00/151k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db7122df29344250bdc5f3dabb6bcaf5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Extracting data files:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "21f21f4a6a61423f813d5c2c3a8c5c9b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating train split:   0%|          | 0/4699 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "time: 16.2 s (started: 2023-11-28 13:28:42 +00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
     "\n",
@@ -1182,128 +927,7 @@
     "id": "aLCZv1Lg0G_O",
     "outputId": "fbf43aca-65e2-40e0-96a1-2bbb07d66773"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:distilabel:Processing batch 1 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 1...\n",
-      "INFO:distilabel:Calling labeller for batch 1...\n",
-      "INFO:distilabel:Processing batch 2 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 2...\n",
-      "INFO:distilabel:Calling labeller for batch 2...\n",
-      "INFO:distilabel:Processing batch 3 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 3...\n",
-      "ERROR:distilabel:Error parsing OpenAI response: list index out of range\n",
-      "INFO:distilabel:Calling labeller for batch 3...\n",
-      "INFO:distilabel:Processing batch 4 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 4...\n",
-      "INFO:distilabel:Calling labeller for batch 4...\n",
-      "INFO:distilabel:Processing batch 5 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 5...\n",
-      "ERROR:distilabel:Error parsing OpenAI response: list index out of range\n",
-      "INFO:distilabel:Calling labeller for batch 5...\n",
-      "INFO:distilabel:Processing batch 6 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 6...\n",
-      "INFO:distilabel:Calling labeller for batch 6...\n",
-      "INFO:distilabel:Processing batch 7 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 7...\n",
-      "ERROR:distilabel:Error parsing OpenAI response: list index out of range\n",
-      "INFO:distilabel:Calling labeller for batch 7...\n",
-      "INFO:distilabel:Processing batch 8 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 8...\n",
-      "ERROR:distilabel:Error parsing OpenAI response: list index out of range\n",
-      "INFO:distilabel:Calling labeller for batch 8...\n",
-      "INFO:distilabel:Processing batch 9 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 9...\n",
-      "INFO:distilabel:Calling labeller for batch 9...\n",
-      "INFO:distilabel:Processing batch 10 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 10...\n",
-      "INFO:distilabel:Calling labeller for batch 10...\n",
-      "INFO:distilabel:Processing batch 11 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 11...\n",
-      "INFO:distilabel:Calling labeller for batch 11...\n",
-      "INFO:distilabel:Processing batch 12 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 12...\n",
-      "INFO:distilabel:Calling labeller for batch 12...\n",
-      "INFO:distilabel:Processing batch 13 of 13...\n",
-      "INFO:distilabel:Calling generator for batch 13...\n",
-      "INFO:distilabel:Calling labeller for batch 13...\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81a74705aa8147ee921accc40ff8e7c9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Flattening the indices:   0%|          | 0/100 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a7bd9d737314a058cdbaac6299a2d13",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/100 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "time: 5min 8s (started: 2023-11-28 13:29:07 +00:00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "distiset_pref = pipeline.generate(\n",
     "    dataset=dataset.shuffle().select(range(100)),\n",
@@ -1503,18 +1127,7 @@
    "source": [
     "## Human Feedback with Argilla\n",
     "\n",
-    "You can use the AI Feedback created by distilabel directly but we hae ve seen that enhancing it with human feedback will improve the quality of your LLM. We provide a `to_argilla` method which creates a dataset for Argilla along with out-of-the-box tailored metadata filters and semantic search to allow you to provide human feedback as quickly and engaging as possible. You can check [the Argilla docs](https://docs.argilla.io/en/latest/getting_started/quickstart_installation.html) to get it up and running.\n",
-    "\n",
-    "First, install it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install \"distilabel[argilla]\""
+    "You can use the AI Feedback created by distilabel directly but we hae ve seen that enhancing it with human feedback will improve the quality of your LLM. We provide a `to_argilla` method which creates a dataset for Argilla along with out-of-the-box tailored metadata filters and semantic search to allow you to provide human feedback as quickly and engaging as possible. You can check [the Argilla docs](https://docs.argilla.io/en/latest/getting_started/quickstart_installation.html) to get it up and running."
    ]
   },
   {
@@ -1561,7 +1174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can convert our dataset to a formatted Argilla dataset."
+    "Now we can convert our dataset to a formatted Argilla dataset and push it."
    ]
   },
   {

--- a/docs/tutorials/create-a-math-preference-dataset.ipynb
+++ b/docs/tutorials/create-a-math-preference-dataset.ipynb
@@ -76,18 +76,8 @@
    },
    "outputs": [],
    "source": [
-    "%pip install distilabel[openai] ipython-autotime -qqq\n",
+    "%pip install distilabel[openai,argilla] ipython-autotime -qqq\n",
     "%load_ext autotime"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install Argilla for a better visualization and curation of the results\n",
-    "%pip install -q -U \"distilabel[argilla]\" --upgrade"
    ]
   },
   {

--- a/docs/tutorials/improving-text-embeddings-with-llms.ipynb
+++ b/docs/tutorials/improving-text-embeddings-with-llms.ipynb
@@ -23,7 +23,7 @@
       "source": [
         "### Installation\n",
         "\n",
-        "We will start off by installing `distilabel` with the `openai` extra, as the authors used both GPT-4 and GPT-3.5 to generate the synthetic data, so no other LLMs were used.\n",
+        "We will start off by installing `distilabel` with the `openai` extra, as the authors used both GPT-4 and GPT-3.5 to generate the synthetic data, so no other LLMs were used. Install **Argilla** for a better visualization and curation of the results\n",
         "\n",
         "Note that we upgrade `typing_extensions` first, since `openai` may have conflicts with the default installed version of `typing_extensions` if outdated."
       ]
@@ -38,18 +38,7 @@
       "outputs": [],
       "source": [
         "%pip install --upgrade typing_extensions --quiet\n",
-        "%pip install \"distilabel[openai]\" --quiet"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0034ed03",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Install Argilla for a better visualization and curation of the results\n",
-        "%pip install -q -U \"distilabel[argilla]\" --upgrade"
+        "%pip install \"distilabel[openai,argilla]\" --quiet"
       ]
     },
     {

--- a/docs/tutorials/improving-text-embeddings-with-llms.ipynb
+++ b/docs/tutorials/improving-text-embeddings-with-llms.ipynb
@@ -42,6 +42,17 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0034ed03",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install Argilla for a better visualization and curation of the results\n",
+        "%pip install -q -U \"distilabel[argilla]\" --upgrade"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "id": "0d3okAvtHQi9",
       "metadata": {
@@ -255,101 +266,7 @@
         "id": "d8aefa70-633a-47ec-b052-ca7c8c37474b",
         "outputId": "12e1b6b9-5a50-4ae4-c629-3c64d800103e"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "74ef7fbecca244f1a6ecb9036a0b0264",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Output()"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "INFO:distilabel:Processing batch 1 of 1...\n",
-            "INFO:distilabel:Calling generator for batch 1...\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-            ],
-            "text/plain": []
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "fbc8bf45cf5745209a4912def8b02bf7",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Flattening the indices:   0%|          | 0/1 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "3b73d717c5e04999a463510f23d0931f",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Saving the dataset (0/1 shards):   0%|          | 0/1 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "INFO:distilabel:Final dataset saved at /content/ckpt\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "new_dataset = pipeline.generate(dataset, num_generations=5, skip_dry_run=True)"
       ]
@@ -440,63 +357,7 @@
         "id": "fb0961bc-8136-4a3c-8599-1709ddeeab65",
         "outputId": "2bffa8c3-f35e-4d9e-ecb7-9d3392f48da9"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ee55aef03ff9492f9a2ceb7d1d16e4f7",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Uploading the dataset shards:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "32846e370d4c443d95dc81c77a2acd64",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Creating parquet from Arrow format:   0%|          | 0/1 [00:00<?, ?ba/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "389ef786d9e4476ea23303db089f2452",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "README.md:   0%|          | 0.00/1.21k [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "CommitInfo(commit_url='https://huggingface.co/datasets/alvarobartt/improving-text-embeddings-with-llms/commit/e762103a4eaa250749900030463907cd36b773d3', commit_message='Upload dataset', commit_description='', oid='e762103a4eaa250749900030463907cd36b773d3', pr_url=None, pr_revision=None, pr_num=None)"
-            ]
-          },
-          "execution_count": 13,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "new_dataset.push_to_hub(\"alvarobartt/improving-text-embeddings-with-llms\", config_name=\"task-generation\")"
       ]
@@ -721,282 +582,7 @@
         "id": "XuPnI4mQy23h",
         "outputId": "c10b9cc9-c482-4c21-83f9-29c31e2126ce"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "INFO:distilabel:Processing batch 1 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 1...\n",
-            "INFO:distilabel:Processing batch 2 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 2...\n",
-            "INFO:distilabel:Processing batch 3 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 3...\n",
-            "INFO:distilabel:Processing batch 4 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 4...\n",
-            "INFO:distilabel:Processing batch 5 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 5...\n",
-            "INFO:distilabel:Processing batch 6 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 6...\n",
-            "INFO:distilabel:Processing batch 7 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 7...\n",
-            "INFO:distilabel:Processing batch 8 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 8...\n",
-            "INFO:distilabel:Processing batch 9 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 9...\n",
-            "INFO:distilabel:Processing batch 10 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 10...\n",
-            "INFO:distilabel:Processing batch 11 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 11...\n",
-            "INFO:distilabel:Processing batch 12 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 12...\n",
-            "INFO:distilabel:Processing batch 13 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 13...\n",
-            "INFO:distilabel:Processing batch 14 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 14...\n",
-            "INFO:distilabel:Processing batch 15 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 15...\n",
-            "INFO:distilabel:Processing batch 16 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 16...\n",
-            "INFO:distilabel:Processing batch 17 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 17...\n",
-            "INFO:distilabel:Processing batch 18 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 18...\n",
-            "INFO:distilabel:Processing batch 19 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 19...\n",
-            "INFO:distilabel:Processing batch 20 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 20...\n",
-            "INFO:distilabel:Processing batch 22 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 22...\n",
-            "INFO:distilabel:Processing batch 23 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 23...\n",
-            "INFO:distilabel:Processing batch 24 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 24...\n",
-            "INFO:distilabel:Processing batch 25 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 25...\n",
-            "INFO:distilabel:Processing batch 26 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 26...\n",
-            "INFO:distilabel:Processing batch 27 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 27...\n",
-            "INFO:distilabel:Processing batch 28 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 28...\n",
-            "INFO:distilabel:Processing batch 29 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 29...\n",
-            "INFO:distilabel:Processing batch 30 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 30...\n",
-            "INFO:distilabel:Processing batch 31 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 31...\n",
-            "INFO:distilabel:Processing batch 32 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 32...\n",
-            "INFO:distilabel:Processing batch 33 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 33...\n",
-            "INFO:distilabel:Processing batch 34 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 34...\n",
-            "INFO:distilabel:Processing batch 35 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 35...\n",
-            "INFO:distilabel:Processing batch 36 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 36...\n",
-            "INFO:distilabel:Processing batch 37 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 37...\n",
-            "INFO:distilabel:Processing batch 38 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 38...\n",
-            "INFO:distilabel:Processing batch 39 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 39...\n",
-            "INFO:distilabel:Processing batch 40 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 40...\n",
-            "INFO:distilabel:Processing batch 41 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 41...\n",
-            "INFO:distilabel:Processing batch 42 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 42...\n",
-            "INFO:distilabel:Processing batch 43 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 43...\n",
-            "INFO:distilabel:Processing batch 44 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 44...\n",
-            "INFO:distilabel:Processing batch 45 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 45...\n",
-            "INFO:distilabel:Processing batch 46 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 46...\n",
-            "INFO:distilabel:Processing batch 47 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 47...\n",
-            "INFO:distilabel:Processing batch 48 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 48...\n",
-            "INFO:distilabel:Processing batch 49 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 49...\n",
-            "INFO:distilabel:Processing batch 50 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 50...\n",
-            "INFO:distilabel:Processing batch 51 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 51...\n",
-            "INFO:distilabel:Processing batch 52 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 52...\n",
-            "INFO:distilabel:Processing batch 53 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 53...\n",
-            "INFO:distilabel:Processing batch 54 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 54...\n",
-            "INFO:distilabel:Processing batch 55 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 55...\n",
-            "INFO:distilabel:Processing batch 56 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 56...\n",
-            "INFO:distilabel:Processing batch 57 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 57...\n",
-            "INFO:distilabel:Processing batch 58 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 58...\n",
-            "INFO:distilabel:Processing batch 59 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 59...\n",
-            "INFO:distilabel:Processing batch 60 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 60...\n",
-            "INFO:distilabel:Processing batch 61 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 61...\n",
-            "INFO:distilabel:Processing batch 62 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 62...\n",
-            "INFO:distilabel:Processing batch 63 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 63...\n",
-            "INFO:distilabel:Processing batch 64 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 64...\n",
-            "INFO:distilabel:Processing batch 65 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 65...\n",
-            "INFO:distilabel:Processing batch 66 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 66...\n",
-            "INFO:distilabel:Processing batch 67 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 67...\n",
-            "INFO:distilabel:Processing batch 68 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 68...\n",
-            "INFO:distilabel:Processing batch 69 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 69...\n",
-            "INFO:distilabel:Processing batch 70 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 70...\n",
-            "INFO:distilabel:Processing batch 71 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 71...\n",
-            "INFO:distilabel:Processing batch 72 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 72...\n",
-            "INFO:distilabel:Processing batch 73 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 73...\n",
-            "INFO:distilabel:Processing batch 74 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 74...\n",
-            "INFO:distilabel:Processing batch 75 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 75...\n",
-            "INFO:distilabel:Processing batch 76 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 76...\n",
-            "INFO:distilabel:Processing batch 77 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 77...\n",
-            "INFO:distilabel:Processing batch 78 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 78...\n",
-            "INFO:distilabel:Processing batch 79 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 79...\n",
-            "INFO:distilabel:Processing batch 80 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 80...\n",
-            "INFO:distilabel:Processing batch 81 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 81...\n",
-            "INFO:distilabel:Processing batch 82 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 82...\n",
-            "INFO:distilabel:Processing batch 83 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 83...\n",
-            "INFO:distilabel:Processing batch 84 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 84...\n",
-            "INFO:distilabel:Processing batch 85 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 85...\n",
-            "INFO:distilabel:Processing batch 86 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 86...\n",
-            "INFO:distilabel:Processing batch 87 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 87...\n",
-            "INFO:distilabel:Processing batch 88 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 88...\n",
-            "INFO:distilabel:Processing batch 89 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 89...\n",
-            "INFO:distilabel:Processing batch 90 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 90...\n",
-            "INFO:distilabel:Processing batch 91 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 91...\n",
-            "INFO:distilabel:Processing batch 92 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 92...\n",
-            "INFO:distilabel:Processing batch 93 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 93...\n",
-            "INFO:distilabel:Processing batch 94 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 94...\n",
-            "INFO:distilabel:Processing batch 95 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 95...\n",
-            "INFO:distilabel:Processing batch 96 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 96...\n",
-            "INFO:distilabel:Calling generator for batch 97...\n",
-            "INFO:distilabel:Processing batch 98 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 98...\n",
-            "INFO:distilabel:Processing batch 99 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 99...\n",
-            "INFO:distilabel:Processing batch 100 of 100...\n",
-            "INFO:distilabel:Calling generator for batch 100...\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-            ],
-            "text/plain": []
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "1193f5b2d96a4ef9a0c5b7278eeffd33",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Flattening the indices:   0%|          | 0/100 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "8ffa39e597574a61aa6d205c5a245039",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Saving the dataset (0/1 shards):   0%|          | 0/100 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "INFO:distilabel:Final dataset saved at /content/ckpt\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "final_dataset = pipeline.generate(new_dataset, num_generations=1, skip_dry_run=True)"
       ]
@@ -1048,63 +634,7 @@
         "id": "2fYPXxgSAnJw",
         "outputId": "c6378c9b-178f-4fca-b9d5-a14e35163e0c"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "f2685a40e76f4e3ba8575804eadf7d8a",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Uploading the dataset shards:   0%|          | 0/1 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c39b7f6d6bf349008dc4a6220f390fc5",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Creating parquet from Arrow format:   0%|          | 0/1 [00:00<?, ?ba/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c870a0d8e67c45ee898b6cb30269b869",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "README.md:   0%|          | 0.00/1.21k [00:00<?, ?B/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "CommitInfo(commit_url='https://huggingface.co/datasets/alvarobartt/improving-text-embeddings-with-llms/commit/1d5ce88974b56cbc1f410ed625e15ac96fe1497d', commit_message='Upload dataset', commit_description='', oid='1d5ce88974b56cbc1f410ed625e15ac96fe1497d', pr_url=None, pr_revision=None, pr_num=None)"
-            ]
-          },
-          "execution_count": 20,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "final_dataset.push_to_hub(\"alvarobartt/improving-text-embeddings-with-llms\", config_name=\"task-completion\")"
       ]
@@ -1116,13 +646,43 @@
         "id": "ZDUOVT29ySEF"
       },
       "source": [
-        "### Annotate with Argilla\n",
+        "### Human Feedback with Argilla\n",
         "\n",
-        "The `datasets.Dataset` generated by `Pipeline.generate` contains a pre-implemented method to easily export it to a `FeedbackDataset` in Argilla, so as to allow any use to easily incorporate feedback to the previously generated synthetic dataset.\n",
+        "You can use the AI Feedback created by distilabel directly but we have seen that enhancing it with human feedback will improve the quality of your LLM. The `datasets.Dataset` generated by `Pipeline.generate` contains the `to_argilla` method which creates a dataset for Argilla along with out-of-the-box tailored metadata filters and semantic search to allow you to provide human feedback as quickly and engaging as possible. You can check [the Argilla docs](https://docs.argilla.io/en/latest/getting_started/quickstart_installation.html) to get it up and running."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "91fee765",
+      "metadata": {},
+      "source": [
+        "If you are running Argilla using the Docker quickstart image or Hugging Face Spaces, you need to init the Argilla client with the URL and API_KEY:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cb4f3708",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import argilla as rg\n",
         "\n",
-        "So on, adding Argilla as a curation tool with humans in the loop, would even push the generated synthetic data further in quality.\n",
-        "\n",
-        "Before calling the `to_argilla` method over the generated dataset, one should first install `argilla`. It can be installed either from the extra within `distilabel` as `pip install \"distilabel[argilla]\"`, which is the recommended way, or just as `pip install argilla --upgrade`."
+        "# Replace api_url with the url to your HF Spaces URL if using Spaces\n",
+        "# Replace api_key if you configured a custom API key\n",
+        "rg.init(\n",
+        "    api_url=\"http://localhost:6900\",\n",
+        "    api_key=\"owner.apikey\",\n",
+        "    workspace=\"admin\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "131f08d7",
+      "metadata": {},
+      "source": [
+        "Now we can convert our dataset to a formatted Argilla dataset and push it."
       ]
     },
     {
@@ -1134,43 +694,11 @@
       },
       "outputs": [],
       "source": [
-        "rg_dataset = final_dataset.to_argilla()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "WPy3em544xIK",
-      "metadata": {
-        "id": "WPy3em544xIK"
-      },
-      "source": [
-        "Besides converting it into a `FeedbackDataset`, it can also be pushed to Argilla, so as to use the Argilla UI to annotate the records recently generated with `distilabel`. To do so, once should first have an Argilla instance running (see [Argilla Documentation - Installation](https://docs.argilla.io/en/latest/getting_started/installation/deployments/deployments.html)) and then you would be free to push the recently converted dataset to annotate it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9ZaxZeJA6QYN",
-      "metadata": {
-        "id": "9ZaxZeJA6QYN"
-      },
-      "outputs": [],
-      "source": [
-        "import argilla as rg\n",
+        "# Convert the dataset to Argilla format\n",
+        "rg_dataset = final_dataset.to_argilla()\n",
         "\n",
-        "rg.init(api_url=\"...\", api_key=\"...\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "s-UWEumu6WFD",
-      "metadata": {
-        "id": "s-UWEumu6WFD"
-      },
-      "outputs": [],
-      "source": [
-        "rg_dataset.push_to_argilla(\"my-dataset\", workspace=\"admin\")"
+        "# Push the dataset to Argilla\n",
+        "rg_dataset.push_to_argilla(name=\"my-dataset\", workspace=\"admin\")"
       ]
     },
     {

--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -40,7 +40,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install  distilabel \"farm-haystack[preprocessing]\" pip install \"distilabel[hf-inference-endpoints]\""
+    "%pip install -q -U distilabel \"farm-haystack[preprocessing]\"\n",
+    "%pip install -q -U \"distilabel[hf-inference-endpoints]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install Argilla for a better visualization and curation of the results\n",
+    "%pip install -q -U \"distilabel[argilla]\" --upgrade"
    ]
   },
   {
@@ -227,56 +238,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "pdftotext version 4.04 [www.xpdfreader.com]\n",
-      "Copyright 1996-2022 Glyph & Cog, LLC\n",
-      "Preprocessing:   0%|          | 0/1 [00:00<?, ?docs/s]"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[01/18/24 09:00:15] </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING </span> WARNING:haystack.nodes.preprocessor.preprocessor:We found one or   <a href=\"file:///Users/ignacio/Documents/recognai/distilabel/.venv/lib/python3.10/site-packages/haystack/nodes/preprocessor/preprocessor.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">preprocessor.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/ignacio/Documents/recognai/distilabel/.venv/lib/python3.10/site-packages/haystack/nodes/preprocessor/preprocessor.py#516\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">516</span></a>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         more sentences whose split count is higher than the split length.  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                   </span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m[01/18/24 09:00:15]\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING \u001b[0m WARNING:haystack.nodes.preprocessor.preprocessor:We found one or   \u001b]8;id=300292;file:///Users/ignacio/Documents/recognai/distilabel/.venv/lib/python3.10/site-packages/haystack/nodes/preprocessor/preprocessor.py\u001b\\\u001b[2mpreprocessor.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=694019;file:///Users/ignacio/Documents/recognai/distilabel/.venv/lib/python3.10/site-packages/haystack/nodes/preprocessor/preprocessor.py#516\u001b\\\u001b[2m516\u001b[0m\u001b]8;;\u001b\\\n",
-       "\u001b[2;36m                    \u001b[0m         more sentences whose split count is higher than the split length.  \u001b[2m                   \u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Preprocessing: 100%|██████████| 1/1 [00:00<00:00,  5.05docs/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Documents: 1\n",
-      "Batches: 355\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The converter turns the PDF into text we can process easily\n",
     "converter = PDFToTextConverter(remove_numeric_tables=True, valid_languages=[\"en\"])\n",
@@ -752,18 +716,7 @@
    "source": [
     "## Human Feedback with Argilla\n",
     "\n",
-    "You can use the AI Feedback created by distilabel directly but we hae ve seen that enhancing it with human feedback will improve the quality of your LLM. We provide a `to_argilla` method which creates a dataset for Argilla along with out-of-the-box tailored metadata filters and semantic search to allow you to provide human feedback as quickly and engaging as possible. You can check [the Argilla docs](https://docs.argilla.io/en/latest/getting_started/quickstart_installation.html) to get it up and running.\n",
-    "\n",
-    "First, install it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install \"distilabel[argilla]\""
+    "You can use the AI Feedback created by distilabel directly but we have seen that enhancing it with human feedback will improve the quality of your LLM. We provide a `to_argilla` method which creates a dataset for Argilla along with out-of-the-box tailored metadata filters and semantic search to allow you to provide human feedback as quickly and engaging as possible. You can check [the Argilla docs](https://docs.argilla.io/en/latest/getting_started/quickstart_installation.html) to get it up and running."
    ]
   },
   {

--- a/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
+++ b/docs/tutorials/pipeline-notus-instructions-preferences-legal.ipynb
@@ -30,8 +30,7 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "\n",
-    "Let's start by installing the required depencies to run distilabel, Argilla and the rest of the packages used in the tutorial; most notably, Haystack.\n"
+    "Let's start by installing the required dependencies to run **distilabel** and the rest of the packages used in the tutorial; most notably, **Haystack**. Install also **Argilla** for a better visualization and curation of the results."
    ]
   },
   {
@@ -41,17 +40,7 @@
    "outputs": [],
    "source": [
     "%pip install -q -U distilabel \"farm-haystack[preprocessing]\"\n",
-    "%pip install -q -U \"distilabel[hf-inference-endpoints]\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install Argilla for a better visualization and curation of the results\n",
-    "%pip install -q -U \"distilabel[argilla]\" --upgrade"
+    "%pip install -q -U \"distilabel[hf-inference-endpoints, argilla]\""
    ]
   },
   {


### PR DESCRIPTION
* Moved the `pip` installation of argilla to the top to avoid importing errors later.
* Some unneeded output removal.
* Some updates of the sections on argilla
