### PR TITLE
Update `_WriteBuffer` to write several parquet files

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -813,6 +813,7 @@ class _WriteBuffer:
         self._buffers: Dict[str, List[Dict[str, Any]]] = {
             step: [] for step in leaf_steps
         }
+        # TODO: make this configurable
         self._buffers_dump_batch_size: Dict[str, int] = {
             step: 50 for step in leaf_steps
         }

--- a/src/distilabel/utils/files.py
+++ b/src/distilabel/utils/files.py
@@ -1,0 +1,28 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import List
+
+
+def list_files_in_dir(dir_path: Path) -> List[Path]:
+    """List all files in a directory.
+
+    Args:
+        dir_path: Path to the directory.
+
+    Returns:
+        A list of file names in the directory.
+    """
+    return [f for f in dir_path.iterdir() if f.is_file()]

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -40,7 +40,7 @@ def get_logger(suffix: str) -> logging.Logger:
         handlers=[RichHandler()],
     )
 
-    log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO")
+    log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO").upper()
     if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
         warnings.warn(
             f"Invalid log level '{log_level}', using default 'INFO' instead.",

--- a/tests/integration/test_pipe_simple.py
+++ b/tests/integration/test_pipe_simple.py
@@ -94,7 +94,7 @@ def test_pipeline_cached():
     print()
     ds = run_pipeline()
     assert isinstance(ds, Distiset)
-    assert len(ds["generate_response"]) == 80
+    assert len(ds["generate_response"]["train"]) == 80
 
 
 if __name__ == "__main__":

--- a/tests/unit/pipeline/utils.py
+++ b/tests/unit/pipeline/utils.py
@@ -68,11 +68,15 @@ class DummyStep2(Step):
 
 
 def batch_gen(
-    step_name: str, seq_no: int = 0, last_batch: bool = False, col_name: str = "a"
+    step_name: str,
+    seq_no: int = 0,
+    last_batch: bool = False,
+    col_name: str = "a",
+    num_rows: int = 5,
 ):
     return _Batch(
         seq_no=seq_no,
         step_name=step_name,
         last_batch=last_batch,
-        data=[[{col_name: 1}, {col_name: 2}, {col_name: 3}]],
+        data=[[{col_name: i} for i in range(num_rows)]],
     )


### PR DESCRIPTION
## Description

This PR updates the `_WriteBuffer` to create several parquet files instead of just one using the `ParquetWriter`. As we're inferring the schema using the first row added to the `_WriteBuffer`, we needed to check that schema for each batch is equal to the writer schema, and if it wasn't, create a new one unifying both schemas. This required closing the `ParquetWriter` and reopening it with the new schema, but this overwrites the content of the parquet file, losing the data from previous steps.

With this new approach, we write a parquet file (`00001.parquet`, `00002.parquet`, etc) once the buffer for the step is full. The buffer will be considered to be full once the defined number of elements in the buffer is reached.