### PR TITLE
Feature DSPy Module as step

### DIFF
--- a/src/distilabel/steps/task/dspy_text_generation.py
+++ b/src/distilabel/steps/task/dspy_text_generation.py
@@ -1,0 +1,48 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+import dspy
+from dspy.signatures.signature import signature_to_template
+
+from distilabel.steps.task.text_generation import TextGeneration
+from distilabel.steps.task.typing import ChatType
+
+
+class DSPyProgram(TextGeneration):
+    program: dspy.Predict
+
+    @property
+    def demos(self):
+        return self.program.demos
+
+    @property
+    def template(self):
+        return signature_to_template(self.program.signature)
+
+    def format_input(self, input: Dict[str, Any]) -> ChatType:
+        prompt = self.render_prompt(input["instruction"])
+        return [
+            {"role": "user", "content": prompt},
+        ]
+
+    def render_prompt(self, input: str) -> str:
+        example = dspy.Example(
+            **{
+                "question": input,
+            }
+        )
+        example.demos = self.demos
+        return self.template(example)


### PR DESCRIPTION
This draft PR proposes a way of using a DSPy prediction module as a text generation step. The advantage of this is that text generation could use an optimised, evaluated, prompt for generating.

# Example usage

## Make an optimised DSPy program

```python
import dspy

class CoT(dspy.Module):
    def __init__(self):
        super().__init__()
        self.prog = dspy.ChainOfThought("question -> answer")

    def forward(self, question):
        return self.prog(question=question)

cot_bs = CoT()

# https://github.com/stanfordnlp/dspy/blob/7227e7081d8edc3d0ffc2729f7c97871aa61338b/examples/math/gsm8k/turbo_8_8_10_gsm8k_200_300.json
```

# Use a DSPy module in a Distilabel pipeline

```python 

from distilabel.pipeline.local import Pipeline
from distilabel.steps.task.text_generation import TextGeneration
from distilabel.llm.openai import OpenAILLM

pipeline = Pipeline()
llm = OpenAILLM(model="gpt-3.5-turbo")
task = DSPyProgram(
    name="program",
    llm=llm,
    pipeline=pipeline,
    program=cot_bs.prog,
)

result = next(
    task.process([{"instruction": "How many fish are there in a dozen fish?"}])
)
print(result)

# Output
# [{'instruction': 'How many fish are there in a dozen fish?', 'model_name': 'gpt-3.5-turbo', 'generation': '12'}]
```