### PR TITLE
Add `input` propagation through `Task.process`

### DIFF
--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -81,8 +81,7 @@ class Task(Step, ABC):
 
         outputs = []
         for input, formatted_output in zip(inputs, formatted_outputs):
-            output = {k: v for k, v in input.items() if k in self.inputs}
-            output.update(formatted_output)
-            output["model_name"] = self.llm.model_name
-            outputs.append(output)
+            input.update(formatted_output)
+            input["model_name"] = self.llm.model_name
+            outputs.append(input)
         yield outputs


### PR DESCRIPTION
## Description

This PR adds the `input` propagation through `Task.process`, so that the outputs are concatenated to the input instead of just returning the input keys matching the `inputs` property.

This means that now providing `{"input_a": ..., "input_b": ...}` with the properties `inputs=["input_a"]` and `outputs=["output_a"]` will produce `{"input_a": ..., "input_b": ..., "output_a": ...}`, instead of the former `{"input_a": ..., "output_a": ...}`.