### PR TITLE
Add `GeneratorStep.process` validation in `DAG` and smaller fixes

### DIFF
--- a/src/distilabel/integrations/argilla/base.py
+++ b/src/distilabel/integrations/argilla/base.py
@@ -26,12 +26,11 @@ except ImportError as ie:
         "Argilla is not installed. Please install it using `pip install argilla`."
     ) from ie
 
-from distilabel.steps.base import Step
+from distilabel.steps.base import Step, StepInput
 
 if TYPE_CHECKING:
     from argilla.client.feedback.dataset.remote.dataset import RemoteFeedbackDataset
 
-    from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
@@ -120,5 +119,5 @@ class Argilla(Step, ABC):
         ...
 
     @abstractmethod
-    def process(self, inputs: "StepInput") -> "StepOutput":
+    def process(self, inputs: StepInput) -> "StepOutput":
         ...

--- a/src/distilabel/integrations/argilla/prompt_completion.py
+++ b/src/distilabel/integrations/argilla/prompt_completion.py
@@ -25,9 +25,9 @@ except ImportError as ie:
     ) from ie
 
 from distilabel.integrations.argilla.base import Argilla
+from distilabel.steps.base import StepInput
 
 if TYPE_CHECKING:
-    from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
@@ -109,7 +109,7 @@ class PromptCompletionToArgilla(Argilla):
         return ["prompt", "completion"]
 
     @override
-    def process(self, inputs: "StepInput") -> "StepOutput":
+    def process(self, inputs: StepInput) -> "StepOutput":
         """Creates and pushes the records as FeedbackRecords to the Argilla dataset.
 
         Args:

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -376,12 +376,12 @@ class DAG(_Serializable):
         """
         if step.get_process_step_input() is not None:
             raise ValueError(
-                f"GeneratorStep '{step.name}' should not expect an argument with type hint"
+                f"Generator step '{step.name}' should not have a parameter with type hint"
                 " `StepInput` within the `process` method signature."
             )
         if not any("offset" == parameter.name for parameter in step.process_parameters):
             raise ValueError(
-                f"GeneratorStep '{step.name}' should expect the `offset` arg within"
+                f"Generator step '{step.name}' should have an `offset` parameter within"
                 " the `process` method signature."
             )
 

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -440,7 +440,7 @@ class _ProcessWrapper:
                 f" Offset: {offset}"
             )
 
-            for data, last_batch in step.process_applying_mappings(offset):
+            for data, last_batch in step.process_applying_mappings(offset=offset):
                 batch.data = [data]
                 batch.last_batch = last_batch
                 self._send_batch(batch)

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -474,7 +474,7 @@ class GeneratorStep(_Step, ABC):
         of the step.
 
         Args:
-            offset (int): The offset to start the generation from. Defaults to 0.
+            offset: The offset to start the generation from. Defaults to 0.
 
         Yields:
             The output rows and a boolean indicating if it's the last batch or not.
@@ -484,9 +484,9 @@ class GeneratorStep(_Step, ABC):
         # the runtime parameters as `kwargs`, so they can be used within the processing
         # function
         generator = (
-            self.process(offset)
+            self.process(offset=offset)
             if not self._built_from_decorator
-            else self.process(offset, **self._runtime_parameters)
+            else self.process(offset=offset, **self._runtime_parameters)
         )
 
         for output_rows, last_batch in generator:

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -465,6 +465,9 @@ class GeneratorStep(_Step, ABC):
 
         Args:
             offset: The offset to start the generation from. Defaults to 0.
+
+        Yields:
+            The output rows and a boolean indicating if it's the last batch or not.
         """
         pass
 

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -250,14 +250,13 @@ class _Step(BaseModel, _Serializable, ABC):
         """
         step_input_parameter = None
         for parameter in self.process_parameters:
-            if (
-                is_parameter_annotated_with(parameter, _STEP_INPUT_ANNOTATION)
-                and step_input_parameter is not None
-            ):
-                raise TypeError(
-                    f"Step '{self.name}' should have only one parameter with type hint `StepInput`."
-                )
-            step_input_parameter = parameter
+            if is_parameter_annotated_with(parameter, _STEP_INPUT_ANNOTATION):
+                if step_input_parameter is not None:
+                    raise TypeError(
+                        f"Step '{self.name}' should have only one parameter with type"
+                        " hint `StepInput`."
+                    )
+                step_input_parameter = parameter
         return step_input_parameter
 
     def verify_inputs_mappings(self) -> None:

--- a/src/distilabel/steps/combine.py
+++ b/src/distilabel/steps/combine.py
@@ -26,6 +26,15 @@ class CombineColumns(Step):
     function to handle and combine a list of `StepInput`. Also `CombineColumns` provides two attributes
     `merge_columns` and `output_merge_columns` to specify the columns to merge and the output columns
     which will override the default value for the properties `inputs` and `outputs`, respectively.
+
+    Args:
+        merge_columns: List of strings with the names of the columns to merge.
+        output_merge_columns: Optional list of strings with the names of the output columns.
+
+    Columns:
+
+    - `input`: dynamic, based on the `merge_columns` value provided
+    - `output`: dynamic, based on the `output_merge_columns` value provided or `merged_{column}` for each column in `merge_columns`
     """
 
     merge_columns: List[str]
@@ -33,10 +42,13 @@ class CombineColumns(Step):
 
     @property
     def inputs(self) -> List[str]:
+        """The inputs for the task are the column names in `merge_columns`."""
         return self.merge_columns
 
     @property
     def outputs(self) -> List[str]:
+        """The outputs for the task are the column names in `output_merge_columns` or
+        `merged_{column}` for each column in `merge_columns`."""
         return (
             self.output_merge_columns
             if self.output_merge_columns is not None
@@ -44,6 +56,14 @@ class CombineColumns(Step):
         )
 
     def process(self, *args: StepInput) -> "StepOutput":
+        """The `process` method calls the `combine_dicts` function to handle and combine a list of `StepInput`.
+
+        Args:
+            *args: A list of `StepInput` to be combined.
+
+        Yields:
+            A `StepOutput` with the combined `StepInput` using the `combine_dicts` function.
+        """
         yield combine_dicts(
             *args,
             merge_keys=self.inputs,

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -107,7 +107,7 @@ class LoadHubDataset(GeneratorStep):
             offset: The offset to start yielding the data from. Will be used during the caching
             process to help skipping already processed data.
 
-        Yield:
+        Yields:
             A tuple containing a batch of rows and a boolean indicating if the batch is
             the last one.
         """

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -105,7 +105,7 @@ class LoadHubDataset(GeneratorStep):
 
         Args:
             offset: The offset to start yielding the data from. Will be used during the caching
-            process to help skipping already processed data.
+                process to help skipping already processed data.
 
         Yields:
             A tuple containing a batch of rows and a boolean indicating if the batch is

--- a/src/distilabel/steps/globals/huggingface.py
+++ b/src/distilabel/steps/globals/huggingface.py
@@ -14,13 +14,16 @@
 
 import os
 from collections import defaultdict
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from datasets import Dataset
 from pydantic import Field
 
-from distilabel.steps.base import GlobalStep, RuntimeParameter, StepInput
-from distilabel.steps.typing import StepOutput
+from distilabel.steps.base import GlobalStep, RuntimeParameter
+
+if TYPE_CHECKING:
+    from distilabel.steps.base import StepInput
+    from distilabel.steps.typing import StepOutput
 
 
 class PushToHub(GlobalStep):
@@ -63,7 +66,7 @@ class PushToHub(GlobalStep):
         " to `None`",
     )
 
-    def process(self, inputs: StepInput) -> StepOutput:
+    def process(self, inputs: "StepInput") -> "StepOutput":
         """Method that processes the input data, respecting the `datasets.Dataset` formatting,
         and pushes it to the Hugging Face Hub based on the `RuntimeParameter`s attributes.
 

--- a/src/distilabel/steps/globals/huggingface.py
+++ b/src/distilabel/steps/globals/huggingface.py
@@ -19,10 +19,9 @@ from typing import TYPE_CHECKING, Optional
 from datasets import Dataset
 from pydantic import Field
 
-from distilabel.steps.base import GlobalStep, RuntimeParameter
+from distilabel.steps.base import GlobalStep, RuntimeParameter, StepInput
 
 if TYPE_CHECKING:
-    from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
@@ -66,7 +65,7 @@ class PushToHub(GlobalStep):
         " to `None`",
     )
 
-    def process(self, inputs: "StepInput") -> "StepOutput":
+    def process(self, inputs: StepInput) -> "StepOutput":
         """Method that processes the input data, respecting the `datasets.Dataset` formatting,
         and pushes it to the Hugging Face Hub based on the `RuntimeParameter`s attributes.
 

--- a/src/distilabel/steps/globals/huggingface.py
+++ b/src/distilabel/steps/globals/huggingface.py
@@ -71,7 +71,7 @@ class PushToHub(GlobalStep):
             inputs: that input data within a single object (as it's a GlobalStep) that
                 will be transformed into a `datasets.Dataset`.
 
-        Returns:
+        Yields:
             An empty `StepOutput` which is an iterator with a single empty dictionary.
         """
         dataset_dict = defaultdict(list)

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -76,12 +76,6 @@ class _Task(_Step, ABC):
         self.llm.load(**self.llm_kwargs)  # type: ignore
 
     @abstractmethod
-    def format_input(self, input: Dict[str, Any]) -> "ChatType":
-        """Asbtract method to format the inputs of the task. It needs to receive an input
-        as a Python dictionary, and generates an OpenAI chat-like list of dicts."""
-        pass
-
-    @abstractmethod
     def format_output(
         self, output: Union[str, None], input: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -91,44 +85,6 @@ class _Task(_Step, ABC):
         needed to be able to parse the output correctly.
         """
         pass
-
-    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
-        """Processes the inputs of the task and generates the outputs using the LLM.
-
-        Args:
-            inputs: A list of Python dictionaries with the inputs of the task.
-
-        Returns:
-            A list of Python dictionaries with the outputs of the task.
-        """
-        formatted_inputs = self._format_inputs(inputs)
-        outputs = self.llm.generate(
-            inputs=formatted_inputs,
-            num_generations=self.num_generations,
-            **self.generation_kwargs,  # type: ignore
-        )
-
-        task_outputs = []
-        for input, input_outputs in zip(inputs, outputs):
-            formatted_outputs = self._format_outputs(input_outputs, inputs)
-
-            if self.group_generations:
-                combined = combine_dicts(*formatted_outputs)
-                task_outputs.append(
-                    {**input, "model_name": self.llm.model_name, **combined}
-                )
-                continue
-
-            # Create a row per generation
-            for formatted_output in formatted_outputs:
-                task_outputs.append(
-                    {**input, "model_name": self.llm.model_name, **formatted_output}
-                )
-
-        yield task_outputs
-
-    def _format_inputs(self, inputs: List[Dict[str, Any]]) -> List["ChatType"]:
-        return [self.format_input(input) for input in inputs]
 
     def _format_outputs(
         self, outputs: "GenerateOutput", inputs: List[Dict[str, Any]]
@@ -180,7 +136,58 @@ class Task(_Task, Step):
             in advance to see which kwargs are available.
     """
 
-    pass
+    @abstractmethod
+    def format_input(self, input: Dict[str, Any]) -> "ChatType":
+        """Asbtract method to format the inputs of the task. It needs to receive an input
+        as a Python dictionary, and generates an OpenAI chat-like list of dicts."""
+        pass
+
+    def _format_inputs(self, inputs: List[Dict[str, Any]]) -> List["ChatType"]:
+        """Formats the inputs of the task using the `format_input` method.
+
+        Args:
+            inputs: A list of Python dictionaries with the inputs of the task.
+
+        Returns:
+            A list containing the formatted inputs, which are `ChatType`-like following
+            the OpenAI formatting.
+        """
+        return [self.format_input(input) for input in inputs]
+
+    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
+        """Processes the inputs of the task and generates the outputs using the LLM.
+
+        Args:
+            inputs: A list of Python dictionaries with the inputs of the task.
+
+        Yields:
+            A list of Python dictionaries with the outputs of the task.
+        """
+        formatted_inputs = self._format_inputs(inputs)
+        outputs = self.llm.generate(
+            inputs=formatted_inputs,
+            num_generations=self.num_generations,
+            **self.generation_kwargs,  # type: ignore
+        )
+
+        task_outputs = []
+        for input, input_outputs in zip(inputs, outputs):
+            formatted_outputs = self._format_outputs(input_outputs, inputs)
+
+            if self.group_generations:
+                combined = combine_dicts(*formatted_outputs)
+                task_outputs.append(
+                    {**input, "model_name": self.llm.model_name, **combined}
+                )
+                continue
+
+            # Create a row per generation
+            for formatted_output in formatted_outputs:
+                task_outputs.append(
+                    {**input, "model_name": self.llm.model_name, **formatted_output}
+                )
+
+        yield task_outputs
 
 
 class GeneratorTask(_Task, GeneratorStep):

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -18,12 +18,17 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from pydantic import Field
 
 from distilabel.llm.base import LLM
-from distilabel.steps.base import GeneratorStep, RuntimeParameter, Step, _Step
+from distilabel.steps.base import (
+    GeneratorStep,
+    RuntimeParameter,
+    Step,
+    StepInput,
+    _Step,
+)
 from distilabel.utils.dicts import combine_dicts
 
 if TYPE_CHECKING:
     from distilabel.llm.typing import GenerateOutput
-    from distilabel.steps.base import StepInput
     from distilabel.steps.task.typing import ChatType
     from distilabel.steps.typing import StepOutput
 
@@ -154,7 +159,7 @@ class Task(_Task, Step):
         """
         return [self.format_input(input) for input in inputs]
 
-    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
+    def process(self, inputs: StepInput) -> "StepOutput":  # type: ignore
         """Processes the inputs of the task and generates the outputs using the LLM.
 
         Args:

--- a/src/distilabel/steps/task/evol_instruct/base.py
+++ b/src/distilabel/steps/task/evol_instruct/base.py
@@ -230,7 +230,7 @@ class EvolInstruct(Task):
         Args:
             inputs: A list of Python dictionaries with the inputs of the task.
 
-        Returns:
+        Yields:
             A list of Python dictionaries with the outputs of the task.
         """
 

--- a/src/distilabel/steps/task/evol_instruct/base.py
+++ b/src/distilabel/steps/task/evol_instruct/base.py
@@ -25,13 +25,12 @@ import numpy as np
 from pydantic import Field
 from typing_extensions import override
 
-from distilabel.steps.base import RuntimeParameter
+from distilabel.steps.base import RuntimeParameter, StepInput
 from distilabel.steps.task.base import Task
 from distilabel.steps.task.evol_instruct.utils import MutationTemplates
 from distilabel.steps.task.typing import ChatType
 
 if TYPE_CHECKING:
-    from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
@@ -224,7 +223,7 @@ class EvolInstruct(Task):
         )
 
     @override
-    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
+    def process(self, inputs: StepInput) -> "StepOutput":  # type: ignore
         """Processes the inputs of the task and generates the outputs using the LLM.
 
         Args:

--- a/src/distilabel/steps/task/evol_instruct/generator.py
+++ b/src/distilabel/steps/task/evol_instruct/generator.py
@@ -138,9 +138,6 @@ class EvolInstructGenerator(GeneratorTask):
         with open(_path, mode="r") as f:
             return [line.strip() for line in f.readlines()]
 
-    def format_input(self, input: Dict[str, Any]) -> "ChatType":  # type: ignore
-        pass
-
     @property
     def outputs(self) -> List[str]:
         """The output for the task are the `instruction`, the `answer` if `generate_answers=True`

--- a/src/distilabel/steps/task/evol_instruct/generator.py
+++ b/src/distilabel/steps/task/evol_instruct/generator.py
@@ -231,11 +231,11 @@ class EvolInstructGenerator(GeneratorTask):
         )
 
     @override
-    def process(self) -> "GeneratorStepOutput":  # type: ignore
+    def process(self, offset: int = 0) -> "GeneratorStepOutput":  # type: ignore
         """Processes the inputs of the task and generates the outputs using the LLM.
 
         Args:
-            inputs: A list of Python dictionaries with the inputs of the task.
+            offset: The offset to start the generation from. Defaults to 0.
 
         Yields:
             A list of Python dictionaries with the outputs of the task, and a boolean

--- a/src/distilabel/steps/task/evol_instruct/generator.py
+++ b/src/distilabel/steps/task/evol_instruct/generator.py
@@ -237,8 +237,9 @@ class EvolInstructGenerator(GeneratorTask):
         Args:
             inputs: A list of Python dictionaries with the inputs of the task.
 
-        Returns:
-            A list of Python dictionaries with the outputs of the task.
+        Yields:
+            A list of Python dictionaries with the outputs of the task, and a boolean
+            flag indicating whether the task has finished or not i.e. is the last batch.
         """
 
         instructions = []

--- a/src/distilabel/steps/task/generate_embeddings.py
+++ b/src/distilabel/steps/task/generate_embeddings.py
@@ -88,7 +88,7 @@ class GenerateEmbeddings(Step):
         Args:
             inputs: A list of Python dictionaries with the inputs of the task.
 
-        Returns:
+        Yields:
             A list of Python dictionaries with the outputs of the task.
         """
         formatted_inputs = [self.format_input(input) for input in inputs]

--- a/src/distilabel/steps/task/generate_embeddings.py
+++ b/src/distilabel/steps/task/generate_embeddings.py
@@ -15,11 +15,10 @@
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from distilabel.llm.base import LLM
-from distilabel.steps.base import Step
+from distilabel.steps.base import Step, StepInput
 from distilabel.utils.chat import is_openai_format
 
 if TYPE_CHECKING:
-    from distilabel.steps.base import StepInput
     from distilabel.steps.task.typing import ChatType
     from distilabel.steps.typing import StepOutput
 
@@ -82,7 +81,7 @@ class GenerateEmbeddings(Step):
             " be a string or a list of dictionaries in OpenAI chat-like format."
         )
 
-    def process(self, inputs: "StepInput") -> "StepOutput":  # type: ignore
+    def process(self, inputs: StepInput) -> "StepOutput":  # type: ignore
         """Generates an embedding for each input using the last hidden state of the `LLM`.
 
         Args:

--- a/tests/unit/integrations/argilla/test_base.py
+++ b/tests/unit/integrations/argilla/test_base.py
@@ -18,10 +18,10 @@ from typing import TYPE_CHECKING, List
 import pytest
 from distilabel.integrations.argilla.base import Argilla
 from distilabel.pipeline.local import Pipeline
+from distilabel.steps.base import StepInput
 from pydantic import ValidationError
 
 if TYPE_CHECKING:
-    from distilabel.steps.base import StepInput
     from distilabel.steps.typing import StepOutput
 
 
@@ -33,7 +33,7 @@ class CustomArgilla(Argilla):
     def inputs(self) -> List[str]:
         return ["instruction"]
 
-    def process(self, inputs: "StepInput") -> "StepOutput":
+    def process(self, inputs: StepInput) -> "StepOutput":
         yield [{}]
 
 

--- a/tests/unit/pipeline/utils.py
+++ b/tests/unit/pipeline/utils.py
@@ -19,11 +19,7 @@ from distilabel.steps.typing import GeneratorStepOutput, StepOutput
 
 
 class DummyGeneratorStep(GeneratorStep):
-    @property
-    def inputs(self) -> List[str]:
-        return []
-
-    def process(self) -> GeneratorStepOutput:  # type: ignore
+    def process(self, offset: int = 0) -> GeneratorStepOutput:  # type: ignore
         yield [{"instruction": "Generate an email..."}], False
 
     @property


### PR DESCRIPTION
## Description

This PR adds a method within `DAG` named `_validate_generator_step_process_signature` that validates that the provided `process` method signature matches the expected one, which should contain the `offset` arg, and also the `inputs` arg should not be there, otherwise, a `ValueError` will be raised during the validation.

Closes #431

Additionally, this PR also tackles the following:

* Add missing `CombineColumns` docstrings
* Use `Yields` over `Returns` in docstrings where `yield` is used instead of `return`
* Move `Task` specific methods out of abstract `_Task`, to avoid conflicts / collisions with `GeneratorTask` that has a different `process` signature
