### PR TITLE
Migrate vllm to the new API

### DIFF
--- a/src/distilabel/pipeline/llm/base.py
+++ b/src/distilabel/pipeline/llm/base.py
@@ -26,16 +26,12 @@ class LLM(BaseModel, _Serializable, ABC):
 
     _values: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
-    @property
-    def model_name(self) -> str:
-        return self._values.get("model_name", None)
-
     @abstractmethod
     def load(self) -> None:
         pass
 
     @abstractmethod
-    def format_input(self, input: ChatType) -> Any:
+    def prepare_input(self, input: ChatType) -> Any:
         pass
 
     @abstractmethod

--- a/src/distilabel/pipeline/llm/llamacpp.py
+++ b/src/distilabel/pipeline/llm/llamacpp.py
@@ -37,9 +37,12 @@ class LlamaCppLLM(LLM):
             n_gpu_layers=self.n_gpu_layers,
             verbose=self.verbose,
         )
-        self._values["model_name"] = self._model.model_path
 
-    def format_input(self, input: ChatType) -> ChatType:
+    @property
+    def model_name(self) -> str:
+        return self._model.model_path
+
+    def prepare_input(self, input: ChatType) -> ChatType:
         return input
 
     def generate(

--- a/src/distilabel/pipeline/llm/openai.py
+++ b/src/distilabel/pipeline/llm/openai.py
@@ -42,9 +42,12 @@ class OpenAILLM(LLM):
 
     def load(self) -> None:
         self._client = OpenAI(api_key=self.api_key.get_secret_value(), max_retries=6)  # type: ignore
-        self._values["model_name"] = self.model
 
-    def format_input(self, input: ChatType) -> ChatType:
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    def prepare_input(self, input: ChatType) -> ChatType:
         return input
 
     def generate(

--- a/src/distilabel/pipeline/llm/transformers.py
+++ b/src/distilabel/pipeline/llm/transformers.py
@@ -61,9 +61,11 @@ class TransformersLLM(LLM):
         ):
             self._pipeline.tokenizer.chat_template = "{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"  # type: ignore
 
-        self._values["model_name"] = self.model
+    @property
+    def model_name(self) -> str:
+        return self.model
 
-    def format_input(self, input: ChatType) -> str:
+    def prepare_input(self, input: ChatType) -> str:
         return self._pipeline.tokenizer.apply_chat_template(  # type: ignore
             input,  # type: ignore
             tokenize=False,
@@ -81,7 +83,7 @@ class TransformersLLM(LLM):
         do_sample: bool = True,
     ) -> str:
         return self._pipeline(  # type: ignore
-            self.format_input(input=input),
+            self.prepare_input(input=input),
             max_new_tokens=max_new_tokens,
             temperature=temperature,
             repetition_penalty=repetition_penalty,

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -1,0 +1,66 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional
+
+from vllm import LLM as _vLLM
+from vllm import SamplingParams
+
+from distilabel.pipeline.llm.base import LLM
+from distilabel.pipeline.step.task.typing import ChatType
+
+
+class vLLM(LLM):
+    model: str
+    model_kwargs: Optional[Dict[str, Any]] = {}
+    chat_format: Optional[str] = None
+
+    def load(self) -> None:
+        self._model = _vLLM(self.model, **self.model_kwargs)  # type: ignore
+        self._tokenizer = self._model.get_tokenizer()
+        self._values["model_name"] = self.model
+
+    def format_input(self, input: ChatType) -> ChatType:
+        return self._tokenizer.apply_chat_template(  # type: ignore
+            input,
+            tokenize=False,
+            add_generation_prompt=True,  # type: ignore
+        )
+
+    def generate(
+        self,
+        input: ChatType,
+        max_new_tokens: int = 128,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        top_k: int = -1,
+        **extra_sampling_params: Any,
+    ) -> str:
+        sampling_params = SamplingParams(  # type: ignore
+            n=1,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_new_tokens,
+            **extra_sampling_params,
+        )
+        # The sampling params are passed from here
+        chat_completions = self._model.generate(  # type: ignore
+            self.format_input(input), sampling_params, use_tqdm=False
+        )
+        return chat_completions[0].outputs[0].text  # type: ignore

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -31,7 +31,7 @@ class vLLM(LLM):
         self._tokenizer = self._model.get_tokenizer()
         self._values["model_name"] = self.model
 
-    def format_input(self, input: ChatType) -> ChatType:
+    def format_input(self, input: ChatType) -> str:
         return self._tokenizer.apply_chat_template(  # type: ignore
             input,
             tokenize=False,

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -29,9 +29,12 @@ class vLLM(LLM):
     def load(self) -> None:
         self._model = _vLLM(self.model, **self.model_kwargs)  # type: ignore
         self._tokenizer = self._model.get_tokenizer()
-        self._values["model_name"] = self.model
 
-    def format_input(self, input: ChatType) -> str:
+    @property
+    def model_name(self) -> str:
+        return self.model
+
+    def prepare_input(self, input: ChatType) -> str:
         return self._tokenizer.apply_chat_template(  # type: ignore
             input,
             tokenize=False,
@@ -61,6 +64,6 @@ class vLLM(LLM):
         )
         # The sampling params are passed from here
         chat_completions = self._model.generate(  # type: ignore
-            self.format_input(input), sampling_params, use_tqdm=False
+            self.prepare_input(input), sampling_params, use_tqdm=False
         )
         return chat_completions[0].outputs[0].text  # type: ignore


### PR DESCRIPTION
## Description

This PR adds support for vllm in the new pipeline.

```python
llm = vLLM(
    model="microsoft/phi-2",
    model_kwargs={
        "tensor_parallel_size": 1,
        "trust_remote_code": True
    }
)
llm.load()
input_ =[
  {
    "content": "Every day, a tree drops 7 leaves. How many leaves would it drop in a month of February in a non-leap year? Include your logic.",
    "role": "user"
  },
  {
    "content": "Here's the logic behind this:\n\n1. We know that February has 28 days in a non-leap year.\n2. If the tree drops 7 leaves every day, then over the course of February, it would drop:\n Leaves dropped in February = Leaves per day * Days in February\n = 7 leaves * 28 days\n = 196 leaves\n\nSo, the tree would drop 196 leaves in February in a non-leap year.",
    "role": "assistant"
  }
]
llm2.generate(input_)
```