### PR TITLE
Refactor `_BatchManager` to have list of batches per step

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -119,14 +119,47 @@ class _Batch:
     """Dataclass to represent a batch of data to be processed by a `Step`.
 
     Attributes:
+        seq_no: The sequence number of the batch.
         step_name: The name of the step that will process the batch.
         last_batch: A flag to indicate if the batch is the last one.
         data: The data to be processed.
     """
 
+    seq_no: int
     step_name: str
     last_batch: bool
     data: List[List[Dict[str, Any]]] = field(default_factory=list, repr=False)
+
+    def next_batch(self) -> "_Batch":
+        """Create a new `_Batch` instance with the next batch of data.
+        Args:
+            data: The data to be processed.
+        Returns:
+            A `_Batch` instance.
+        """
+        return _Batch(
+            seq_no=self.seq_no + 1, step_name=self.step_name, last_batch=self.last_batch
+        )
+
+    @classmethod
+    def from_batches(cls, step_name: str, batches: List["_Batch"]) -> "_Batch":
+        """Create a `_Batch` instance from a list of `_Batch` instances.
+
+        Args:
+            step_name: The name of the step that will process the batch.
+            batches: A list of `_Batch` instances.
+
+        Returns:
+            A `_Batch` instance.
+        """
+
+        seq_no = batches[0].seq_no
+        if not all(batch.seq_no == seq_no for batch in batches):
+            raise ValueError("All batches must have the same sequence number")
+
+        data = [batch.data[0] for batch in batches]
+        last_batch = batches[-1].last_batch
+        return cls(seq_no, step_name, last_batch, data)
 
 
 class _BatchManager:
@@ -136,15 +169,15 @@ class _BatchManager:
 
     Attributes:
         _batches: A dictionary with the step name as the key and a dictionary with the
-            predecessor step name as the key and the batch as the value.
+            predecessor step name as the key and a list of batches as the value.
     """
 
-    def __init__(self, batches: Dict[str, Dict[str, Union["_Batch", None]]]) -> None:
+    def __init__(self, batches: Dict[str, Dict[str, List["_Batch"]]]) -> None:
         """Initialize the `_BatchManager` instance.
 
         Args:
             batches: A dictionary with the step name as the key and a dictionary with the
-                predecessor step name as the key and the batch as the value.
+                predecessor step name as the key and a list of batches as the value.
         """
         self._batches = batches
 
@@ -164,17 +197,17 @@ class _BatchManager:
             ValueError: If a batch was already received from `from_step` to `to_step`.
         """
         from_step = batch.step_name
-        if self._batches[to_step][from_step] is not None:
-            raise ValueError(
-                f"Step '{to_step}' already had a batch waiting from '{from_step}'"
-            )
-        self._batches[to_step][from_step] = batch
+        for batch in self._batches[to_step][from_step]:
+            if batch.seq_no == batch.seq_no:
+                raise ValueError(
+                    f"A batch from '{from_step}' to '{to_step}' with sequence number "
+                    f"{batch.seq_no} was already received"
+                )
+
+        self._batches[to_step][from_step].append(batch)
 
         if self._step_input_batches_received(to_step):
-            batches = []
-            for batch in self._batches[to_step].values():  # type: ignore
-                batches.append(batch)
-            self._clean_step_input_batches(to_step)
+            batches = [batches.pop(0) for batches in self._batches[to_step].values()]
             return batches
 
         return None
@@ -196,7 +229,7 @@ class _BatchManager:
                 continue
             batches[step_name] = {}
             for predecessor in dag.get_step_predecessors(step_name):
-                batches[step_name][predecessor] = None
+                batches[step_name][predecessor] = []
         return cls(batches)
 
     def _step_input_batches_received(self, step_name: str) -> bool:
@@ -209,12 +242,4 @@ class _BatchManager:
             A boolean indicating if all the inputs for the step have been received.
         """
 
-        return all(self._batches[step_name].values())
-
-    def _clean_step_input_batches(self, step_name: str) -> None:
-        """Clean the input batches for a step.
-
-        Args:
-            step_name: The name of the step.
-        """
-        self._batches[step_name] = {step: None for step in self._batches[step_name]}
+        return all(len(batches) > 0 for batches in self._batches[step_name].values())

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -194,7 +194,8 @@ class _BatchManager:
             to be processed. Otherwise, return `None`.
 
         Raises:
-            ValueError: If a batch was already received from `from_step` to `to_step`.
+            ValueError: If a batch from `from_step` to `to_step` with the same sequence
+            number was already received.
         """
         from_step = batch.step_name
         for batch in self._batches[to_step][from_step]:

--- a/tests/pipeline/test_base.py
+++ b/tests/pipeline/test_base.py
@@ -56,6 +56,24 @@ class TestBasePipeline:
         assert _GlobalPipelineManager.get_pipeline() is None
 
 
+class TestBatch:
+    def test_next_batch(self) -> None:
+        batch = _Batch(seq_no=0, step_name="step1", last_batch=False)
+        next_batch = batch.next_batch()
+
+        assert next_batch == _Batch(seq_no=1, step_name="step1", last_batch=False)
+
+    def test_from_batches(self) -> None:
+        batches = [
+            _Batch(seq_no=0, step_name="step1", last_batch=False, data=[[]]),
+            _Batch(seq_no=0, step_name="step2", last_batch=False, data=[[]]),
+        ]
+        batch = _Batch.from_batches(step_name="step3", batches=batches)
+        assert batch == _Batch(
+            seq_no=0, step_name="step3", last_batch=False, data=[[], []]
+        )
+
+
 class TestBatchManager:
     def test_add_batch(self) -> None:
         batch_manager = _BatchManager(

--- a/tests/pipeline/test_base.py
+++ b/tests/pipeline/test_base.py
@@ -58,73 +58,98 @@ class TestBasePipeline:
 
 class TestBatchManager:
     def test_add_batch(self) -> None:
-        batch_manager = _BatchManager(batches={"step1": {"step2": None, "step3": None}})
-        batch = _Batch(step_name="step2", last_batch=False, data=[[]])
-
-        batches = batch_manager.add_batch(to_step="step1", batch=batch)
-
-        assert batches is None
-        assert batch_manager._batches["step1"]["step2"] == batch
-
-    def test_add_batch_all_batches_received(self) -> None:
-        batch_from_step_2 = _Batch(step_name="step2", last_batch=False, data=[[]])
-        batch_from_step_3 = _Batch(step_name="step3", last_batch=True, data=[[]])
         batch_manager = _BatchManager(
-            batches={"step1": {"step2": None, "step3": batch_from_step_3}}
+            batches={
+                "step3": {
+                    "step1": [],
+                    "step2": [],
+                }
+            }
         )
 
-        batches = batch_manager.add_batch(to_step="step1", batch=batch_from_step_2)
+        batch_from_step_1 = _Batch(
+            seq_no=0, step_name="step1", last_batch=False, data=[[]]
+        )
+        batches = batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
 
-        assert batches == [batch_from_step_2, batch_from_step_3]
-        assert batch_manager._batches["step1"] == {"step2": None, "step3": None}
+        assert batches is None
+        assert batch_manager._batches["step3"]["step1"] == [batch_from_step_1]
+
+    def test_add_batch_all_batches_received(self) -> None:
+        first_batch_from_step_2 = _Batch(
+            seq_no=0, step_name="step2", last_batch=False, data=[[]]
+        )
+        batch_manager = _BatchManager(
+            batches={
+                "step3": {
+                    "step1": [],
+                    "step2": [first_batch_from_step_2],
+                }
+            }
+        )
+
+        batch_from_step_1 = _Batch(
+            seq_no=0, step_name="step1", last_batch=False, data=[[]]
+        )
+        batches = batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
+
+        assert batches == [batch_from_step_1, first_batch_from_step_2]
+        assert batch_manager._batches["step3"]["step1"] == []
+        assert batch_manager._batches["step3"]["step2"] == []
 
     def test_add_batch_for_step_with_batch_waiting(self) -> None:
         batch_manager = _BatchManager(
             batches={
-                "step1": {
-                    "step2": _Batch(step_name="step2", last_batch=False, data=[[]])
+                "step2": {
+                    "step1": [
+                        _Batch(seq_no=0, step_name="step1", last_batch=False, data=[[]])
+                    ]
                 }
             }
         )
 
         with pytest.raises(
-            ValueError, match="Step 'step1' already had a batch waiting from 'step2'"
+            ValueError,
+            match="A batch from 'step1' to 'step2' with sequence number 0 was already received",
         ):
             batch_manager.add_batch(
-                to_step="step1",
-                batch=_Batch(step_name="step2", last_batch=False, data=[[]]),
+                to_step="step2",
+                batch=_Batch(seq_no=0, step_name="step1", last_batch=False, data=[[]]),
             )
 
     def test_from_dag(
-        self, dummy_generator_step: "GeneratorStep", dummy_step_1: "Step"
+        self,
+        dummy_generator_step: "GeneratorStep",
+        dummy_step_1: "Step",
+        dummy_step_2: "Step",
     ) -> None:
         dag = DAG()
         dag.add_step(dummy_generator_step)
         dag.add_step(dummy_step_1)
+        dag.add_step(dummy_step_2)
         dag.add_edge("dummy_generator_step", "dummy_step_1")
+        dag.add_edge("dummy_step_1", "dummy_step_2")
 
         batch_manager = _BatchManager.from_dag(dag)
 
         assert batch_manager._batches == {
-            "dummy_step_1": {"dummy_generator_step": None}
+            "dummy_step_1": {"dummy_generator_step": []},
+            "dummy_step_2": {"dummy_step_1": []},
         }
 
     def test_step_input_batches_received(self) -> None:
-        batch_from_step_2 = _Batch(step_name="step2", last_batch=False, data=[[]])
-        batch_from_step_3 = _Batch(step_name="step3", last_batch=True, data=[[]])
+        batch_from_step_1 = _Batch(
+            seq_no=0, step_name="step1", last_batch=False, data=[[]]
+        )
+        batch_from_step_2 = _Batch(
+            seq_no=0, step_name="step2", last_batch=True, data=[[]]
+        )
         batch_manager = _BatchManager(
-            batches={"step1": {"step2": batch_from_step_2, "step3": batch_from_step_3}}
+            batches={"step3": {"step1": [batch_from_step_1], "step2": []}}
         )
 
-        assert batch_manager._step_input_batches_received("step1")
+        assert batch_manager._step_input_batches_received("step3") is False
 
-    def test_clean_step_input_batches(self) -> None:
-        batch_from_step_2 = _Batch(step_name="step2", last_batch=False, data=[[]])
-        batch_from_step_3 = _Batch(step_name="step3", last_batch=True, data=[[]])
-        batch_manager = _BatchManager(
-            batches={"step1": {"step2": batch_from_step_2, "step3": batch_from_step_3}}
-        )
+        batch_manager._batches["step3"]["step2"] = [batch_from_step_2]
 
-        batch_manager._clean_step_input_batches("step1")
-
-        assert batch_manager._batches["step1"] == {"step2": None, "step3": None}
+        assert batch_manager._step_input_batches_received("step3") is True


### PR DESCRIPTION
## Description

The current implementation of `_BatchManager` was very limited, as it only allowed to have one batch per step. This implementation was not realistic as some steps are faster than others. 

For example, `step3` depends on `step2` and `step1`. `step1` is faster than `step2` and is able to generate 2 batches faster than `step2` to generate one. As one batch was already added to `_BatchManager` for `step1`, when the second is going to be added the current implementation would raise a `ValueError` as there is a batch from `step1` already waiting for `step2`.

This PR modifies the `_BatchManager`, so it has a list of batches per step. In addition, the attribute `seq_no` has been added to `_Batch`, to be able to sync the input batches for a step.

