### PR TITLE
Add `multiprocess` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,12 @@ dependencies = [
     "pydantic >= 2.0",
     "networkx >= 3.0",
     "scipy >= 1.10.0",
+    "multiprocess >= 0.70",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-anthropic =["anthropic >= 0.20.0"]
+anthropic = ["anthropic >= 0.20.0"]
 argilla = ["argilla >= 1.23.0"]
 hf-inference-endpoints = ["huggingface_hub >= 0.19.0"]
 hf-transformers = ["transformers >= 4.34.1", "torch >= 2.0.0"]

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import multiprocessing as mp
 import signal
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+
+import multiprocess as mp
 
 from distilabel.llm.mixins import CudaDevicePlacementMixin
 from distilabel.pipeline.base import BasePipeline, _Batch, _BatchManager, _WriteBuffer
@@ -82,7 +83,7 @@ class Pipeline(BasePipeline):
         write_buffer = _WriteBuffer(buffer_data_path, self.dag.leaf_steps)
 
         num_processes = len(self.dag)
-        ctx = mp.get_context("forkserver")
+        ctx = mp.get_context("fork")  # type: ignore
         with ctx.Manager() as manager, ctx.Pool(num_processes) as pool:
             self.output_queue: "Queue[Any]" = manager.Queue()
             self.shared_info = self._create_shared_info_dict(manager)


### PR DESCRIPTION
## Description

This PR adds `multiprocess` as a dependency of `distilabel` to replace the builtin library `multiprocessing`, as the serialization is better thanks to `dill`, and works better on Jupyter Notebooks.
