### PR TITLE
Add `PushToHub` step and fix `typing`

### DIFF
--- a/src/distilabel/pipeline/llm/base.py
+++ b/src/distilabel/pipeline/llm/base.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.task.typing import ChatType
 
 
 class LLM(BaseModel, ABC):

--- a/src/distilabel/pipeline/llm/base.py
+++ b/src/distilabel/pipeline/llm/base.py
@@ -25,6 +25,10 @@ class LLM(BaseModel, ABC):
 
     _values: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
+    @property
+    def model_name(self) -> str:
+        return self._values.get("model_name", None)
+
     @abstractmethod
     def load(self) -> None:
         pass

--- a/src/distilabel/pipeline/llm/llamacpp.py
+++ b/src/distilabel/pipeline/llm/llamacpp.py
@@ -37,6 +37,7 @@ class LlamaCppLLM(LLM):
             n_gpu_layers=self.n_gpu_layers,
             verbose=self.verbose,
         )
+        self._values["model_name"] = self._model.model_path
 
     def format_input(self, input: ChatType) -> ChatType:
         return input

--- a/src/distilabel/pipeline/llm/llamacpp.py
+++ b/src/distilabel/pipeline/llm/llamacpp.py
@@ -19,7 +19,7 @@ from llama_cpp import Llama
 from pydantic import PrivateAttr
 
 from distilabel.pipeline.llm.base import LLM
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.task.typing import ChatType
 
 
 class LlamaCppLLM(LLM):
@@ -50,7 +50,7 @@ class LlamaCppLLM(LLM):
         temperature: float = 1.0,
         top_p: float = 1.0,
     ) -> str:
-        chat_completions = self._model.create_chat_completion(
+        chat_completions = self._model.create_chat_completion(  # type: ignore
             messages=input,  # type: ignore
             max_tokens=max_new_tokens,
             frequency_penalty=frequency_penalty,

--- a/src/distilabel/pipeline/llm/openai.py
+++ b/src/distilabel/pipeline/llm/openai.py
@@ -39,6 +39,7 @@ class OpenAILLM(LLM):
 
     def load(self) -> None:
         self._client = OpenAI(api_key=self.api_key.get_secret_value(), max_retries=6)  # type: ignore
+        self._values["model_name"] = self.model
 
     def format_input(self, input: ChatType) -> ChatType:
         return input

--- a/src/distilabel/pipeline/llm/openai.py
+++ b/src/distilabel/pipeline/llm/openai.py
@@ -19,7 +19,7 @@ from openai import OpenAI
 from pydantic import PrivateAttr, SecretStr, field_validator
 
 from distilabel.pipeline.llm.base import LLM
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.task.typing import ChatType
 
 
 # TODO: OpenAI client can be used for AnyScale, TGI, vLLM, etc.

--- a/src/distilabel/pipeline/llm/transformers.py
+++ b/src/distilabel/pipeline/llm/transformers.py
@@ -19,7 +19,7 @@ from pydantic import PrivateAttr
 from transformers import Pipeline, pipeline
 
 from distilabel.pipeline.llm.base import LLM
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.task.typing import ChatType
 
 
 class TransformersLLM(LLM):

--- a/src/distilabel/pipeline/llm/transformers.py
+++ b/src/distilabel/pipeline/llm/transformers.py
@@ -61,6 +61,8 @@ class TransformersLLM(LLM):
         ):
             self._pipeline.tokenizer.chat_template = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"  # type: ignore
 
+        self._values["model_name"] = self.model
+
     def format_input(self, input: ChatType) -> str:
         return self._pipeline.tokenizer.apply_chat_template(  # type: ignore
             input,  # type: ignore

--- a/src/distilabel/pipeline/step/base.py
+++ b/src/distilabel/pipeline/step/base.py
@@ -15,17 +15,13 @@
 import inspect
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any, Dict, Generator, List, Tuple, Union
+from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from typing_extensions import Annotated, get_args, get_origin
 
 from distilabel.pipeline.base import BasePipeline, _GlobalPipelineManager
-
-StepInput = Annotated[List[Dict[str, Any]], "StepInput"]
-"""StepInput is just an `Annotated` alias of the typing `List[Dict[str, Any]]` with
-extra metadata that allows `distilabel` to perform validations over the `process` step
-method defined in each `Step`"""
+from distilabel.pipeline.step.typing import GeneratorStepOutput, StepOutput
 
 
 class Step(BaseModel, ABC):
@@ -171,9 +167,7 @@ class Step(BaseModel, ABC):
         return []
 
     @abstractmethod
-    def process(
-        self, *args: Any, **kwargs: Any
-    ) -> Generator[List[Dict[str, Any]], None, None]:
+    def process(self, *args: Any, **kwargs: Any) -> StepOutput:
         """Method that defines the processing logic of the step."""
         pass
 
@@ -246,9 +240,7 @@ class GeneratorStep(Step, ABC):
         return []
 
     @abstractmethod
-    def process(  # type: ignore
-        self, *args: Any, **kwargs: Any
-    ) -> Generator[Tuple[List[Dict[str, Any]], bool], None, None]:
+    def process(self, *args: Any, **kwargs: Any) -> GeneratorStepOutput:  # type: ignore
         pass
 
 

--- a/src/distilabel/pipeline/step/generators/huggingface.py
+++ b/src/distilabel/pipeline/step/generators/huggingface.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from functools import lru_cache
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 import requests
 from datasets import load_dataset
 
-from distilabel.pipeline.step.base import Generator, GeneratorStep, List, Tuple
+from distilabel.pipeline.step.base import GeneratorStep
+from distilabel.pipeline.step.typing import GeneratorStepOutput
 
 
 @lru_cache
@@ -82,7 +83,7 @@ class LoadHubDataset(GeneratorStep):
 
     def process(  # type: ignore
         self, repo_id: str, split: str, config: Union[str, None] = None
-    ) -> Generator[Tuple[List[Dict[str, Any]], bool], None, None]:
+    ) -> GeneratorStepOutput:
         """Yields batches from the loaded dataset from the Hugging Face Hub.
 
         Yield:

--- a/src/distilabel/pipeline/step/huggingface.py
+++ b/src/distilabel/pipeline/step/huggingface.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from collections import defaultdict
 from typing import List, Optional
 
 from datasets import Dataset
@@ -41,10 +42,11 @@ class PushToHub(Step):
         split: str = "train",
         token: Optional[str] = None,
     ) -> StepOutput:
-        dataset_dict = {}
+        dataset_dict = defaultdict(list)
         for input in inputs:
             for key, value in input.items():
-                dataset_dict[key] = [value]
+                dataset_dict[key].append(value)
+        dataset_dict = dict(dataset_dict)
         dataset = Dataset.from_dict(dataset_dict)
         dataset.push_to_hub(repo_id, split=split, token=token or os.getenv("HF_TOKEN"))
         yield [{}]

--- a/src/distilabel/pipeline/step/huggingface.py
+++ b/src/distilabel/pipeline/step/huggingface.py
@@ -1,0 +1,50 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import List, Optional
+
+from datasets import Dataset
+
+from distilabel.pipeline.step.base import Step
+from distilabel.pipeline.step.typing import StepInput, StepOutput
+
+
+# NOTE: should we implement a `LeafStep`?
+class PushToHub(Step):
+    # NOTE: shouldn't `inputs` and `outputs` have a default value of [] meaning any input or no outputs?
+    @property
+    def inputs(self) -> List[str]:
+        # NOTE: no inputs means any input, is that correct?
+        return []
+
+    @property
+    def outputs(self) -> List[str]:
+        return []
+
+    # NOTE: `process` should be able to not return anything i.e. LeafStep, or just return None
+    def process(
+        self,
+        inputs: StepInput,
+        repo_id: str,
+        split: str = "train",
+        token: Optional[str] = None,
+    ) -> StepOutput:
+        dataset_dict = {}
+        for input in inputs:
+            for key, value in input.items():
+                dataset_dict[key] = [value]
+        dataset = Dataset.from_dict(dataset_dict)
+        dataset.push_to_hub(repo_id, split=split, token=token or os.getenv("HF_TOKEN"))
+        yield [{}]

--- a/src/distilabel/pipeline/step/task/base.py
+++ b/src/distilabel/pipeline/step/task/base.py
@@ -40,5 +40,7 @@ class Task(Step, ABC):
             formatted_input = self.format_input(input)
             output = self.llm.generate(formatted_input)  # type: ignore
             formatted_output = self.format_output(output)  # type: ignore
+
             input.update(formatted_output)
+            input["model_name"] = self.llm.model_name
         yield inputs  # type: ignore

--- a/src/distilabel/pipeline/step/task/base.py
+++ b/src/distilabel/pipeline/step/task/base.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict
 
 from distilabel.pipeline.llm.base import LLM
-from distilabel.pipeline.step.base import Step, StepInput
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.base import Step
+from distilabel.pipeline.step.task.typing import ChatType
+from distilabel.pipeline.step.typing import StepInput, StepOutput
 
 
 class Task(Step, ABC):
@@ -34,7 +35,7 @@ class Task(Step, ABC):
     def format_output(self, output: str) -> Dict[str, Any]:
         pass
 
-    def process(self, inputs: StepInput) -> Iterator[List[Dict[str, Any]]]:
+    def process(self, inputs: StepInput) -> StepOutput:
         for input in inputs:
             formatted_input = self.format_input(input)
             output = self.llm.generate(formatted_input)  # type: ignore

--- a/src/distilabel/pipeline/step/task/generation.py
+++ b/src/distilabel/pipeline/step/task/generation.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict, List
 
 from distilabel.pipeline.step.task.base import Task
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.task.typing import ChatType
 
 
 class TextGeneration(Task):

--- a/src/distilabel/pipeline/step/task/typing.py
+++ b/src/distilabel/pipeline/step/task/typing.py
@@ -14,4 +14,8 @@
 
 from typing import Dict, List, Literal
 
-ChatType = List[Dict[Literal["role", "content"], str]]
+from typing_extensions import Annotated
+
+ChatType = Annotated[List[Dict[Literal["role", "content"], str]], "ChatType"]
+"""ChatType is just an `Annotated` alias of the typing `List[Dict[Literal["role", "content"], str]]`
+following the OpenAI conversational format."""

--- a/src/distilabel/pipeline/step/typing.py
+++ b/src/distilabel/pipeline/step/typing.py
@@ -1,0 +1,30 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Iterator, List, Tuple
+
+from typing_extensions import Annotated
+
+StepInput = Annotated[List[Dict[str, Any]], "StepInput"]
+"""StepInput is just an `Annotated` alias of the typing `List[Dict[str, Any]]` with
+extra metadata that allows `distilabel` to perform validations over the `process` step
+method defined in each `Step`"""
+
+StepOutput = Annotated[Iterator[List[Dict[str, Any]]], "StepOutput"]
+"""StepOutput is just an `Annotated` alias of the typing `Iterator[List[Dict[str, Any]]]`"""
+
+GeneratorStepOutput = Annotated[
+    Iterator[Tuple[List[Dict[str, Any]], bool]], "GeneratorStepOutput"
+]
+"""GeneratorStepOutput is just an `Annotated` alias of the typing `Iterator[Tuple[List[Dict[str, Any]], bool]]`"""

--- a/src/distilabel/pipeline/utils.py
+++ b/src/distilabel/pipeline/utils.py
@@ -1,0 +1,48 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Set
+
+from distilabel.pipeline.step.typing import StepInput
+
+
+def combine_dicts(
+    *inputs: StepInput,
+    merge_keys: Set[str],
+    output_merge_keys: Optional[Set[str]] = None,
+) -> StepInput:
+    if output_merge_keys is not None and len(output_merge_keys) != len(merge_keys):
+        raise ValueError(
+            "The length of output_merge_keys must be the same as the length of merge_keys"
+        )
+    if output_merge_keys is None:
+        output_merge_keys = {f"merged_{key}" for key in merge_keys}
+    merge_keys_dict = dict(zip(merge_keys, output_merge_keys))
+
+    result = []
+    # Use zip to iterate over lists based on their index
+    for dicts_at_index in zip(*inputs):
+        combined_dict = {}
+        # Iterate over dicts at the same index
+        for d in dicts_at_index:
+            # Iterate over key-value pairs in each dict
+            for key, value in d.items():
+                # If the key is in the merge_keys, append the value to the existing list
+                if key in merge_keys_dict.keys():
+                    combined_dict.setdefault(merge_keys_dict[key], []).append(value)
+                # If the key is not in the merge_keys, create a new key-value pair
+                else:
+                    combined_dict[key] = value
+        result.append(combined_dict)
+    return result

--- a/tests/pipeline/step/test_base.py
+++ b/tests/pipeline/step/test_base.py
@@ -16,7 +16,8 @@ from typing import Any, Dict, Generator, List
 
 import pytest
 from distilabel.pipeline.local import Pipeline
-from distilabel.pipeline.step.base import GeneratorStep, GlobalStep, Step, StepInput
+from distilabel.pipeline.step.base import GeneratorStep, GlobalStep, Step
+from distilabel.pipeline.step.typing import StepInput
 
 
 class DummyStep(Step):

--- a/tests/pipeline/utils.py
+++ b/tests/pipeline/utils.py
@@ -14,7 +14,8 @@
 
 from typing import Any, Dict, List
 
-from distilabel.pipeline.step.base import GeneratorStep, Step, StepInput
+from distilabel.pipeline.step.base import GeneratorStep, Step
+from distilabel.pipeline.step.typing import StepInput
 
 
 class DummyGeneratorStep(GeneratorStep):


### PR DESCRIPTION
## Description

This PR adds the `PushToHub` method which will push the `datasets.Dataset` to the HuggingFace Hub and loads that from the `*StepInput`, additionally, some in-code notes have been included for future iterations on the `Step` definition.

Additionally, the pre-defined types have been moved to a `typing.py` file wherever those belong to, and also `StepOutput` and `GeneratorStepOutput` have been included.

## Example

```python
from distilabel.pipeline.step.huggingface import PushToHub

push_to_hub = PushToHub(name="push_to_hub")

...

pipeline.run(
    parameters={
        "push_to_hub": {
            "repo_id": "<REPO_ID>",
            "split": "<SPLIT>",
            "token": "***",
        },
)
```