### PR TITLE
Fix `Step.process_applying_mappings`

### DIFF
--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -410,7 +410,9 @@ class Step(_Step, ABC):
             yield [
                 {
                     # Apply output mapping and revert input mapping
-                    self.input_mappings.get(self.output_mappings.get(k, k), k): v
+                    self.output_mappings.get(k, None)
+                    or self.input_mappings.get(k, None)
+                    or k: v
                     for k, v in row.items()
                 }
                 for row in output_rows

--- a/tests/unit/steps/test_base.py
+++ b/tests/unit/steps/test_base.py
@@ -193,9 +193,9 @@ class TestStep:
         )
 
         assert outputs == [
-            {"prompt": "hello 1", "response": "unit test"},
-            {"prompt": "hello 2", "response": "unit test"},
-            {"prompt": "hello 3", "response": "unit test"},
+            {"prompt": "hello 1", "generation": "unit test"},
+            {"prompt": "hello 2", "generation": "unit test"},
+            {"prompt": "hello 3", "generation": "unit test"},
         ]
 
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the `process_applying_mappings` method, as it was not properly applying the `output_mappings`, so the resulting columns were not properly renamed for `Step` subclasses.

## Note

While `input_mappings` operates at `Step` level and does not rename the output, `output_mappings` operates at global level meaning that the `Step` will propagate the outputs with the renames applied, while the input ones will be reverted before propagating the inputs and outputs.