### PR TITLE
Fix `LLM` subclasses based on `OpenAILLM`

### DIFF
--- a/src/distilabel/llm/anyscale.py
+++ b/src/distilabel/llm/anyscale.py
@@ -12,18 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from typing import Optional
+
+from pydantic import PrivateAttr, SecretStr
 
 from distilabel.llm.openai import OpenAILLM
 
 
 class AnyscaleLLM(OpenAILLM):
-    """
-    Anyscale LLM implementation running the async API client of OpenAI because of duplicate API behavior.
+    """Anyscale LLM implementation running the async API client of OpenAI because of
+    duplicate API behavior.
 
     Attributes:
-        model: the model name to use for the LLM, e.g., `google/gemma-7b-it`. [Supported models](https://docs.endpoints.anyscale.com/text-generation/supported-models/google-gemma-7b-it).
-        base_url: the base URL to use for the Anyscale API can be set with `OPENAI_BASE_URL`. Default is "https://api.endpoints.anyscale.com/v1".
-        api_key: the API key to authenticate the requests to the Anyscale API. Can be set with `OPENAI_API_KEY`. Default is `None`.
+        model: the model name to use for the LLM, e.g., `google/gemma-7b-it`. See the
+            supported models under the "Text Generation -> Supported Models" section
+            [here](https://docs.endpoints.anyscale.com/).
+        base_url: the base URL to use for the Anyscale API can be set with `ANYSCALE_BASE_URL`.
+            Defaults to the value set for the environment variable `ANYSCALE_BASE_URL`, or
+            "https://api.endpoints.anyscale.com/v1" if not set.
+        api_key: the API key to authenticate the requests to the Anyscale API. Defaults to the
+            value set for the environment variable `ANYSCALE_API_KEY`, or `None` if not set.
+
     """
 
-    base_url: str = "https://api.endpoints.anyscale.com/v1"
+    base_url: Optional[str] = os.getenv(
+        "ANYSCALE_BASE_URL", "https://api.endpoints.anyscale.com/v1"
+    )
+    api_key: Optional[SecretStr] = os.getenv("ANYSCALE_API_KEY", None)  # type: ignore
+
+    _env_var: Optional[str] = PrivateAttr(default="ANYSCALE_API_KEY")

--- a/src/distilabel/llm/anyscale.py
+++ b/src/distilabel/llm/anyscale.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from typing import Optional
-
-from pydantic import PrivateAttr, SecretStr
+from pydantic import PrivateAttr
 
 from distilabel.llm.openai import OpenAILLM
 
@@ -28,17 +25,14 @@ class AnyscaleLLM(OpenAILLM):
         model: the model name to use for the LLM, e.g., `google/gemma-7b-it`. See the
             supported models under the "Text Generation -> Supported Models" section
             [here](https://docs.endpoints.anyscale.com/).
-        base_url: the base URL to use for the Anyscale API can be set with `ANYSCALE_BASE_URL`.
-            Defaults to the value set for the environment variable `ANYSCALE_BASE_URL`, or
+        base_url: the base URL to use for the Anyscale API requests. Defaults to `None`, which
+            means that the value set for the environment variable `ANYSCALE_BASE_URL` will be used, or
             "https://api.endpoints.anyscale.com/v1" if not set.
-        api_key: the API key to authenticate the requests to the Anyscale API. Defaults to the
-            value set for the environment variable `ANYSCALE_API_KEY`, or `None` if not set.
-
+        api_key: the API key to authenticate the requests to the Anyscale API. Defaults to `None` which
+            means that the value set for the environment variable `ANYSCALE_API_KEY` will be used, or
+            `None` if not set.
     """
 
-    base_url: Optional[str] = os.getenv(
-        "ANYSCALE_BASE_URL", "https://api.endpoints.anyscale.com/v1"
-    )
-    api_key: Optional[SecretStr] = os.getenv("ANYSCALE_API_KEY", None)  # type: ignore
-
-    _env_var: Optional[str] = PrivateAttr(default="ANYSCALE_API_KEY")
+    _base_url_env_var: str = PrivateAttr(default="ANYSCALE_BASE_URL")
+    _default_base_url: str = PrivateAttr("https://api.endpoints.anyscale.com/v1")
+    _api_key_env_var: str = PrivateAttr(default="ANYSCALE_API_KEY")

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -29,7 +29,9 @@ if TYPE_CHECKING:
 
 
 class LLM(BaseModel, _Serializable, ABC):
-    model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, protected_namespaces=(), validate_default=True
+    )
 
     _values: Dict[str, Any] = PrivateAttr(default_factory=dict)
     _logger: logging.Logger = PrivateAttr(get_logger("llm"))
@@ -72,7 +74,7 @@ class LLM(BaseModel, _Serializable, ABC):
     def _handle_api_key_value(
         self,
         self_value: Union[str, SecretStr, None],
-        load_value: Union[str, None],
+        load_value: Union[str, SecretStr, None],
         env_var: str,
     ) -> SecretStr:
         """Method to handle the API key for the LLM, either from the `self_value` or the

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 import os
-from typing import TYPE_CHECKING, Optional, Self, Union
+import sys
+from typing import TYPE_CHECKING, Optional, Union
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from pydantic import PrivateAttr, SecretStr, model_validator
 

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Self, Union
 
-from pydantic import PrivateAttr, SecretStr
+from pydantic import PrivateAttr, SecretStr, model_validator
 
 from distilabel.llm.base import AsyncLLM
 
@@ -31,19 +31,35 @@ class OpenAILLM(AsyncLLM):
 
     Attributes:
         model: the model name to use for the LLM e.g. "gpt-3.5-turbo", "gpt-4", etc.
-        base_url: the base URL to use for the OpenAI API requests. Defaults to `None`,
-            which means that https://api.openai.com/v1 will be used.
-        api_key: the API key to authenticate the requests to the OpenAI API.
+            Supported models can be found [here](https://platform.openai.com/docs/guides/text-generation).
+        base_url: the base URL to use for the OpenAI API requests. Defaults to `None`, which means that
+            the value set for the environment variable `OPENAI_BASE_URL` will be used, or "https://api.openai.com/v1"
+            if not set.
+        api_key: the API key to authenticate the requests to the OpenAI API. Defaults to `None` which
+            means that the value set for the environment variable `OPENAI_API_KEY` will be used, or
+            `None` if not set.
     """
 
     model: str
     base_url: Optional[str] = None
-    api_key: Optional[SecretStr] = os.getenv("OPENAI_API_KEY", None)  # type: ignore
+    api_key: Optional[SecretStr] = None
 
-    _env_var: Optional[str] = PrivateAttr(default="OPENAI_API_KEY")
+    _base_url_env_var: str = PrivateAttr(default="OPENAI_BASE_URL")
+    _default_base_url: str = PrivateAttr("https://api.openai.com/v1")
+    _api_key_env_var: str = PrivateAttr(default="OPENAI_API_KEY")
     _aclient: Optional["AsyncOpenAI"] = PrivateAttr(...)
 
-    def load(self, api_key: Optional[str] = None) -> None:
+    @model_validator(mode="after")
+    def base_url_provided_or_env_var(self) -> Self:
+        if self.base_url is None:
+            self.base_url = os.getenv(self._base_url_env_var, self._default_base_url)
+        if self.api_key is None:
+            self.api_key = os.getenv(self._api_key_env_var, None)  # type: ignore
+        if self.api_key is not None and isinstance(self.api_key, str):
+            self.api_key = SecretStr(self.api_key)
+        return self
+
+    def load(self, api_key: Optional[Union[str, SecretStr]] = None) -> None:
         """Loads the `AsyncOpenAI` client to benefit from async requests."""
 
         try:
@@ -54,6 +70,8 @@ class OpenAILLM(AsyncLLM):
                 " `pip install openai`."
             ) from ie
 
+        # TODO: this may not be needed at the end, and a simple `self.api_key = self.api_key or api_key`
+        # may do the work.
         self.api_key = self._handle_api_key_value(
             self_value=self.api_key,
             load_value=api_key,

--- a/src/distilabel/llm/together.py
+++ b/src/distilabel/llm/together.py
@@ -27,13 +27,15 @@ class TogetherLLM(OpenAILLM):
     Attributes:
         model: the model name to use for the LLM e.g. "mistralai/Mixtral-8x7B-Instruct-v0.1".
             Supported models can be found [here](https://api.together.xyz/models).
-        base_url: the base URL to use for the Together API can be set with `OPENAI_BASE_URL`.
+        base_url: the base URL to use for the Together API can be set with `TOGETHER_BASE_URL`.
             Defaults to "https://api.together.xyz/v1".
         api_key: the API key to authenticate the requests to the Together API. Defaults to the
             value set for the environment variable `TOGETHER_API_KEY`, or `None` if not set.
     """
 
-    base_url: Optional[str] = "https://api.together.xyz/v1"
+    base_url: Optional[str] = os.getenv(
+        "TOGETHER_BASE_URL", "https://api.together.xyz/v1"
+    )
     api_key: Optional[SecretStr] = os.getenv("TOGETHER_API_KEY", None)  # type: ignore
 
     _env_var: Optional[str] = PrivateAttr(default="TOGETHER_API_KEY")

--- a/src/distilabel/llm/together.py
+++ b/src/distilabel/llm/together.py
@@ -12,43 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Optional
+
+from pydantic import PrivateAttr, SecretStr
 
 from distilabel.llm.openai import OpenAILLM
 
 
 class TogetherLLM(OpenAILLM):
-    """
-    TogetherLLM LLM implementation running the async API client of OpenAI because of duplicate API behavior.
+    """TogetherLLM LLM implementation running the async API client of OpenAI because of
+    duplicate API behavior.
 
     Attributes:
-        model: the model name to use for the LLM e.g. "mistralai/Mixtral-8x7B-Instruct-v0.1". Supported models can be found [here](https://api.together.xyz/models).
-        base_url: the base URL to use for the Together API can be set with `OPENAI_BASE_URL`. Default is "https://api.together.xyz/v1".
-        api_key: the API key to authenticate the requests to the Together API. Can be set with `TOGETHER_API_KEY`. Default is `None`.
+        model: the model name to use for the LLM e.g. "mistralai/Mixtral-8x7B-Instruct-v0.1".
+            Supported models can be found [here](https://api.together.xyz/models).
+        base_url: the base URL to use for the Together API can be set with `OPENAI_BASE_URL`.
+            Defaults to "https://api.together.xyz/v1".
+        api_key: the API key to authenticate the requests to the Together API. Defaults to the
+            value set for the environment variable `TOGETHER_API_KEY`, or `None` if not set.
     """
 
     base_url: Optional[str] = "https://api.together.xyz/v1"
+    api_key: Optional[SecretStr] = os.getenv("TOGETHER_API_KEY", None)  # type: ignore
 
-    def load(
-        self, api_key: Optional[str] = None, base_url: Optional[str] = None
-    ) -> None:
-        """Loads the `AsyncOpenAI` client to benefit from async requests."""
-
-        try:
-            from openai import AsyncOpenAI
-        except ImportError as ie:
-            raise ImportError(
-                "OpenAI Python client is not installed which is required for `TogetherLLM`. Please install it using"
-                " `pip install openai`."
-            ) from ie
-
-        self.api_key = self._handle_api_key_value(
-            self_value=self.api_key, load_value=api_key, env_var="TOGETHER_API_KEY"
-        )
-        self.base_url = base_url or self.base_url
-
-        self._aclient = AsyncOpenAI(
-            api_key=self.api_key.get_secret_value(),
-            base_url=self.base_url,
-            max_retries=6,
-        )
+    _env_var: Optional[str] = PrivateAttr(default="TOGETHER_API_KEY")

--- a/src/distilabel/llm/together.py
+++ b/src/distilabel/llm/together.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from typing import Optional
-
-from pydantic import PrivateAttr, SecretStr
+from pydantic import PrivateAttr
 
 from distilabel.llm.openai import OpenAILLM
 
@@ -28,14 +25,13 @@ class TogetherLLM(OpenAILLM):
         model: the model name to use for the LLM e.g. "mistralai/Mixtral-8x7B-Instruct-v0.1".
             Supported models can be found [here](https://api.together.xyz/models).
         base_url: the base URL to use for the Together API can be set with `TOGETHER_BASE_URL`.
-            Defaults to "https://api.together.xyz/v1".
-        api_key: the API key to authenticate the requests to the Together API. Defaults to the
-            value set for the environment variable `TOGETHER_API_KEY`, or `None` if not set.
+            Defaults to `None` which means that the value set for the environment variable
+            `TOGETHER_BASE_URL` will be used, or "https://api.together.xyz/v1" if not set.
+        api_key: the API key to authenticate the requests to the Together API. Defaults to `None`
+            which means that the value set for the environment variable `TOGETHER_API_KEY` will be
+            used, or `None` if not set.
     """
 
-    base_url: Optional[str] = os.getenv(
-        "TOGETHER_BASE_URL", "https://api.together.xyz/v1"
-    )
-    api_key: Optional[SecretStr] = os.getenv("TOGETHER_API_KEY", None)  # type: ignore
-
-    _env_var: Optional[str] = PrivateAttr(default="TOGETHER_API_KEY")
+    _base_url_env_var: str = PrivateAttr(default="TOGETHER_BASE_URL")
+    _default_base_url: str = PrivateAttr("https://api.together.xyz/v1")
+    _api_key_env_var: str = PrivateAttr(default="TOGETHER_API_KEY")

--- a/tests/unit/llm/test_anyscale.py
+++ b/tests/unit/llm/test_anyscale.py
@@ -16,21 +16,35 @@ import os
 
 from distilabel.llm.anyscale import AnyscaleLLM
 
-MODEL = "mistralai/Mixtral-8x7B-Instruct-v0.1"
-
 
 class TestAnyscaleLLM:
+    model_id: str = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+
     def test_anyscale_llm(self) -> None:
-        llm = AnyscaleLLM(model=MODEL, api_key="api.key")
+        llm = AnyscaleLLM(model=self.model_id, api_key="api.key")  # type: ignore
+
         assert isinstance(llm, AnyscaleLLM)
-        assert llm.model_name == MODEL
+        assert llm.model_name == self.model_id
+
+    def test_anyscale_llm_env_vars(self) -> None:
+        os.environ["ANYSCALE_API_KEY"] = "another.api.key"
+        os.environ["ANYSCALE_BASE_URL"] = "https://example.com"
+
+        llm = AnyscaleLLM(model=self.model_id)
+
+        assert isinstance(llm, AnyscaleLLM)
+        assert llm.model_name == self.model_id
+        assert llm.base_url == "https://example.com"
+        assert llm.api_key.get_secret_value() == "another.api.key"  # type: ignore
+
+        del os.environ["ANYSCALE_API_KEY"]
+        del os.environ["ANYSCALE_BASE_URL"]
 
     def test_serialization(self) -> None:
-        os.environ["OPENAI_API_KEY"] = "api.key"
-        llm = AnyscaleLLM(model=MODEL)
+        llm = AnyscaleLLM(model=self.model_id)
 
         _dump = {
-            "model": MODEL,
+            "model": self.model_id,
             "base_url": "https://api.endpoints.anyscale.com/v1",
             "type_info": {
                 "module": "distilabel.llm.anyscale",

--- a/tests/unit/llm/test_together.py
+++ b/tests/unit/llm/test_together.py
@@ -21,7 +21,8 @@ MODEL = "mistralai/Mixtral-8x7B-Instruct-v0.1"
 
 class TestTogetherLLM:
     def test_llm(self) -> None:
-        llm = TogetherLLM(model=MODEL, api_key="api.key")
+        llm = TogetherLLM(model=MODEL, api_key="api.key")  # type: ignore
+
         assert isinstance(llm, TogetherLLM)
         assert llm.model_name == MODEL
 

--- a/tests/unit/llm/test_together.py
+++ b/tests/unit/llm/test_together.py
@@ -16,22 +16,36 @@ import os
 
 from distilabel.llm.together import TogetherLLM
 
-MODEL = "mistralai/Mixtral-8x7B-Instruct-v0.1"
-
 
 class TestTogetherLLM:
-    def test_llm(self) -> None:
-        llm = TogetherLLM(model=MODEL, api_key="api.key")  # type: ignore
+    model_id: str = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+
+    def test_together_llm(self) -> None:
+        llm = TogetherLLM(model=self.model_id, api_key="api.key")  # type: ignore
 
         assert isinstance(llm, TogetherLLM)
-        assert llm.model_name == MODEL
+        assert llm.model_name == self.model_id
+
+    def test_together_llm_env_vars(self) -> None:
+        os.environ["TOGETHER_API_KEY"] = "another.api.key"
+        os.environ["TOGETHER_BASE_URL"] = "https://example.com"
+
+        llm = TogetherLLM(model=self.model_id)
+
+        assert isinstance(llm, TogetherLLM)
+        assert llm.model_name == self.model_id
+        assert llm.base_url == "https://example.com"
+        assert llm.api_key.get_secret_value() == "another.api.key"  # type: ignore
+
+        del os.environ["TOGETHER_API_KEY"]
+        del os.environ["TOGETHER_BASE_URL"]
 
     def test_serialization(self) -> None:
         os.environ["TOGETHER_API_KEY"] = "api.key"
-        llm = TogetherLLM(model=MODEL)
+        llm = TogetherLLM(model=self.model_id)
 
         _dump = {
-            "model": MODEL,
+            "model": self.model_id,
             "base_url": "https://api.together.xyz/v1",
             "type_info": {
                 "module": "distilabel.llm.together",


### PR DESCRIPTION
## Description

This PR fixes and improves the handling in `OpenAILLM` for both `base_url` and `api_key` and fixes both `TogetherLLM` (#449) and `AnyscaleLLM` (#447).

Now the `base_url` and `api_key` handling via environment variable is fixed and aligned, also some tests were included to ensure that the environment variables are properly used, and also the docstrings have been updated and aligned.