### PR TITLE
Add `overload` to `step` decorator

### DIFF
--- a/src/distilabel/steps/decorator.py
+++ b/src/distilabel/steps/decorator.py
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, List, Literal, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Literal,
+    Type,
+    Union,
+    overload,
+)
 
 from pydantic import create_model
 
@@ -36,9 +45,34 @@ _STEP_MAPPING = {
     "generator": GeneratorStep,
 }
 
-ProcessingFunc = TypeVar(
-    "ProcessingFunc", bound=Callable[..., Union["StepOutput", "GeneratorStepOutput"]]
-)
+ProcessingFunc = Callable[..., Union["StepOutput", "GeneratorStepOutput"]]
+
+
+@overload
+def step(
+    inputs: Union[List[str], None] = None,
+    outputs: Union[List[str], None] = None,
+    step_type: Literal["normal"] = "normal",
+) -> Callable[..., Type["Step"]]:
+    ...
+
+
+@overload
+def step(
+    inputs: Union[List[str], None] = None,
+    outputs: Union[List[str], None] = None,
+    step_type: Literal["global"] = "global",
+) -> Callable[..., Type["GlobalStep"]]:
+    ...
+
+
+@overload
+def step(
+    inputs: None = None,
+    outputs: Union[List[str], None] = None,
+    step_type: Literal["generator"] = "generator",
+) -> Callable[..., Type["GeneratorStep"]]:
+    ...
 
 
 def step(
@@ -95,9 +129,7 @@ def step(
     inputs = inputs or []
     outputs = outputs or []
 
-    def decorator(
-        func: Callable[..., Union["StepOutput", "GeneratorStepOutput"]],
-    ) -> Type["_Step"]:
+    def decorator(func: ProcessingFunc) -> Type["_Step"]:
         if step_type not in _STEP_MAPPING:
             raise ValueError(
                 f"Invalid step type '{step_type}'. Please, review the '{func.__name__}'"


### PR DESCRIPTION
## Description

This PR adds a few `overload`s to the `step` decorator function for better type hint of the returned step.