### PR TITLE
Add `combine_dicts` function and `CombineColumns` class

### DIFF
--- a/src/distilabel/pipeline/step/task/combine.py
+++ b/src/distilabel/pipeline/step/task/combine.py
@@ -1,0 +1,44 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Iterator, List
+
+from distilabel.pipeline.step.base import Step
+from distilabel.pipeline.step.typing import StepInput
+from distilabel.pipeline.utils import combine_dicts
+
+
+class CombineColumns(Step, ABC):
+    """CombineColumns is an abstract Step that implements the `process` method that calls
+    the `combine_dicts` function to handle and combine a list of `StepInput`. Anyway, in order
+    to use this class, one would still need to implement the `inputs` and `outputs` properties
+    that will be the columns to merge and the name of those merged columns."""
+
+    @property
+    @abstractmethod
+    def inputs(self) -> List[str]:
+        ...
+
+    @property
+    @abstractmethod
+    def outputs(self) -> List[str]:
+        ...
+
+    def process(self, *args: StepInput) -> Iterator[StepInput]:
+        yield combine_dicts(
+            *args,
+            merge_keys=set(self.inputs),
+            output_merge_keys=set(self.outputs),
+        )

--- a/src/distilabel/pipeline/step/task/combine.py
+++ b/src/distilabel/pipeline/step/task/combine.py
@@ -12,29 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
 from distilabel.pipeline.step.base import Step
 from distilabel.pipeline.step.typing import StepInput
 from distilabel.pipeline.utils import combine_dicts
 
 
-class CombineColumns(Step, ABC):
-    """CombineColumns is an abstract Step that implements the `process` method that calls
-    the `combine_dicts` function to handle and combine a list of `StepInput`. Anyway, in order
-    to use this class, one would still need to implement the `inputs` and `outputs` properties
-    that will be the columns to merge and the name of those merged columns."""
+class CombineColumns(Step):
+    """CombineColumns is a Step that implements the `process` method that calls the `combine_dicts`
+    function to handle and combine a list of `StepInput`. Also `CombineColumns` provides two attributes
+    `merge_columns` and `output_merge_columns` to specify the columns to merge and the output columns
+    which will override the default value for the properties `inputs` and `outputs`, respectively.
+    """
+
+    merge_columns: List[str]
+    output_merge_columns: Optional[List[str]] = None
 
     @property
-    @abstractmethod
     def inputs(self) -> List[str]:
-        ...
+        return self.merge_columns
 
     @property
-    @abstractmethod
     def outputs(self) -> List[str]:
-        ...
+        return (
+            self.output_merge_columns
+            if self.output_merge_columns is not None
+            else [f"merged_{column}" for column in self.merge_columns]
+        )
 
     def process(self, *args: StepInput) -> Iterator[StepInput]:
         yield combine_dicts(

--- a/src/distilabel/pipeline/step/task/combine.py
+++ b/src/distilabel/pipeline/step/task/combine.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterator, List, Optional
+from typing import List, Optional
 
 from distilabel.pipeline.step.base import Step
-from distilabel.pipeline.step.typing import StepInput
+from distilabel.pipeline.step.typing import StepInput, StepOutput
 from distilabel.pipeline.utils import combine_dicts
 
 
@@ -41,7 +41,7 @@ class CombineColumns(Step):
             else [f"merged_{column}" for column in self.merge_columns]
         )
 
-    def process(self, *args: StepInput) -> Iterator[StepInput]:
+    def process(self, *args: StepInput) -> StepOutput:
         yield combine_dicts(
             *args,
             merge_keys=set(self.inputs),

--- a/src/distilabel/pipeline/utils.py
+++ b/src/distilabel/pipeline/utils.py
@@ -1,0 +1,48 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Set
+
+from distilabel.pipeline.step.typing import StepInput
+
+
+def combine_dicts(
+    *inputs: StepInput,
+    merge_keys: Set[str],
+    output_merge_keys: Optional[Set[str]] = None,
+) -> StepInput:
+    if output_merge_keys is not None and len(output_merge_keys) != len(merge_keys):
+        raise ValueError(
+            "The length of output_merge_keys must be the same as the length of merge_keys"
+        )
+    if output_merge_keys is None:
+        output_merge_keys = {f"merged_{key}" for key in merge_keys}
+    merge_keys_dict = dict(zip(merge_keys, output_merge_keys))
+
+    result = []
+    # Use zip to iterate over lists based on their index
+    for dicts_at_index in zip(*inputs):
+        combined_dict = {}
+        # Iterate over dicts at the same index
+        for d in dicts_at_index:
+            # Iterate over key-value pairs in each dict
+            for key, value in d.items():
+                # If the key is in the merge_keys, append the value to the existing list
+                if key in merge_keys_dict.keys():
+                    combined_dict.setdefault(merge_keys_dict[key], []).append(value)
+                # If the key is not in the merge_keys, create a new key-value pair
+                else:
+                    combined_dict[key] = value
+        result.append(combined_dict)
+    return result


### PR DESCRIPTION
## Description

This PR adds the `combine_dicts` function to combine the columns of `*StepInput` into a single one i.e. the result is a Python dictionary where each key contains a list as a value.

Additionally, this PR also includes the `CombineColumns` class which is a class inheriting from `Step` which implements the `process` method that calls the `combine_dicts` function. Also the `inputs` and `ouputs` properties are defined by the attributes `merge_columns` and `output_merge_columns`, respectively.

## Example

```python
from distilabel.pipeline.step.combine import CombineColumns

step = CombineColumns(
    merge_columns=["generation", "model_name"],
    output_merge_columns=["generations", "model_names"],
)
```