### PR TITLE
Improve `GlobalStep` error handling

### DIFF
--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -142,6 +142,15 @@ class DAG(_Serializable):
         """
         return {node for node, degree in self.G.out_degree() if degree == 0}
 
+    @cached_property
+    def trophic_levels(self) -> Dict[str, int]:
+        """The trophic level of each step in the DAG.
+
+        Returns:
+            A dictionary with the trophic level of each step.
+        """
+        return {step: int(level) for step, level in nx.trophic_levels(self.G).items()}
+
     def get_step_predecessors(self, step_name: str) -> Iterable[str]:
         """Gets the predecessors of a step.
         Args:
@@ -175,14 +184,48 @@ class DAG(_Serializable):
         Yields:
             A list containing the names of the steps that can be run in parallel.
         """
-        trophic_levels = nx.trophic_levels(self.G)
-
         v = defaultdict(list)
-        for step, trophic_level in trophic_levels.items():
-            v[int(trophic_level)].append(step)
+        for step, trophic_level in self.trophic_levels.items():
+            v[trophic_level].append(step)
 
         for trophic_level in sorted(v.keys()):
             yield v[trophic_level]
+
+    def get_step_trophic_level(self, step_name: str) -> int:
+        """Gets the trophic level of a step.
+
+        Args:
+            step_name: The name of the step.
+
+        Returns:
+            The trophic level of the step.
+        """
+        return int(self.trophic_levels[step_name])
+
+    def is_step_in_trophic_level(self, step_name: str, trophic_level: int) -> bool:
+        """Checks if a step is in a given trophic level.
+
+        Args:
+            step_name: The name of the step.
+            trophic_level: The trophic level.
+
+        Returns:
+            True if the step is in the given trophic level, False otherwise.
+        """
+        return self.get_step_trophic_level(step_name) == trophic_level
+
+    def step_in_last_trophic_level(self, step_name: str) -> bool:
+        """Checks if a step is in the last trophic level.
+
+        Args:
+            step_name: The name of the step.
+
+        Returns:
+            True if the step is in the last trophic level, False otherwise.
+        """
+        return self.is_step_in_trophic_level(
+            step_name, max(self.trophic_levels.values())
+        )
 
     def validate(self) -> None:
         """Validates that the `Step`s included in the pipeline are correctly connected and

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -69,9 +69,7 @@ class Pipeline(BasePipeline):
         ctx = mp.get_context("forkserver")
         with ctx.Manager() as manager, ctx.Pool(mp.cpu_count()) as pool:
             self.output_queue: "Queue[Any]" = manager.Queue()
-            self.shared_info = manager.dict(
-                **{_STEPS_LOADED_KEY: 0, _STEPS_LOADED_LOCK_KEY: manager.Lock()}
-            )
+            self.shared_info = self._create_shared_info_dict(manager)
 
             # Run the steps using the pool of processes
             self._run_steps_in_loop(pool, manager, self.output_queue, self.shared_info)
@@ -112,6 +110,22 @@ class Pipeline(BasePipeline):
                     # All the leaf steps have processed the last batch, stop the generation
                     if all(leaf_steps_received_last_batch.values()):
                         break
+
+            pool.close()
+            pool.join()
+
+    def _create_shared_info_dict(self, manager: "SyncManager") -> "DictProxy[str, Any]":
+        """Creates the shared information dictionary to be used by the processes.
+
+        Args:
+            manager: The manager to create the shared information.
+
+        Returns:
+            The shared information dictionary.
+        """
+        return manager.dict(
+            **{_STEPS_LOADED_KEY: 0, _STEPS_LOADED_LOCK_KEY: manager.Lock()}
+        )
 
     def _all_steps_loaded(self) -> bool:
         """Waits for all the steps to load.
@@ -194,11 +208,24 @@ class Pipeline(BasePipeline):
         """
         if e.is_load_error:
             self._logger.error(f"Failed to load step '{e.step.name}': {e.message}")
-        else:
-            self._logger.error(
-                f"An error occurred in step '{e.step.name}': {e.message}"
-            )
+            self._stop()
+            return
 
+        # if the step is global, is not in the last trophic level and has no successors,
+        # then we can ignore the error and continue executing the pipeline
+        if (
+            e.step.is_global
+            and not self.dag.step_in_last_trophic_level(e.step.name)
+            and list(self.dag.get_step_successors(e.step.name)) == []
+        ):
+            self._logger.error(
+                f"An error occurred when running global step '{e.step.name}' with no"
+                f" successors and not in the last trophic level. Pipeline execution can"
+                f" continue. Error will be ignored: {e.message}"
+            )
+            return
+
+        self._logger.error(f"An error occurred in step '{e.step.name}': {e.message}")
         self._stop()
 
     def _stop(self) -> None:
@@ -393,6 +420,9 @@ class _ProcessWrapper:
             self.step._logger.info(
                 f"📦 Processing batch {batch.seq_no} in '{batch.step_name}'"
             )
+            # `result` is initally an empty list so f `process` method raises an exception
+            # an empty batch will be sent to the `output_queue`
+            result = []
             try:
                 if self.step.has_multiple_inputs:
                     result = next(self.step.process_applying_mappings(*batch.data))
@@ -400,9 +430,7 @@ class _ProcessWrapper:
                     result = next(self.step.process_applying_mappings(batch.data[0]))
             except Exception as e:
                 if self.step.is_global:
-                    raise _ProcessWrapperException(
-                        message=str(e), step=self.step, code=2
-                    ) from e
+                    raise _ProcessWrapperException(str(e), self.step, 2) from e
 
                 # if the step is not global then we can skip the batch which means sending
                 # an empty batch to the output queue
@@ -410,10 +438,9 @@ class _ProcessWrapper:
                     f"⚠️ Processing batch {batch.seq_no} with step '{self.step.name}' failed:"
                     f" {e}. Sending empty batch..."
                 )
-                result = []
-
-            batch.data = [result]
-            self._send_batch(batch)
+            finally:
+                batch.data = [result]
+                self._send_batch(batch)
 
             if batch.last_batch:
                 break

--- a/tests/unit/pipeline/test_dag.py
+++ b/tests/unit/pipeline/test_dag.py
@@ -134,6 +134,24 @@ class TestDAG:
         dag.add_edge("dummy_step_1", "dummy_step_2")
         assert dag.leaf_steps == {"dummy_step_2"}
 
+    def test_trophic_levels(
+        self,
+        dummy_generator_step: "GeneratorStep",
+        dummy_step_1: "Step",
+        dummy_step_2: "Step",
+    ) -> None:
+        dag = DAG()
+        dag.add_step(dummy_generator_step)
+        dag.add_step(dummy_step_1)
+        dag.add_step(dummy_step_2)
+        dag.add_edge("dummy_generator_step", "dummy_step_1")
+        dag.add_edge("dummy_step_1", "dummy_step_2")
+        assert dag.trophic_levels == {
+            "dummy_generator_step": 1,
+            "dummy_step_1": 2,
+            "dummy_step_2": 3,
+        }
+
     def get_step_predecessors(self, dummy_step_1: "Step", dummy_step_2: "Step") -> None:
         dag = DAG()
         dag.add_step(dummy_step_1)
@@ -149,6 +167,56 @@ class TestDAG:
         dag.add_step(dummy_step_2)
         dag.add_edge("dummy_step_1", "dummy_step_2")
         assert list(dag.get_step_successors("dummy_step_1")) == ["dummy_step_2"]
+
+    def test_iter_based_on_trophic_levels(
+        self,
+        dummy_generator_step: "GeneratorStep",
+        dummy_step_1: "Step",
+        dummy_step_2: "Step",
+    ) -> None:
+        dag = DAG()
+        dag.add_step(dummy_generator_step)
+        dag.add_step(dummy_step_1)
+        dag.add_step(dummy_step_2)
+        dag.add_edge("dummy_generator_step", "dummy_step_1")
+        dag.add_edge("dummy_step_1", "dummy_step_2")
+
+        steps = list(dag.iter_based_on_trophic_levels())
+        assert steps == [["dummy_generator_step"], ["dummy_step_1"], ["dummy_step_2"]]
+
+    def test_get_step_trophic_level(
+        self,
+        dummy_generator_step: "GeneratorStep",
+        dummy_step_1: "Step",
+        dummy_step_2: "Step",
+    ) -> None:
+        dag = DAG()
+        dag.add_step(dummy_generator_step)
+        dag.add_step(dummy_step_1)
+        dag.add_step(dummy_step_2)
+        dag.add_edge("dummy_generator_step", "dummy_step_1")
+        dag.add_edge("dummy_step_1", "dummy_step_2")
+
+        assert dag.get_step_trophic_level("dummy_generator_step") == 1
+        assert dag.get_step_trophic_level("dummy_step_1") == 2
+        assert dag.get_step_trophic_level("dummy_step_2") == 3
+
+    def test_step_in_last_trophic_level(
+        self,
+        dummy_generator_step: "GeneratorStep",
+        dummy_step_1: "Step",
+        dummy_step_2: "Step",
+    ) -> None:
+        dag = DAG()
+        dag.add_step(dummy_generator_step)
+        dag.add_step(dummy_step_1)
+        dag.add_step(dummy_step_2)
+        dag.add_edge("dummy_generator_step", "dummy_step_1")
+        dag.add_edge("dummy_step_1", "dummy_step_2")
+
+        assert not dag.step_in_last_trophic_level("dummy_generator_step")
+        assert not dag.step_in_last_trophic_level("dummy_step_1")
+        assert dag.step_in_last_trophic_level("dummy_step_2")
 
     def test_validate_first_step_not_generator(
         self, dummy_step_1: "Step", dummy_step_2: "Step"


### PR DESCRIPTION
## Description

This PR improves the `GlobalStep` error handling when executing one fails. If the `GlobalStep` executed doesn't have successors and is not in the last trophic level, then the error will be ignored. 