### PR TITLE
Add `api_key` within `LLM.load` and add `llm_kwargs` as `RuntimeParameter`

### DIFF
--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -207,7 +207,7 @@ class Pipeline(BasePipeline):
                 that raised the error.
         """
         if e.is_load_error:
-            self._logger.error(f"Failed to load step '{e.step.name}': {e.message}")
+            self._logger.error(f"❌ Failed to load step '{e.step.name}': {e.message}")
             self._stop()
             return
 
@@ -233,7 +233,7 @@ class Pipeline(BasePipeline):
         notify the pipeline to stop, and set the `_STEPS_LOADED_KEY` to `_STEPS_LOADED_ERROR_CODE`
         for the pipeline to stop waiting for the steps to load.
         """
-        self._logger.info("Stopping pipeline...")
+        self._logger.info("🛑 Stopping pipeline...")
         self.output_queue.put(None)
         with self.shared_info[_STEPS_LOADED_LOCK_KEY]:
             self.shared_info[_STEPS_LOADED_KEY] = _STEPS_LOADED_ERROR_CODE

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -23,6 +23,7 @@ from distilabel.utils.dicts import combine_dicts
 
 if TYPE_CHECKING:
     from distilabel.llm.typing import GenerateOutput
+    from distilabel.steps.base import StepInput
     from distilabel.steps.task.typing import ChatType
     from distilabel.steps.typing import StepOutput
 
@@ -91,7 +92,7 @@ class _Task(_Step, ABC):
         """
         pass
 
-    def process(self, inputs: StepInput) -> "StepOutput":  # type: ignore
+    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
         """Processes the inputs of the task and generates the outputs using the LLM.
 
         Args:

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pydantic import Field
 
 from distilabel.llm.base import LLM
-from distilabel.steps.base import GeneratorStep, RuntimeParameter, Step
+from distilabel.steps.base import GeneratorStep, RuntimeParameter, Step, _Step
 from distilabel.utils.dicts import combine_dicts
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from distilabel.steps.typing import StepOutput
 
 
-class _Task(Step, ABC):
+class _Task(_Step, ABC):
     """_Task is an abstract class that implements the `Step` interface and adds the
     `format_input` and `format_output` methods to format the inputs and outputs of the
     task. It also adds a `llm` attribute to be used as the LLM to generate the outputs.
@@ -147,7 +147,7 @@ class _Task(Step, ABC):
         return {output: None for output in self.outputs}  # type: ignore
 
 
-class Task(_Task):
+class Task(_Task, Step):
     """Task is a class that implements the `_Task` abstract class and adds the `Step`
     interface to be used as a step in the pipeline.
 
@@ -170,7 +170,7 @@ class Task(_Task):
     pass
 
 
-class GeneratorTask(GeneratorStep, _Task):
+class GeneratorTask(_Task, GeneratorStep):
     """GeneratorTask is a class that implements the `_Task` abstract class and adds the
     `GeneratorStep` interface to be used as a step in the pipeline.
 

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -34,6 +34,10 @@ class _Task(Step, ABC):
 
     Args:
         llm: the `LLM` to be used to generate the outputs of the task.
+        llm_kwargs: The kwargs to be propagated to the `LLM` constructor. Note that these
+            kwargs will be specific to each LLM, and while some as `model` may be present
+            on each `LLM`, some others may not, so read the `LLM` constructor signature in
+            advance to see which kwargs are available.
         group_generations: whether to group the `num_generations` generated per input in
             a list or create a row per generation. Defaults to `False`.
         num_generations: The number of generations to be produced per input.
@@ -149,6 +153,10 @@ class Task(_Task):
 
     Args:
         llm: the `LLM` to be used to generate the outputs of the task.
+        llm_kwargs: The kwargs to be propagated to the `LLM` constructor. Note that these
+            kwargs will be specific to each LLM, and while some as `model` may be present
+            on each `LLM`, some others may not, so read the `LLM` constructor signature in
+            advance to see which kwargs are available.
         group_generations: whether to group the `num_generations` generated per input in
             a list or create a row per generation. Defaults to `False`.
         num_generations: The number of generations to be produced per input.
@@ -168,6 +176,10 @@ class GeneratorTask(GeneratorStep, _Task):
 
     Args:
         llm: the `LLM` to be used to generate the outputs of the task.
+        llm_kwargs: The kwargs to be propagated to the `LLM` constructor. Note that these
+            kwargs will be specific to each LLM, and while some as `model` may be present
+            on each `LLM`, some others may not, so read the `LLM` constructor signature in
+            advance to see which kwargs are available.
         group_generations: whether to group the `num_generations` generated per input in
             a list or create a row per generation. Defaults to `False`.
         num_generations: The number of generations to be produced per input.

--- a/tests/unit/llm/test_llamacpp.py
+++ b/tests/unit/llm/test_llamacpp.py
@@ -28,7 +28,7 @@ def llamacpp_llm() -> Generator[LlamaCppLLM, None, None]:
             "tinyllama.gguf",
         )
 
-    llm = LlamaCppLLM(model_path="tinyllama.gguf", n_gpu_layers=0)
+    llm = LlamaCppLLM(model_path="tinyllama.gguf", n_gpu_layers=0)  # type: ignore
     llm.load()
 
     yield llm

--- a/tests/unit/llm/test_transformers.py
+++ b/tests/unit/llm/test_transformers.py
@@ -41,7 +41,7 @@ class TestTransformersLLM:
                 [
                     {
                         "role": "user",
-                        "content": "You're GPT2, you're old now but you still serves a purpose which is being used in unit tests.",
+                        "content": "You're GPT2, you're old now but you still serve a purpose which is being used in unit tests.",
                     }
                 ],
             ],

--- a/tests/unit/steps/task/evol_instruct/test_base.py
+++ b/tests/unit/steps/task/evol_instruct/test_base.py
@@ -139,6 +139,7 @@ class TestEvolInstruct:
                     "name": "DummyLLM",
                 }
             },
+            "llm_kwargs": {},
             "num_evolutions": task.num_evolutions,
             "store_evolutions": task.store_evolutions,
             "generate_answers": task.generate_answers,
@@ -156,6 +157,11 @@ class TestEvolInstruct:
             "generation_kwargs": {},
             "seed": task.seed,
             "runtime_parameters_info": [
+                {
+                    "name": "llm_kwargs",
+                    "description": "The kwargs to be propagated to the `LLM` constructor. Note that these kwargs will be specific to each LLM, and while some as `model` may be present on each `LLM`, some others may not, so read the `LLM` constructor signature in advance to see which kwargs are available.",
+                    "optional": True,
+                },
                 {
                     "name": "num_generations",
                     "optional": True,

--- a/tests/unit/steps/task/evol_instruct/test_generator.py
+++ b/tests/unit/steps/task/evol_instruct/test_generator.py
@@ -136,6 +136,7 @@ class TestEvolInstructGenerator:
                     "name": "DummyLLM",
                 }
             },
+            "llm_kwargs": {},
             "num_instructions": task.num_instructions,
             "generate_answers": task.generate_answers,
             "mutation_templates": {
@@ -154,6 +155,11 @@ class TestEvolInstructGenerator:
             "max_length": task.max_length,
             "seed": task.seed,
             "runtime_parameters_info": [
+                {
+                    "name": "llm_kwargs",
+                    "description": "The kwargs to be propagated to the `LLM` constructor. Note that these kwargs will be specific to each LLM, and while some as `model` may be present on each `LLM`, some others may not, so read the `LLM` constructor signature in advance to see which kwargs are available.",
+                    "optional": True,
+                },
                 {
                     "name": "num_generations",
                     "optional": True,

--- a/tests/unit/steps/task/test_base.py
+++ b/tests/unit/steps/task/test_base.py
@@ -128,10 +128,16 @@ class TestTask:
                     "name": "DummyLLM",
                 }
             },
+            "llm_kwargs": {},
             "generation_kwargs": {},
             "group_generations": False,
             "num_generations": 1,
             "runtime_parameters_info": [
+                {
+                    "name": "llm_kwargs",
+                    "description": "The kwargs to be propagated to the `LLM` constructor. Note that these kwargs will be specific to each LLM, and while some as `model` may be present on each `LLM`, some others may not, so read the `LLM` constructor signature in advance to see which kwargs are available.",
+                    "optional": True,
+                },
                 {
                     "name": "num_generations",
                     "description": "The number of generations to be produced per input.",


### PR DESCRIPTION
## Description

This PR adds the `llm_kwargs` as `RuntimeParameter` within the `Task` so that those can be propagated to the `LLM.load` method (depending on which ones are exposed).

Additionally, the `api_key` has been included in both `OpenAILLM.load` and `MistralLLM.load` methods, so that it can be defined via `llm_kwargs` from the `Task` so as to solve the existing issue with the `api_key` during the serialization, as it's excluded from it, and then couldn't be defined, as it was only a `__init__` arg.

Finally, also `_handle_api_key_value` method has been included to `LLM` so as to unify the `api_key` handling of the values to the `LLM` base class, as it can be reused on subclasses.

Closes #422

Besides that, also the `_Task` subclassing has been fixed to subclass `Step` in the first place, and then for `GeneratorTask` to subclass from `GeneratorStep` and `_Task`, as otherwise some issues were encountered.

## Example

```python
from distilabel.llm.openai import OpenAILLM
from distilabel.pipeline.local import Pipeline
from distilabel.steps.task.text_generation import TextGeneration

if __name__ == "__main__":
    with Pipeline() as pipeline:
        ...

        openai_generation = TextGeneration(
            name="openai_generation",
            llm=OpenAILLM(),
        )
        
        ...

    pipeline.run(
        parameters={
            ...,
            "openai_generation": {
                "llm_kwargs": {
                    "api_key": "sk-***",
                },
                "generation_kwargs": {
                    "max_new_tokens": 512,
                    "temperature": 0.7,
                },
            },
        }
    )
```