### PR TITLE
Fix `OpenAILLM.api_key` due to `SecretStr` and `StepInput` wrong imports

### DIFF
--- a/src/distilabel/pipeline/llm/openai.py
+++ b/src/distilabel/pipeline/llm/openai.py
@@ -26,15 +26,18 @@ from distilabel.pipeline.step.task.typing import ChatType
 # https://github.com/vllm-project/vllm/blob/main/examples/openai_chatcompletion_client.py
 class OpenAILLM(LLM):
     model: str = "gpt-3.5-turbo"
-    api_key: Optional[SecretStr] = os.getenv("OPENAI_API_KEY")  # type: ignore
+    api_key: Optional[SecretStr] = None
 
     _client: Optional["OpenAI"] = PrivateAttr(...)
 
     @field_validator("api_key")
     @classmethod
     def api_key_must_not_be_none(cls, v: Union[SecretStr, None]) -> SecretStr:
+        v = v or os.getenv("OPENAI_API_KEY", None)  # type: ignore
         if v is None:
             raise ValueError("You must provide an API key to use OpenAI.")
+        if not isinstance(v, SecretStr):
+            v = SecretStr(v)
         return v
 
     def load(self) -> None:

--- a/tests/integration/test_pipe_llms.py
+++ b/tests/integration/test_pipe_llms.py
@@ -17,9 +17,10 @@ from typing import Any, Dict, Generator, List
 from distilabel.pipeline.llm.openai import OpenAILLM
 from distilabel.pipeline.llm.transformers import TransformersLLM
 from distilabel.pipeline.local import Pipeline
-from distilabel.pipeline.step.base import Step, StepInput
+from distilabel.pipeline.step.base import Step
 from distilabel.pipeline.step.generators.huggingface import LoadHubDataset
 from distilabel.pipeline.step.task.generation import TextGeneration
+from distilabel.pipeline.step.typing import StepInput
 
 
 class RenameColumns(Step):

--- a/tests/integration/test_pipe_simple.py
+++ b/tests/integration/test_pipe_simple.py
@@ -16,8 +16,9 @@ from pathlib import Path
 from typing import Any, Dict, Generator, List
 
 from distilabel.pipeline.local import Pipeline
-from distilabel.pipeline.step.base import Step, StepInput
+from distilabel.pipeline.step.base import Step
 from distilabel.pipeline.step.generators.huggingface import LoadHubDataset
+from distilabel.pipeline.step.typing import StepInput
 
 
 class RenameColumns(Step):

--- a/tests/pipeline/llm/test_serialization.py
+++ b/tests/pipeline/llm/test_serialization.py
@@ -18,8 +18,9 @@ from typing import Any, Dict, Generator, List, Optional
 from distilabel.pipeline.llm.base import LLM
 from distilabel.pipeline.llm.openai import OpenAILLM
 from distilabel.pipeline.local import Pipeline
-from distilabel.pipeline.step.base import Step, StepInput
-from distilabel.pipeline.step.task.types import ChatType
+from distilabel.pipeline.step.base import Step
+from distilabel.pipeline.step.task.typing import ChatType
+from distilabel.pipeline.step.typing import StepInput
 
 
 class TestLLMSerialization:


### PR DESCRIPTION
## Description

This PR solves the issue with `SecretStr` as the default value of `api_key` in `OpenAILLM` was set to be the `OPENAI_API_KEY` environment variable, and now that's controlled within the `field_validator`.

Also there were some wrong imports with `StepInput` as it was moved from `distilabel.pipeline.step.base` to `distilabel.pipeline.step.typing`.