### PR TITLE
Improve `Pipeline` error handling

### DIFF
--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -48,6 +48,9 @@ class DAG(_Serializable):
     def __iter__(self) -> Generator[str, None, None]:
         yield from self.G
 
+    def __len__(self) -> int:
+        return len(self.G)
+
     def add_step(self, step: "_Step") -> None:
         """Add a step to the DAG.
 

--- a/tests/unit/pipeline/test_local.py
+++ b/tests/unit/pipeline/test_local.py
@@ -63,6 +63,7 @@ class TestPipeline:
         pool = mock.MagicMock()
         manager = mock.MagicMock()
         queue = mock.MagicMock()
+        shared_info = mock.MagicMock()
 
         with Pipeline() as pipeline:
             dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
@@ -72,7 +73,7 @@ class TestPipeline:
             dummy_generator.connect(dummy_step_1)
             dummy_step_1.connect(dummy_step_2)
 
-        pipeline._run_steps_in_loop(pool, manager, queue)
+        pipeline._run_steps_in_loop(pool, manager, queue, shared_info)
 
         assert manager.Queue.call_count == 3
 
@@ -82,16 +83,19 @@ class TestPipeline:
                     step=dummy_generator,
                     input_queue=mock.ANY,
                     output_queue=queue,
+                    shared_info=shared_info,
                 ),
                 mock.call(
                     step=dummy_step_1,
                     input_queue=mock.ANY,
                     output_queue=queue,
+                    shared_info=shared_info,
                 ),
                 mock.call(
                     step=dummy_step_2,
                     input_queue=mock.ANY,
                     output_queue=queue,
+                    shared_info=shared_info,
                 ),
             ],
         )


### PR DESCRIPTION
## Description

This PR improves the `Pipeline` error handling when the `process` function of a `Step` fails:

1. If the step is a `GeneratorStep`, then the execution of the pipeline will be stopped.
2. If the step is a `GlobalStep`, then the execution of the pipeline will be stopped.
3. If the step is a `Step`, then the output batch will be empty, effectively skipping the data.