### PR TITLE
Add `Argilla` and `PromptCompletionToArgilla`

### DIFF
--- a/src/distilabel/integrations/__init__.py
+++ b/src/distilabel/integrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/distilabel/integrations/argilla.py
+++ b/src/distilabel/integrations/argilla.py
@@ -1,0 +1,118 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import TYPE_CHECKING, Annotated, List, Optional, Union
+
+from pydantic import Field, PrivateAttr, SecretStr, field_validator
+from typing_extensions import override
+
+try:
+    import argilla as rg
+except ImportError as ie:
+    raise ImportError(
+        "Argilla is not installed. Please install it using `pip install argilla`."
+    ) from ie
+
+from distilabel.steps.base import Step
+
+if TYPE_CHECKING:
+    from argilla.client.feedback.dataset.remote.dataset import RemoteFeedbackDataset
+
+    from distilabel.steps.base import StepInput
+    from distilabel.steps.typing import StepOutput
+
+
+class PromptCompletionToArgilla(Step):
+    api_url: str
+    api_key: Annotated[Optional[SecretStr], Field(validate_default=True)] = None
+
+    dataset_name: str
+    dataset_workspace: Optional[str] = None
+
+    _rg_dataset: Optional["RemoteFeedbackDataset"] = PrivateAttr(...)
+
+    @field_validator("api_key")
+    @classmethod
+    def api_key_must_not_be_none(cls, v: Union[str, SecretStr, None]) -> SecretStr:
+        """Ensures that either the `api_key` or the environment variable `ARGILLA_API_KEY` are set.
+
+        Additionally, the `api_key` when provided is casted to `pydantic.SecretStr` to prevent it
+        from being leaked and/or included within the logs or the serialization of the object.
+        """
+        v = v or os.getenv("ARGILLA_API_KEY", None)  # type: ignore
+        if v is None:
+            raise ValueError("You must provide an API key to use Argilla.")
+        if not isinstance(v, SecretStr):
+            v = SecretStr(v)
+        return v
+
+    def load(self) -> None:
+        try:
+            rg.init(api_url=self.api_url, api_key=self.api_key.get_secret_value())  # type: ignore
+        except Exception as e:
+            raise ValueError(f"Failed to initialize the Argilla API: {e}") from e
+
+        # TODO: shoudln't `input_mappings` always have a value? It would make things easier
+        try:
+            self._prompt = (
+                self.input_mappings["prompt"] if self.input_mappings else "prompt"
+            )
+            self._completion = (
+                self.input_mappings["completion"]
+                if self.input_mappings
+                else "completion"
+            )
+
+            _rg_dataset = rg.FeedbackDataset(
+                fields=[
+                    rg.TextField(name=self._prompt),
+                    rg.TextField(name=self._completion),
+                ],  # type: ignore
+                questions=[
+                    rg.LabelQuestion(  # type: ignore
+                        name="quality",
+                        title=f"What's the quality of the {self._completion} for the given {self._prompt}?",
+                        labels=["bad", "good", "excellent"],
+                    )
+                ],
+            )
+            self._rg_dataset = _rg_dataset.push_to_argilla(
+                name=self.dataset_name, workspace=self.dataset_workspace
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to initialize the Argilla dataset: {e}") from e
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["prompt", "completion"]
+
+    @property
+    def outputs(self) -> List[str]:
+        return []
+
+    @override
+    def process(self, inputs: "StepInput") -> "StepOutput":
+        self._rg_dataset.add_records(  # type: ignore
+            [
+                rg.FeedbackRecord(
+                    fields={
+                        self._prompt: input["prompt"],
+                        self._completion: input["completion"],
+                    }
+                )
+                for input in inputs
+            ]
+        )
+        yield [{}]

--- a/src/distilabel/integrations/argilla/__init__.py
+++ b/src/distilabel/integrations/argilla/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/src/distilabel/integrations/argilla/base.py
+++ b/src/distilabel/integrations/argilla/base.py
@@ -14,9 +14,10 @@
 
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Annotated, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from pydantic import Field, PrivateAttr, SecretStr, field_validator
+from typing_extensions import Annotated
 
 try:
     import argilla as rg

--- a/src/distilabel/integrations/argilla/base.py
+++ b/src/distilabel/integrations/argilla/base.py
@@ -96,6 +96,13 @@ class Argilla(Step, ABC):
         except Exception as e:
             raise ValueError(f"Failed to initialize the Argilla API: {e}") from e
 
+    def _rg_dataset_exists(self) -> bool:
+        """Checks if the dataset already exists in Argilla."""
+        return self.dataset_name in [
+            dataset.name
+            for dataset in rg.FeedbackDataset.list(workspace=self.dataset_workspace)
+        ]
+
     @property
     def outputs(self) -> List[str]:
         """The outputs of the step is an empty list, since the steps subclassing from this one, will

--- a/src/distilabel/integrations/argilla/base.py
+++ b/src/distilabel/integrations/argilla/base.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from distilabel.steps.typing import StepOutput
 
 
-class _Argilla(Step, ABC):
+class Argilla(Step, ABC):
     """Abstract step that provides a class to subclass from, that contains the boilerplate code
     required to interact with Argilla, as well as some extra validations on top of it. It also defines
     the abstract methods that need to be implemented in order to add a new dataset type as a step.

--- a/src/distilabel/integrations/argilla/base.py
+++ b/src/distilabel/integrations/argilla/base.py
@@ -14,7 +14,7 @@
 
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from pydantic import Field, PrivateAttr, SecretStr, field_validator
 from typing_extensions import Annotated
@@ -88,12 +88,6 @@ class Argilla(Step, ABC):
         if not isinstance(v, SecretStr):
             v = SecretStr(v)
         return v
-
-    def model_post_init(self, __context: Any) -> None:
-        """Override this method to perform additional initialization after `__init__` and `model_construct`.
-        This is useful if you want to do some validation that requires the entire model to be initialized.
-        """
-        super().model_post_init(__context)
 
     def _rg_init(self) -> None:
         """Initializes the Argilla API client with the provided `api_url` and `api_key`."""

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -23,14 +23,14 @@ except ImportError as ie:
         "Argilla is not installed. Please install it using `pip install argilla`."
     ) from ie
 
-from distilabel.integrations.argilla.base import _Argilla
+from distilabel.integrations.argilla.base import Argilla
 
 if TYPE_CHECKING:
     from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
-class PromptCompletionToArgilla(_Argilla):
+class PromptCompletionToArgilla(Argilla):
     """Step that creates a dataset in Argilla during the load phase, and then pushses the input
     batches into it as records. This dataset is a prompt-completion dataset, where there's one field
     per each input, and then a label question to rate the quality of the completion in either bad,

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -45,10 +45,9 @@ class PromptCompletionToArgilla(Argilla):
         dataset_workspace: The workspace where the dataset will be created in Argilla. Defaults to
             None, which means it will be created in the default workspace.
 
-    Columns:
-
-    - `prompt`
-    - `completion`
+    Input columns:
+        prompt (str): The prompt that was used to generate the completion.
+        completion (str): The completion that was generated based on the prompt.
     """
 
     def load(self) -> None:

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -23,15 +23,39 @@ except ImportError as ie:
         "Argilla is not installed. Please install it using `pip install argilla`."
     ) from ie
 
-from distilabel.integrations.argilla.base import Argilla
+from distilabel.integrations.argilla.base import _Argilla
 
 if TYPE_CHECKING:
     from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
-class PromptCompletionToArgilla(Argilla):
+class PromptCompletionToArgilla(_Argilla):
+    """Step that creates a dataset in Argilla during the load phase, and then pushses the input
+    batches into it as records. This dataset is a prompt-completion dataset, where there's one field
+    per each input, and then a label question to rate the quality of the completion in either bad,
+    good or excellent.
+
+    Args:
+        api_url: The URL of the Argilla API. Defaults to `None`, which means it will be read from
+            the `ARGILLA_API_URL` environment variable.
+        api_key: The API key to authenticate with Argilla. Defaults to `None`, which means it will
+            be read from the `ARGILLA_API_KEY` environment variable.
+        dataset_name: The name of the dataset in Argilla.
+        dataset_workspace: The workspace where the dataset will be created in Argilla. Defaults to
+            None, which means it will be created in the default workspace.
+
+    Columns:
+
+    - `prompt`
+    - `completion`
+    """
+
     def load(self) -> None:
+        """Sets the `_prompt` and `_completion` attributes based on the `inputs_mapping`, otherwise
+        uses the default values; and then uses those values to createa a `FeedbackDataset` suited for
+        the prompt-completion scenario. And then it pushes it to Argilla.
+        """
         self._rg_init()
 
         self._prompt = (
@@ -64,6 +88,7 @@ class PromptCompletionToArgilla(Argilla):
 
     @override
     def process(self, inputs: "StepInput") -> "StepOutput":
+        """Creates and pushes the records as FeedbackRecords to the Argilla dataset."""
         self._rg_dataset.add_records(  # type: ignore
             [
                 rg.FeedbackRecord(
@@ -75,4 +100,5 @@ class PromptCompletionToArgilla(Argilla):
                 for input in inputs
             ]
         )
+        # Empty yield as it's intended to be a leaf step
         yield [{}]

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -41,9 +41,6 @@ class PromptCompletionToArgilla(Argilla):
             self.input_mappings["completion"] if self.input_mappings else "completion"
         )
 
-        self._logger.info(f"{rg.active_client().client.base_url}")
-        self._logger.info(f"Available workspaces: {rg.Workspace.list()}")
-
         _rg_dataset = rg.FeedbackDataset(
             fields=[
                 rg.TextField(name=self._prompt),  # type: ignore

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -1,0 +1,81 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, List
+
+from typing_extensions import override
+
+try:
+    import argilla as rg
+except ImportError as ie:
+    raise ImportError(
+        "Argilla is not installed. Please install it using `pip install argilla`."
+    ) from ie
+
+from distilabel.integrations.argilla.base import Argilla
+
+if TYPE_CHECKING:
+    from distilabel.steps.base import StepInput
+    from distilabel.steps.typing import StepOutput
+
+
+class PromptCompletionToArgilla(Argilla):
+    def load(self) -> None:
+        self._rg_init()
+
+        self._prompt = (
+            self.input_mappings["prompt"] if self.input_mappings else "prompt"
+        )
+        self._completion = (
+            self.input_mappings["completion"] if self.input_mappings else "completion"
+        )
+
+        self._logger.info(f"{rg.active_client().client.base_url}")
+        self._logger.info(f"Available workspaces: {rg.Workspace.list()}")
+
+        _rg_dataset = rg.FeedbackDataset(
+            fields=[
+                rg.TextField(name=self._prompt),  # type: ignore
+                rg.TextField(name=self._completion),  # type: ignore
+            ],
+            questions=[
+                rg.LabelQuestion(  # type: ignore
+                    name="quality",
+                    title=f"What's the quality of the {self._completion} for the given {self._prompt}?",
+                    labels=["bad", "good", "excellent"],
+                )
+            ],
+        )
+        self._rg_dataset = _rg_dataset.push_to_argilla(
+            name=self.dataset_name, workspace=self.dataset_workspace
+        )
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["prompt", "completion"]
+
+    @override
+    def process(self, inputs: "StepInput") -> "StepOutput":
+        self._rg_dataset.add_records(  # type: ignore
+            [
+                rg.FeedbackRecord(
+                    fields={
+                        self._prompt: input["prompt"],
+                        self._completion: input["completion"],
+                    },
+                )
+                for input in inputs
+            ]
+        )
+        yield [{}]

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
-from distilabel.pipeline.logging import get_logger
+from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import _Serializable
 
 if TYPE_CHECKING:

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -19,7 +19,7 @@ from typing_extensions import Self
 
 from distilabel import __version__
 from distilabel.pipeline._dag import DAG
-from distilabel.pipeline.logging import get_logger
+from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import _Serializable
 
 if TYPE_CHECKING:

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, PrivateAttr
 from typing_extensions import Annotated, get_args, get_origin
 
 from distilabel.pipeline.base import BasePipeline, _GlobalPipelineManager
-from distilabel.pipeline.logging import get_logger
+from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
 from distilabel.utils.typing import is_parameter_annotated_with
 

--- a/src/distilabel/utils/__init__.py
+++ b/src/distilabel/utils/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -23,16 +23,16 @@ def get_logger(suffix: str) -> logging.Logger:
     """Gets the `logging.Logger` for the `distilabel` package with a custom
     configuration. Also uses `rich` for better formatting.
     """
+    # Disable logging for argilla.client.feedback.dataset.local.mixins
+    # as it's too verbose, and there's no way to disable all the `argilla` logs
+    logging.getLogger("argilla.client.feedback.dataset.local.mixins").disabled = True
 
     logging.basicConfig(
-        level="INFO", format="%(message)s", datefmt="[%X]", handlers=[RichHandler()]
+        level="INFO",
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler()],
     )
-    # Remove `datasets` logger to only log on `critical` mode
-    # as it produces `PyTorch` messages to update on `info`
-    logging.getLogger("datasets").setLevel(logging.CRITICAL)
-
-    # Skip verbose logging messages from `argilla
-    logging.getLogger("argilla").setLevel(logging.CRITICAL)
 
     log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO")
     if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -31,6 +31,9 @@ def get_logger(suffix: str) -> logging.Logger:
     # as it produces `PyTorch` messages to update on `info`
     logging.getLogger("datasets").setLevel(logging.CRITICAL)
 
+    # Skip verbose logging messages from `argilla
+    logging.getLogger("argilla").setLevel(logging.CRITICAL)
+
     log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO")
     if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
         warnings.warn(

--- a/tests/unit/integrations/__init__.py
+++ b/tests/unit/integrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/integrations/argilla/__init__.py
+++ b/tests/unit/integrations/argilla/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/integrations/argilla/test_base.py
+++ b/tests/unit/integrations/argilla/test_base.py
@@ -1,0 +1,166 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import TYPE_CHECKING, List
+
+import pytest
+from distilabel.integrations.argilla.base import Argilla
+from distilabel.pipeline.local import Pipeline
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from distilabel.steps.base import StepInput
+    from distilabel.steps.typing import StepOutput
+
+
+class CustomArgilla(Argilla):
+    def load(self) -> None:
+        pass
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["instruction"]
+
+    def process(self, inputs: "StepInput") -> "StepOutput":
+        yield [{}]
+
+
+class TestArgilla:
+    def test_passing_pipeline(self) -> None:
+        pipeline = Pipeline()
+        step = CustomArgilla(
+            name="step",
+            api_url="https://example.com",
+            api_key="api.key",  # type: ignore
+            dataset_name="argilla",
+            dataset_workspace="argilla",
+            pipeline=pipeline,
+        )
+        assert step.name == "step"
+        assert step.api_url == "https://example.com"
+        assert step.api_key.get_secret_value() == "api.key"  # type: ignore
+        assert step.dataset_name == "argilla"
+        assert step.dataset_workspace == "argilla"
+        assert step.pipeline is pipeline
+
+    def test_within_pipeline_context(self) -> None:
+        with Pipeline() as pipeline:
+            step = CustomArgilla(
+                name="step",
+                api_url="https://example.com",
+                api_key="api.key",  # type: ignore
+                dataset_name="argilla",
+                dataset_workspace="argilla",
+                pipeline=pipeline,
+            )
+            assert step.name == "step"
+            assert step.api_url == "https://example.com"
+            assert step.api_key.get_secret_value() == "api.key"  # type: ignore
+            assert step.dataset_name == "argilla"
+            assert step.dataset_workspace == "argilla"
+        assert step.pipeline is pipeline
+
+    def test_with_errors(self) -> None:
+        with pytest.raises(ValueError, match="Step 'step' hasn't received a pipeline"):
+            CustomArgilla(
+                name="step",
+                api_url="https://example.com",
+                api_key="api.key",  # type: ignore
+                dataset_name="argilla",
+                dataset_workspace="argilla",
+            )
+
+        with pytest.raises(
+            ValidationError,
+            match="api_url\n  Value error, You must provide an API URL either via \\`api_url\\` arg or setting \\`ARGILLA_API_URL\\` environment variable to use Argilla. \\[type=value_error",
+        ):
+            CustomArgilla(
+                name="step",
+                api_key="api.key",  # type: ignore
+                dataset_name="argilla",
+                dataset_workspace="argilla",
+                pipeline=Pipeline(),
+            )
+
+        with pytest.raises(
+            ValidationError,
+            match="api_key\n  Value error, You must provide an API key either via \\`api_key\\` arg or setting \\`ARGILLA_API_URL\\` environment variable to use Argilla. \\[type=value_error",
+        ):
+            CustomArgilla(
+                name="step",
+                api_url="https://example.com",
+                dataset_name="argilla",
+                dataset_workspace="argilla",
+                pipeline=Pipeline(),
+            )
+
+        with pytest.raises(
+            ValidationError, match="dataset_name\n  Field required \\[type=missing"
+        ):
+            CustomArgilla(
+                name="step",
+                api_url="https://example.com",
+                api_key="api.key",  # type: ignore
+                dataset_workspace="argilla",
+                pipeline=Pipeline(),
+            )
+
+        with pytest.raises(
+            TypeError,
+            match="Can't instantiate abstract class Argilla with abstract methods inputs, load, process",
+        ):
+            Argilla(name="step", pipeline=Pipeline())  # type: ignore
+
+    def test_process(self) -> None:
+        pipeline = Pipeline()
+        step = CustomArgilla(
+            name="step",
+            api_url="https://example.com",
+            api_key="api.key",  # type: ignore
+            dataset_name="argilla",
+            dataset_workspace="argilla",
+            pipeline=pipeline,
+        )
+        assert list(step.process([{"instruction": "test"}])) == [[{}]]
+
+    def test_serialization(self) -> None:
+        os.environ["ARGILLA_API_KEY"] = "api.key"
+
+        pipeline = Pipeline()
+        step = CustomArgilla(
+            name="step",
+            api_url="https://example.com",
+            dataset_name="argilla",
+            dataset_workspace="argilla",
+            pipeline=pipeline,
+        )
+        assert step.dump() == {
+            "name": "step",
+            "input_mappings": {},
+            "output_mappings": {},
+            "input_batch_size": 50,
+            "api_url": "https://example.com",
+            "dataset_name": "argilla",
+            "dataset_workspace": "argilla",
+            "runtime_parameters_info": [],
+            "type_info": {
+                "module": "tests.unit.integrations.argilla.test_base",
+                "name": "CustomArgilla",
+            },
+        }
+
+        with Pipeline() as pipeline:
+            new_step = CustomArgilla.from_dict(step.dump())
+            assert isinstance(new_step, CustomArgilla)

--- a/tests/unit/integrations/argilla/test_prompt_completion.py
+++ b/tests/unit/integrations/argilla/test_prompt_completion.py
@@ -1,0 +1,82 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+import argilla as rg
+from distilabel.integrations.argilla.prompt_completion import PromptCompletionToArgilla
+from distilabel.pipeline.local import Pipeline
+
+MockFeedbackDataset = rg.FeedbackDataset(
+    fields=[rg.TextField(name="prompt"), rg.TextField(name="completion")],  # type: ignore
+    questions=[
+        rg.LabelQuestion(  # type: ignore
+            name="quality",
+            title="What's the quality of the completion for the given prompt?",
+            labels=["bad", "good", "excellent"],
+        )
+    ],
+)
+
+
+class TestPromptCompletionToArgilla:
+    def test_process(self) -> None:
+        pipeline = Pipeline()
+        step = PromptCompletionToArgilla(
+            name="step",
+            api_url="https://example.com",
+            api_key="api.key",  # type: ignore
+            dataset_name="argilla",
+            dataset_workspace="argilla",
+            pipeline=pipeline,
+        )
+        with patch.object(PromptCompletionToArgilla, "load"):
+            step.load()
+        step._prompt = "prompt"
+        step._completion = "completion"
+        step._rg_dataset = MockFeedbackDataset  # type: ignore
+
+        assert list(step.process([{"prompt": "test", "completion": "test"}])) == [[{}]]
+        assert len(step._rg_dataset.records) == 1
+
+    def test_serialization(self) -> None:
+        os.environ["ARGILLA_API_KEY"] = "api.key"
+
+        pipeline = Pipeline()
+        step = PromptCompletionToArgilla(
+            name="step",
+            api_url="https://example.com",
+            dataset_name="argilla",
+            dataset_workspace="argilla",
+            pipeline=pipeline,
+        )
+        assert step.dump() == {
+            "name": "step",
+            "input_mappings": {},
+            "output_mappings": {},
+            "input_batch_size": 50,
+            "api_url": "https://example.com",
+            "dataset_name": "argilla",
+            "dataset_workspace": "argilla",
+            "runtime_parameters_info": [],
+            "type_info": {
+                "module": "distilabel.integrations.argilla.prompt_completion",
+                "name": "PromptCompletionToArgilla",
+            },
+        }
+
+        with Pipeline() as pipeline:
+            new_step = PromptCompletionToArgilla.from_dict(step.dump())
+            assert isinstance(new_step, PromptCompletionToArgilla)


### PR DESCRIPTION
## Description

This PR adds both the `Argilla` abstract step with the shared logic for Argilla, and also adds `PromptCompletionToArgilla` which is a step that will create a `prompt-completion` like dataset and push it to Argilla iteratively as part of the `process` method. Also note that all the `Argilla` subclassed steps are intended to be used as leaf steps.\

Additionally, this PR also moves the `logging.py` file with `get_logger` from `pipeline/logging.py` to `utils/logging.py`, and also patches the logging messages generated by Argilla, for a less verbose output.

Closes #412 

## Example

```python
from uuid import uuid4

from distilabel.integrations.argilla.prompt_completion import PromptCompletionToArgilla
from distilabel.llm.openai import OpenAILLM
from distilabel.pipeline.local import Pipeline
from distilabel.steps.generators.huggingface import LoadHubDataset
from distilabel.steps.task.text_generation import TextGeneration

if __name__ == "__main__":
    with Pipeline() as pipeline:
        load_hub_dataset = LoadHubDataset(name="load_dataset")

        openai_generation = TextGeneration(
            name="openai_generation",
            llm=OpenAILLM(
                api_key="sk-***"  # type: ignore
            ),
        )
        load_hub_dataset.connect(openai_generation)

        prompt_completion_to_argilla = PromptCompletionToArgilla(
            name="prompt_completion_to_argilla",
            api_url="https://alvarobartt-my-argilla.hf.space",
            api_key="owner.apikey",  # type: ignore
            dataset_name=f"prompt-completion-{uuid4()}",
            dataset_workspace="admin",
            input_mappings={"prompt": "instruction", "completion": "generation"},
        )
        openai_generation.connect(prompt_completion_to_argilla)

    pipeline.run(
        parameters={
            "load_dataset": {
                "repo_id": "alvarobartt/logging",
                "split": "train",
            },
            "openai_generation": {
                "generation_kwargs": {
                    "max_new_tokens": 512,
                    "temperature": 0.7,
                },
            },
        }
    )
```