### PR TITLE
Fix `Task` and `TextGeneration`

### DIFF
--- a/src/distilabel/pipeline/step/task/generation.py
+++ b/src/distilabel/pipeline/step/task/generation.py
@@ -25,7 +25,6 @@ class TextGeneration(Task):
 
     def format_input(self, input: Dict[str, Any]) -> ChatType:
         return [
-            {"role": "system", "content": ""},
             {"role": "user", "content": input[self.inputs[0]]},
         ]
 


### PR DESCRIPTION
## Description

This PR fixes both the `Task` and the `TextGeneration`.

The `Task` was using both `input_mapping` and `output_mapping` but with an inconsistent approach so it has been temporarily removed as it was initially planned to be included within the `connect` method. Also the `validate` method from the `_DAG` was failing, as it was not taking the mapping into consideration but only the `inputs` which were not matching the columns of the `datasets.Dataset`.

Also the `TextGeneration` task has been fixed as `format_input` was injecting the `system` message in the chat, and in some scenarios not only is not needed but also not allowed i.e. `google/gemma-7b-it`.