### PR TITLE
Fix `combine_dicts` and `StepInput` import in `PushToHub`

### DIFF
--- a/src/distilabel/pipeline/utils.py
+++ b/src/distilabel/pipeline/utils.py
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Set
+from typing import List, Optional
 
 from distilabel.steps.base import StepInput
 
 
 def combine_dicts(
     *inputs: StepInput,
-    merge_keys: Set[str],
-    output_merge_keys: Optional[Set[str]] = None,
+    merge_keys: List[str],
+    output_merge_keys: Optional[List[str]] = None,
 ) -> StepInput:
     if output_merge_keys is not None and len(output_merge_keys) != len(merge_keys):
         raise ValueError(
             "The length of output_merge_keys must be the same as the length of merge_keys"
         )
     if output_merge_keys is None:
-        output_merge_keys = {f"merged_{key}" for key in merge_keys}
+        output_merge_keys = [f"merged_{key}" for key in merge_keys]
     merge_keys_dict = dict(zip(merge_keys, output_merge_keys))
 
     result = []

--- a/src/distilabel/steps/combine.py
+++ b/src/distilabel/steps/combine.py
@@ -46,6 +46,6 @@ class CombineColumns(Step):
     def process(self, *args: StepInput) -> "StepOutput":
         yield combine_dicts(
             *args,
-            merge_keys=set(self.inputs),
-            output_merge_keys=set(self.outputs),
+            merge_keys=self.inputs,
+            output_merge_keys=self.outputs,
         )

--- a/src/distilabel/steps/globals/huggingface.py
+++ b/src/distilabel/steps/globals/huggingface.py
@@ -19,8 +19,8 @@ from typing import Optional
 from datasets import Dataset
 from pydantic import Field
 
-from distilabel.steps.base import GlobalStep, RuntimeParameter
-from distilabel.steps.typing import StepInput, StepOutput
+from distilabel.steps.base import GlobalStep, RuntimeParameter, StepInput
+from distilabel.steps.typing import StepOutput
 
 
 class PushToHub(GlobalStep):

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -81,8 +81,7 @@ class Task(Step, ABC):
 
         outputs = []
         for input, formatted_output in zip(inputs, formatted_outputs):
-            output = {k: v for k, v in input.items() if k in self.inputs}
-            output.update(formatted_output)
-            output["model_name"] = self.llm.model_name
-            outputs.append(output)
+            input.update(formatted_output)
+            input["model_name"] = self.llm.model_name
+            outputs.append(input)
         yield outputs


### PR DESCRIPTION
## Description

This PR fixes a `StepInput` import that was not updated as of https://github.com/argilla-io/distilabel/pull/387 when it was moved from `typing.py` to `base.py`.

This PR also fixes a bug within `combine_dicts`, as it uses now `List` over `Set` to avoid the ordering issues introduced when using `Set`.