### PR TITLE
Refactor model availability check in is_serverless_endpoint_available

### DIFF
--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -66,11 +66,11 @@ def is_serverless_endpoint_available(model_id: str) -> bool:
     # 2. Then we check if the model is currently deployed
     try:
         client = InferenceClient()
-        deploy_llms = client.list_deployed_models("text-generation-inference")[
-            "text-generation"
-        ]
-        if model_id in deploy_llms:
-            return True
+        status = client.get_model_status("meta-llama/Llama-2-70b-chat-hf")
+        return (
+            status.state in {"Loadable", "Loaded"}
+            and status.framework == "text-generation-inference"
+        )
     except Exception as e:
         logger.error(e)
 

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -66,7 +66,7 @@ def is_serverless_endpoint_available(model_id: str) -> bool:
     # 2. Then we check if the model is currently deployed
     try:
         client = InferenceClient()
-        status = client.get_model_status("meta-llama/Llama-2-70b-chat-hf")
+        status = client.get_model_status(model_id)
         return (
             status.state in {"Loadable", "Loaded"}
             and status.framework == "text-generation-inference"


### PR DESCRIPTION
Currently, the is_serverless_endpoint_available function fails for models that could be loaded by the serveless inference endpoints. This PR updates the logic to check if the model is either loaded or can be loaded and uses the `text-generation-inference` framework 