### PR TITLE
Improve runtime parameter definition

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -113,7 +113,7 @@ class BasePipeline(_Serializable):
             the parameter name as the key and the parameter value as the value.
         """
         for step_name, step_parameters in parameters.items():
-            step = self.dag.get_step(step_name)["step"]
+            step: "_Step" = self.dag.get_step(step_name)["step"]
             step._set_runtime_parameters(step_parameters)
 
     def _model_dump(self, obj: Any, **kwargs: Any) -> Dict[str, Any]:

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -252,9 +252,7 @@ class _ProcessWrapper:
         self.step._logger.info(
             f"🧬 Starting yielding batches from generator step '{batch.step_name}'"
         )
-        for data, last_batch in step.process_applying_mappings(
-            **self.step._runtime_parameters
-        ):
+        for data, last_batch in step.process_applying_mappings():
             batch.data = [data]
             batch.last_batch = last_batch
             self.output_queue.put(batch)
@@ -281,17 +279,9 @@ class _ProcessWrapper:
             )
 
         if self.step.has_multiple_inputs:
-            result = next(
-                self.step.process_applying_mappings(
-                    *batch.data, **self.step._runtime_parameters
-                )
-            )
+            result = next(self.step.process_applying_mappings(*batch.data))
         else:
-            result = next(
-                self.step.process_applying_mappings(
-                    batch.data[0], **self.step._runtime_parameters
-                )
-            )
+            result = next(self.step.process_applying_mappings(batch.data[0]))
         self.step._logger.info(
             f"📨 Step '{batch.step_name}' sending batch {batch.seq_no} to output queue"
         )

--- a/src/distilabel/pipeline/step/generators/huggingface.py
+++ b/src/distilabel/pipeline/step/generators/huggingface.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from functools import lru_cache
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from datasets import load_dataset
 
-from distilabel.pipeline.step.base import GeneratorStep
+from distilabel.pipeline.step.base import GeneratorStep, RuntimeParameter
 from distilabel.pipeline.step.typing import GeneratorStepOutput
 
 
@@ -72,18 +72,20 @@ class LoadHubDataset(GeneratorStep):
     - `output`: dynamic, based on the dataset being loaded.
     """
 
+    repo_id: RuntimeParameter[str]
+    split: RuntimeParameter[str]
+    config: Optional[RuntimeParameter[str]] = None
+
     def load(self) -> None:
         """Load the dataset from the Hugging Face Hub"""
         self._values["dataset"] = load_dataset(
-            self._runtime_parameters["repo_id"],
-            self._runtime_parameters.get("config"),
-            split=self._runtime_parameters.get("split", "train"),
+            self.repo_id,  # type: ignore
+            self.config,
+            split=self.split,
             streaming=True,
         )
 
-    def process(  # type: ignore
-        self, repo_id: str, split: str, config: Union[str, None] = None
-    ) -> GeneratorStepOutput:
+    def process(self) -> GeneratorStepOutput:
         """Yields batches from the loaded dataset from the Hugging Face Hub.
 
         Yield:
@@ -132,8 +134,8 @@ class LoadHubDataset(GeneratorStep):
             The number of examples in the dataset.
         """
         dataset_info = self._get_dataset_info()
-        split = self._runtime_parameters.get("split")
-        if self._runtime_parameters.get("config"):
+        split = self.split
+        if self.config:
             return dataset_info["splits"][split]["num_examples"]
         return dataset_info["default"]["splits"][split]["num_examples"]
 
@@ -144,7 +146,7 @@ class LoadHubDataset(GeneratorStep):
             The columns of the dataset.
         """
         dataset_info = self._get_dataset_info()
-        if self._runtime_parameters.get("config"):
+        if self.config:
             return list(dataset_info["features"].keys())
         return list(dataset_info["default"]["features"].keys())
 
@@ -154,6 +156,6 @@ class LoadHubDataset(GeneratorStep):
         Returns:
             The dataset information.
         """
-        repo_id = self._runtime_parameters.get("repo_id")
-        config = self._runtime_parameters.get("config")
+        repo_id = self.repo_id
+        config = self.config
         return _get_hf_dataset_info(repo_id, config)

--- a/src/distilabel/pipeline/step/globals/huggingface.py
+++ b/src/distilabel/pipeline/step/globals/huggingface.py
@@ -18,19 +18,20 @@ from typing import Optional
 
 from datasets import Dataset
 
-from distilabel.pipeline.step.base import GlobalStep
+from distilabel.pipeline.step.base import GlobalStep, RuntimeParameter
 from distilabel.pipeline.step.typing import StepInput, StepOutput
 
 
 class PushToHub(GlobalStep):
+    repo_id: RuntimeParameter[str]
+    split: RuntimeParameter[str] = "train"
+    private: RuntimeParameter[bool] = False
+    token: Optional[RuntimeParameter[str]] = None
+
     # NOTE: `process` should be able to not return anything i.e. LeafStep, or just return None
     def process(
         self,
         inputs: StepInput,
-        repo_id: str,
-        split: str = "train",
-        private: bool = False,
-        token: Optional[str] = None,
     ) -> StepOutput:
         dataset_dict = defaultdict(list)
         for input in inputs:
@@ -39,6 +40,9 @@ class PushToHub(GlobalStep):
         dataset_dict = dict(dataset_dict)
         dataset = Dataset.from_dict(dataset_dict)
         dataset.push_to_hub(
-            repo_id, split=split, private=private, token=token or os.getenv("HF_TOKEN")
+            self.repo_id,  # type: ignore
+            split=self.split,
+            private=self.private,
+            token=self.token or os.getenv("HF_TOKEN"),
         )
         yield [{}]

--- a/tests/pipeline/step/test_base.py
+++ b/tests/pipeline/step/test_base.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Optional
 
 import pytest
 from distilabel.pipeline.local import Pipeline
-from distilabel.pipeline.step.base import GeneratorStep, GlobalStep, Step
+from distilabel.pipeline.step.base import (
+    GeneratorStep,
+    GlobalStep,
+    RuntimeParameter,
+    Step,
+)
 from distilabel.pipeline.step.typing import GeneratorStepOutput, StepInput, StepOutput
 
 
@@ -80,6 +85,23 @@ class TestStep:
     def test_is_global(self) -> None:
         step = DummyStep(name="dummy", pipeline=Pipeline())
         assert not step.is_global
+
+    def test_runtime_parameters_names(self) -> None:
+        class StepWithRuntimeParameters(Step):
+            runtime_param1: RuntimeParameter[int]
+            runtime_param2: RuntimeParameter[str] = "hello"
+            runtime_param3: Optional[RuntimeParameter[str]] = None
+
+            def process(self, *inputs: StepInput) -> StepOutput:
+                yield []
+
+        step = StepWithRuntimeParameters(name="dummy", pipeline=Pipeline())  # type: ignore
+
+        assert step.runtime_parameters_names == {
+            "runtime_param1": False,
+            "runtime_param2": True,
+            "runtime_param3": True,
+        }
 
     def test_verify_inputs_mappings(self) -> None:
         step = DummyStep(name="dummy", pipeline=Pipeline())


### PR DESCRIPTION
## Description

This PR adds a new `typing.Annotated` called `RuntimeParameter` that can be used to mark a `Step` attribute as a runtime parameter. This replaces the old method of adding extra keyword arguments to the `process` method of the `Step`, which was confusing because in some cases these arguments were not used at all by the `process` function and instead they were being used in other methods.