### PR TITLE
Fix `fork` on macOS

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -12,8 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
+
 from rich.traceback import install
 
 __version__ = "1.0.0.b0"
 
 install(show_locals=True)
+
+
+# Fix for macOS fork() error because added security to restrict multithreading in macOS
+# High Sierra and later versions of macOS
+if sys.platform == "darwin":
+    os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"


### PR DESCRIPTION
## Description

This PR sets the value of the env variable `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` when `sys.platform == "darwin"` to disable a security feature that restricts multithreading in macOS High Sierra and later versions as described here: https://stackoverflow.com/questions/50168647/multiprocessing-causes-python-to-crash-and-gives-an-error-may-have-been-in-progr. This restriction was causing an error when calling `fork` system call when a pipeline was executed:

```
objc[38093]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
objc[38093]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```