### PR TITLE
Add fix for labels not returned by openai api

### DIFF
--- a/src/distilabel/pipeline.py
+++ b/src/distilabel/pipeline.py
@@ -457,7 +457,12 @@ class Pipeline:
             processed_labels = [{} for _ in range(len(dataset))]  # type: ignore
         else:
             batch_labels = []
+            labels = labels if labels is not None else []
             for label in labels:
+                # GPT4 started throwing some weird errors that results in some labels
+                # being None, in the meantime, this allows generating the dataset:
+                if not label:
+                    label = []
                 batch_labels.extend(label)
 
             processed_labels = self._process_batch_labels(


### PR DESCRIPTION
## Description

OpenAI started throwing errors (all I found related to the error is [this](https://community.openai.com/t/failed-to-generate-output-due-to-special-tokens-in-the-input/621660)), which weren't controlled in the processing of the labeller outputs. This fixes the problem, resulting in the errored record containing a `None` in the final dataset. 