### PR TITLE
Add `use_cache` to `BasePipeline`

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -264,9 +264,6 @@ class BasePipeline(_Serializable):
 
     def _cache(self) -> None:
         """Saves the `BasePipeline` using the `_cache_filename`."""
-        if not self._use_cache:
-            return
-
         self.save(
             path=self._cache_location["pipeline"],
             format=self._cache_location["pipeline"].suffix.replace(".", ""),
@@ -284,8 +281,6 @@ class BasePipeline(_Serializable):
         if not self._use_cache:
             return
 
-        # Store the _cache_filename in a variable to avoid it changing when refreshing
-        # the dag
         cache_loc = self._cache_location
         if cache_loc["pipeline"].exists():
             # Refresh the DAG to avoid errors when it's created within a context manager

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -86,6 +86,12 @@ class _GlobalPipelineManager:
 class BasePipeline(_Serializable):
     """Base class for a `distilabel` pipeline.
 
+    Args:
+        cache_dir: The directory where the pipeline will be cached. Defaults to `None`, which will
+            define it internally.
+        use_cache: A flag to indicate if the pipeline should be cached and loaded if available.
+            Defaults to `True`.
+
     Attributes:
         dag: The `DAG` instance that represents the pipeline.
     """

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -962,14 +962,16 @@ class TestPipelineSerialization:
         signature = pipeline._create_signature()
         assert signature == "9da791477eab8cab62c09af59fb08ac42e039ce5"
 
-    def test_run_pipe_and_load_from_cache(self):
+    @pytest.mark.parametrize("use_cache", [True, False])
+    def test_run_pipe_and_load_from_cache(self, use_cache: bool):
         # Maybe not the best place for this test, but does the work for now
         from distilabel.pipeline.base import BasePipeline
 
         from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            with BasePipeline(tmpdirname) as pipeline:
+            with BasePipeline(cache_dir=tmpdirname, use_cache=use_cache) as pipeline:
+                assert pipeline._use_cache == use_cache
                 dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
                 dummy_step_1 = DummyStep1(name="dummy_step_1")
                 dummy_step_2 = DummyStep2(name="dummy_step_2")
@@ -980,9 +982,13 @@ class TestPipelineSerialization:
                 assert not pipeline._cache_location["pipeline"].exists()
                 pipeline._cache()
             # Check the file exists AFTER we are out of the context manager
-            assert pipeline._cache_location["pipeline"].exists()
+            if use_cache:
+                assert pipeline._cache_location["pipeline"].exists()
+            else:
+                assert not pipeline._cache_location["pipeline"].exists()
 
-            with BasePipeline(tmpdirname) as pipe:
+            with BasePipeline(cache_dir=tmpdirname, use_cache=use_cache) as pipe:
+                assert pipe._use_cache == use_cache
                 dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
                 dummy_step_1 = DummyStep1(name="dummy_step_1")
                 dummy_step_2 = DummyStep2(name="dummy_step_2")
@@ -991,10 +997,13 @@ class TestPipelineSerialization:
                 dummy_step_1.connect(dummy_step_2)
 
                 cache_filename = pipe._cache_location["pipeline"]
-                assert pipe._cache_location["pipeline"].exists()
+                # assert pipe._cache_location["pipeline"].exists()
                 # Run the pipeline and check the _cache_filename is the same afterwards
                 pipe.run()
-                assert pipe._cache_location["pipeline"].exists()
+                if use_cache:
+                    assert pipe._cache_location["pipeline"].exists()
+                else:
+                    assert not pipe._cache_location["pipeline"].exists()
                 assert cache_filename == pipe._cache_location["pipeline"]
 
 


### PR DESCRIPTION
## Description

This PR adds an argument `use_cache` to `BasePipeline` to decide whether we should cache the pipeline and reuse it or not.

Closes #460.