### PR TITLE
Set `_batch_manager` to `None` after run

### DIFF
--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -99,6 +99,7 @@ class Pipeline(BasePipeline):
             # Wait for all the steps to be loaded correctly
             if not self._all_steps_loaded():
                 write_buffer.close()
+                self._batch_manager = None
                 raise RuntimeError(
                     "Failed to load all the steps. Could not run pipeline."
                 )
@@ -114,6 +115,7 @@ class Pipeline(BasePipeline):
             pool.join()
 
         write_buffer.close()
+        self._batch_manager = None
         return _create_dataset(self._cache_location["data"])
 
     def _output_queue_loop(self, write_buffer: "_WriteBuffer") -> None:


### PR DESCRIPTION
## Description

This PR updates the code of `Pipeline.run` to set the `_batch_manager` attribute to `None` after finishing the execution of the pipeline. This is useful for environments in which the `Pipeline` instance is going to be reused, and the `run` method is going to be called more than once. This way, every time `run` is executed a new `_BatchManager` instance is created (from cache or not depending on the `use_cache` parameter), avoiding reusing `_batch_manager` from previous calls to `run`.