### PR TITLE
Fix `CustomDataset.load_from_disk` with `str`/`Path` objects

### DIFF
--- a/src/distilabel/dataset.py
+++ b/src/distilabel/dataset.py
@@ -197,12 +197,13 @@ class CustomDataset(Dataset):
         """Load a CustomDataset from disk, also reading the task.
 
         Args:
-            dataset_path: Path to the dataset, as you would do with a standard Dataset.
+            dataset_path (os.PathLike): Path to the dataset.
+            kwargs (Any): Keyword arguments passed to Dataset.load_from_disk.
 
         Returns:
             The loaded dataset.
         """
-        ds = super().load_from_disk(dataset_path, *kwargs)
+        ds = super().load_from_disk(dataset_path, **kwargs)
         # Dynamically remaps the `datasets.Dataset` to be a `CustomDataset` instance
         ds.__class__ = cls
         task = load_task_from_disk(dataset_path)

--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -45,7 +45,7 @@ def load_from_dict(template: Dict[str, Any]) -> Generic[T]:
     return instance
 
 
-def load_task_from_disk(path: Path) -> "Task":
+def load_task_from_disk(path: os.PathLike) -> "Task":
     """Loads a task from disk.
 
     Args:
@@ -54,7 +54,7 @@ def load_task_from_disk(path: Path) -> "Task":
     Returns:
         Task: The task.
     """
-    task_path = path / TASK_FILE_NAME
+    task_path = Path(path) / TASK_FILE_NAME
     if not task_path.exists():
         raise FileNotFoundError(f"The task file does not exist: {task_path}")
 


### PR DESCRIPTION
## Description

This PR fixes an bug with `CustomDataset.load_from_disk`. The type information and the docstrings say that it accepts an `os.PathLike` object but it failed for `str` objects. Now it works as expected.

Closes https://github.com/argilla-io/distilabel/issues/340.