### PR TITLE
Update `_BatchManager` to work with `GlobalStep`s and `input_batch_size` per step

### DIFF
--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -23,6 +23,7 @@ from typing import (
     Iterable,
     List,
     Set,
+    Type,
     Union,
 )
 
@@ -31,7 +32,7 @@ import networkx as nx
 from distilabel.utils.serialization_v2 import _get_class, _Serializable
 
 if TYPE_CHECKING:
-    from distilabel.pipeline.step.base import Step
+    from distilabel.pipeline.step.base import _Step
 
 
 class DAG(_Serializable):
@@ -47,7 +48,7 @@ class DAG(_Serializable):
     def __iter__(self) -> Generator[str, None, None]:
         yield from self.G
 
-    def add_step(self, step: "Step") -> None:
+    def add_step(self, step: "_Step") -> None:
         """Add a step to the DAG.
 
         Args:
@@ -206,7 +207,7 @@ class DAG(_Serializable):
                 else:
                     self._step_inputs_are_available(step)
 
-    def _step_inputs_are_available(self, step: "Step") -> None:
+    def _step_inputs_are_available(self, step: "_Step") -> None:
         """Validates that the `Step.inputs` will be available when the step gets to be
         executed in the pipeline i.e. the step will receive list of dictionaries containing
         its inputs as keys.
@@ -228,7 +229,7 @@ class DAG(_Serializable):
                 f" the required inputs. Available inputs are: {inputs_available_for_step}"
             )
 
-    def _validate_step_process_arguments(self, step: "Step") -> None:
+    def _validate_step_process_arguments(self, step: "_Step") -> None:
         """Validates the arguments of the `Step.process` method, checking there is an
         argument with type hint `StepInput` and that all the required runtime parameters
         are provided.
@@ -292,7 +293,7 @@ class DAG(_Serializable):
                 f" to receive outputs from previous steps."
             )
 
-    def _validate_step_process_runtime_parameters(self, step: "Step") -> None:
+    def _validate_step_process_runtime_parameters(self, step: "_Step") -> None:
         """Validates that the required runtime parameters of the step are provided.
 
         Args:
@@ -351,7 +352,7 @@ class DAG(_Serializable):
         for node in data["nodes"]:
             step = node["step"]
             # Create the step instance from the serialized content, dynamically loading the step.
-            cls_step: "Step" = _get_class(**step["_type_info_"])
+            cls_step: Type["_Step"] = _get_class(**step["_type_info_"])
             nodes.append({"step": cls_step.from_dict(step), "id": node["id"]})
 
         # Update the instantiated nodes (the steps), and recreate the digraph.

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -295,7 +295,10 @@ class _BatchManagerStep:
             `False`.
         """
         if self.accumulate:
-            return all(step in self._last_batch_received for step in self.data)
+            return all(
+                step in self._last_batch_received and len(rows) > 0
+                for step, rows in self.data.items()
+            )
 
         for step_name, rows in self.data.items():
             # If there are now rows but the last batch was already received, then there
@@ -325,7 +328,9 @@ class _BatchManagerStep:
             The list of data needed to create a batch for the step to process.
         """
         if self.accumulate:
-            return list(self.data.values())
+            data = list(self.data.values())
+            self.data = {step_name: [] for step_name in self.data}
+            return data
 
         data = []
         for step_name in self.data:

--- a/src/distilabel/pipeline/step/base.py
+++ b/src/distilabel/pipeline/step/base.py
@@ -103,7 +103,7 @@ class _Step(BaseModel, _Serializable, ABC):
         self.pipeline._add_step(self)
 
     def connect(
-        self, step: "Step", input_mapping: Union[Dict[str, Any], None] = None
+        self, step: "_Step", input_mapping: Union[Dict[str, Any], None] = None
     ) -> None:
         """Connects the current step to another step in the pipeline, which means that
         the output of this step will be the input of the other step.

--- a/src/distilabel/utils/serialization_v2.py
+++ b/src/distilabel/utils/serialization_v2.py
@@ -29,7 +29,7 @@ DISTILABEL_FILENAME = "distilabel-file.json"
 SaveFormats = Literal["json", "yaml"]
 
 
-def _get_class(module: str = None, name: str = None) -> Type:
+def _get_class(module: str, name: str) -> Type:
     mod = importlib.import_module(module)
     return getattr(mod, name)
 

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -15,7 +15,12 @@
 import pytest
 from distilabel.pipeline.local import Pipeline
 
-from tests.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
+from tests.pipeline.utils import (
+    DummyGeneratorStep,
+    DummyGlobalStep,
+    DummyStep1,
+    DummyStep2,
+)
 
 
 @pytest.fixture(name="pipeline")
@@ -36,3 +41,8 @@ def dummy_step_2_fixture(pipeline: "Pipeline") -> DummyStep2:
 @pytest.fixture(name="dummy_generator_step")
 def dummy_generator_step_fixture(pipeline: "Pipeline") -> DummyGeneratorStep:
     return DummyGeneratorStep(name="dummy_generator_step", pipeline=pipeline)
+
+
+@pytest.fixture(name="dummy_global_step")
+def dummy_global_step_fixture(pipeline: "Pipeline") -> DummyGlobalStep:
+    return DummyGlobalStep(name="dummy_global_step", pipeline=pipeline)

--- a/tests/pipeline/llm/test_serialization.py
+++ b/tests/pipeline/llm/test_serialization.py
@@ -104,6 +104,7 @@ class TestTaskSerialization:
         "name": "OpenAILLM"
         }
     },
+    "input_batch_size": 50,
     "input_mapping": null,
     "output_mapping": {
         "generation": "output"

--- a/tests/pipeline/step/test_base.py
+++ b/tests/pipeline/step/test_base.py
@@ -101,6 +101,7 @@ class TestStepSerialization:
         step = DummyStep(name="dummy", pipeline=pipeline)
         assert step.dump() == {
             "name": "dummy",
+            "input_batch_size": 50,
             "_type_info_": {
                 "module": "tests.pipeline.step.test_base",
                 "name": "DummyStep",

--- a/tests/pipeline/utils.py
+++ b/tests/pipeline/utils.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import List
 
-from distilabel.pipeline.step.base import GeneratorStep, Step
-from distilabel.pipeline.step.typing import StepInput
+from distilabel.pipeline.step.base import GeneratorStep, GlobalStep, Step
+from distilabel.pipeline.step.typing import GeneratorStepOutput, StepInput, StepOutput
 
 
 class DummyGeneratorStep(GeneratorStep):
@@ -23,12 +23,25 @@ class DummyGeneratorStep(GeneratorStep):
     def inputs(self) -> List[str]:
         return []
 
-    def process(self) -> List[Dict[str, Any]]:
-        return [{"instruction": "Generate an email..."}]
+    def process(self) -> GeneratorStepOutput:  # type: ignore
+        yield [{"instruction": "Generate an email..."}], False
 
     @property
     def outputs(self) -> List[str]:
         return ["instruction"]
+
+
+class DummyGlobalStep(GlobalStep):
+    @property
+    def inputs(self) -> List[str]:
+        return ["instruction"]
+
+    def process(self) -> StepOutput:  # type: ignore
+        yield [{"instruction": "Generate an email..."}]
+
+    @property
+    def outputs(self) -> List[str]:
+        return []
 
 
 class DummyStep1(Step):
@@ -36,8 +49,8 @@ class DummyStep1(Step):
     def inputs(self) -> List[str]:
         return ["instruction"]
 
-    def process(self, input: StepInput) -> List[Dict[str, Any]]:
-        return [{"response": "response1"}]
+    def process(self, input: StepInput) -> StepOutput:  # type: ignore
+        yield [{"response": "response1"}]
 
     @property
     def outputs(self) -> List[str]:
@@ -49,8 +62,8 @@ class DummyStep2(Step):
     def inputs(self) -> List[str]:
         return ["response"]
 
-    def process(self, *inputs: StepInput) -> List[Dict[str, Any]]:
-        return [{"response": "response1"}]
+    def process(self, *inputs: StepInput) -> StepOutput:  # type: ignore
+        yield [{"response": "response1"}]
 
     @property
     def outputs(self) -> List[str]:


### PR DESCRIPTION
## Description

This PR updates the `_BatchManager` to handle the creation of a "super" batch gathering all the data from the previous batches for the `GlobalStep`s. In addition, it adds a new attribute to the `Step` class called `input_batch_size`. This argument can be used to define the desired number of rows that the step will receive per batch. Having that said, the `_BatchManager` has also been updated to store the data of the output batches, instead of the batches itself. This allows to build batches of the desired size for each step.