### PR TITLE
Move batching from `Task` to `LLM`, fix `vLLM.generate` and add `DISTILABEL_LOG_LEVEL`

### DIFF
--- a/src/distilabel/pipeline/llm/base.py
+++ b/src/distilabel/pipeline/llm/base.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
+from distilabel.pipeline.logging import get_logger
 from distilabel.pipeline.serialization import _Serializable
 
 if TYPE_CHECKING:
@@ -30,6 +32,7 @@ class LLM(BaseModel, _Serializable, ABC):
     )
 
     _values: Dict[str, Any] = PrivateAttr(default_factory=dict)
+    _logger: logging.Logger = PrivateAttr(get_logger("llm"))
 
     @abstractmethod
     def load(self) -> None:

--- a/src/distilabel/pipeline/llm/base.py
+++ b/src/distilabel/pipeline/llm/base.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from distilabel.pipeline.serialization import _Serializable
-from distilabel.pipeline.step.task.typing import ChatType
+
+if TYPE_CHECKING:
+    from distilabel.pipeline.step.task.typing import ChatType
 
 
 class LLM(BaseModel, _Serializable, ABC):
@@ -34,9 +36,5 @@ class LLM(BaseModel, _Serializable, ABC):
         pass
 
     @abstractmethod
-    def prepare_input(self, input: ChatType) -> Any:
-        pass
-
-    @abstractmethod
-    def generate(self, input: Any, *args: Any, **kwargs: Any) -> str:
+    def generate(self, inputs: List["ChatType"], *args: Any, **kwargs: Any) -> str:
         pass

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -27,6 +27,10 @@ if TYPE_CHECKING:
 
 
 class vLLM(LLM):
+    """To run `vLLM` the following environment variable needs to be set in advance:
+    `OPENBLAS_NUM_THREADS=1`.
+    """
+    
     model: str
     model_kwargs: Optional[Dict[str, Any]] = {}
     chat_format: Optional[str] = None

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -12,19 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from pydantic import PrivateAttr
 from vllm import LLM as _vLLM
 from vllm import SamplingParams
 
 from distilabel.pipeline.llm.base import LLM
-from distilabel.pipeline.step.task.typing import ChatType
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
+
+    from distilabel.pipeline.step.task.typing import ChatType
 
 
 class vLLM(LLM):
     model: str
     model_kwargs: Optional[Dict[str, Any]] = {}
     chat_format: Optional[str] = None
+
+    _model: Optional["_vLLM"] = PrivateAttr(...)
+    _tokenizer: Optional["PreTrainedTokenizer"] = PrivateAttr(...)
 
     def load(self) -> None:
         self._model = _vLLM(self.model, **self.model_kwargs)  # type: ignore
@@ -34,7 +42,7 @@ class vLLM(LLM):
     def model_name(self) -> str:
         return self.model
 
-    def prepare_input(self, input: ChatType) -> str:
+    def prepare_input(self, input: "ChatType") -> str:
         return self._tokenizer.apply_chat_template(  # type: ignore
             input,
             tokenize=False,
@@ -43,7 +51,7 @@ class vLLM(LLM):
 
     def generate(
         self,
-        input: ChatType,
+        inputs: List["ChatType"],
         max_new_tokens: int = 128,
         frequency_penalty: float = 0.0,
         presence_penalty: float = 0.0,
@@ -51,7 +59,7 @@ class vLLM(LLM):
         top_p: float = 1.0,
         top_k: int = -1,
         **extra_sampling_params: Any,
-    ) -> str:
+    ) -> List[str]:
         sampling_params = SamplingParams(  # type: ignore
             n=1,
             presence_penalty=presence_penalty,
@@ -62,8 +70,11 @@ class vLLM(LLM):
             max_tokens=max_new_tokens,
             **extra_sampling_params,
         )
-        # The sampling params are passed from here
-        chat_completions = self._model.generate(  # type: ignore
-            self.prepare_input(input), sampling_params, use_tqdm=False
-        )
-        return chat_completions[0].outputs[0].text  # type: ignore
+
+        outputs = []
+        for input in inputs:
+            chat_completions = self._model.generate(  # type: ignore
+                self.prepare_input(input), sampling_params, use_tqdm=False
+            )
+            outputs.append(chat_completions[0].outputs[0].text)  # type: ignore
+        return outputs

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -36,7 +36,7 @@ class vLLM(LLM):
 
     def load(self) -> None:
         self._model = _vLLM(self.model, **self.model_kwargs)  # type: ignore
-        self._tokenizer = self._model.get_tokenizer()
+        self._tokenizer = self._model.get_tokenizer()  # type: ignore
 
     @property
     def model_name(self) -> str:
@@ -71,10 +71,14 @@ class vLLM(LLM):
             **extra_sampling_params,
         )
 
-        outputs = []
-        for input in inputs:
-            chat_completions = self._model.generate(  # type: ignore
-                self.prepare_input(input), sampling_params, use_tqdm=False
-            )
-            outputs.append(chat_completions[0].outputs[0].text)  # type: ignore
+        prepared_inputs = [self.prepare_input(input) for input in inputs]
+        raw_outputs = self._model.generate(  # type: ignore
+            prepared_inputs,
+            sampling_params,
+            use_tqdm=False,  # type: ignore
+        )
+        outputs = [
+            chat_completion.outputs[0].text
+            for chat_completion in raw_outputs.chat_completions
+        ]  # type: ignore
         return outputs

--- a/src/distilabel/pipeline/llm/vllm.py
+++ b/src/distilabel/pipeline/llm/vllm.py
@@ -77,8 +77,5 @@ class vLLM(LLM):
             sampling_params,
             use_tqdm=False,  # type: ignore
         )
-        outputs = [
-            chat_completion.outputs[0].text
-            for chat_completion in raw_outputs.chat_completions
-        ]  # type: ignore
+        outputs = [raw_output.outputs[0].text for raw_output in raw_outputs]  # type: ignore
         return outputs

--- a/src/distilabel/pipeline/logging.py
+++ b/src/distilabel/pipeline/logging.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import logging
+import os
+import warnings
 
 from rich.logging import RichHandler
 
@@ -29,4 +31,14 @@ def get_logger(suffix: str) -> logging.Logger:
     # as it produces `PyTorch` messages to update on `info`
     logging.getLogger("datasets").setLevel(logging.CRITICAL)
 
-    return logging.getLogger(f"distilabel.{suffix}")
+    log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO")
+    if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        warnings.warn(
+            f"Invalid log level '{log_level}', using default 'INFO' instead.",
+            stacklevel=2,
+        )
+        log_level = "INFO"
+
+    logger = logging.getLogger(f"distilabel.{suffix}")
+    logger.setLevel(log_level)
+    return logger

--- a/src/distilabel/pipeline/step/task/base.py
+++ b/src/distilabel/pipeline/step/task/base.py
@@ -40,7 +40,10 @@ class Task(Step, ABC):
         outputs = self.llm.generate(formatted_inputs)  # type: ignore
         formatted_outputs = [self.format_output(output) for output in outputs]  # type: ignore
 
+        outputs: StepOutput = []
         for input, formatted_output in zip(inputs, formatted_outputs):
-            input.update(formatted_output)
-            input["model_name"] = self.llm.model_name  # type: ignore
-        yield inputs  # type: ignore
+            output = {k: v for k, v in input.items() if k in self.inputs}
+            output.update(formatted_output)
+            output["model_name"] = self.llm.model_name  # type: ignore
+            outputs.append(output)
+        yield outputs  # type: ignore

--- a/src/distilabel/pipeline/step/task/base.py
+++ b/src/distilabel/pipeline/step/task/base.py
@@ -36,11 +36,11 @@ class Task(Step, ABC):
         pass
 
     def process(self, inputs: StepInput) -> StepOutput:
-        for input in inputs:
-            formatted_input = self.format_input(input)
-            output = self.llm.generate(formatted_input)  # type: ignore
-            formatted_output = self.format_output(output)  # type: ignore
+        formatted_inputs = [self.format_input(input) for input in inputs]
+        outputs = self.llm.generate(formatted_inputs)  # type: ignore
+        formatted_outputs = [self.format_output(output) for output in outputs]  # type: ignore
 
+        for input, formatted_output in zip(inputs, formatted_outputs):
             input.update(formatted_output)
-            input["model_name"] = self.llm.model_name
+            input["model_name"] = self.llm.model_name  # type: ignore
         yield inputs  # type: ignore


### PR DESCRIPTION
## Description

This PR moves the batching from the `Task` to the `LLM` so that the `LLM` handles the batches in the best way possible rather than via a simple for-loop, since there are some LLM engines that have mechanisms to handle batches in a more efficient way. Also the `prepare_input` abstract method has been removed from `LLM` and is no longer needed, unless a specific LLM implementation requires it.

Also this PR fixes `vLLM.generate` and stops propagating the unsolicited `inputs` through the `Pipeline`, so that only the ones solicited via the `property` are kept.

Besides that, this PR also adds the `DISTILABEL_LOG_LEVEL` environment variable to control the log level of `distilabel`, which defaults to `INFO`.

## Example

Find a full example at https://huggingface.co/datasets/alvarobartt/instruction-dataset-mistral-7b-instruct-v0.2/blob/main/example.py