### PR TITLE
Use `QueueHandler` for `Pipeline` logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "datasets >= 2.14.0",
     "importlib-resources >= 6.1.1; python_version < '3.9'",
     "Jinja2 >= 3.1.2",
+    "multiprocess >= 0.70",
     "networkx >= 3.0",
     "pydantic >= 2.0",
     "rich >= 13.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "datasets >= 2.14.0",
     "importlib-resources >= 6.1.1; python_version < '3.9'",
     "Jinja2 >= 3.1.2",
-    "multiprocess >= 0.70",
     "networkx >= 3.0",
     "pydantic >= 2.0",
     "rich >= 13.5.0",

--- a/src/distilabel/llm/anthropic.py
+++ b/src/distilabel/llm/anthropic.py
@@ -93,6 +93,8 @@ class AnthropicLLM(AsyncLLM):
 
     def load(self) -> None:
         """Loads the `AsyncAnthropic` client to use the Anthropic async API."""
+        super().load()
+
         try:
             from anthropic import AsyncAnthropic
         except ImportError as ie:

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -70,8 +70,8 @@ class LLM(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
         per input in `inputs`."""
         pass
 
-    @cached_property
-    def generate_parameters(self) -> List[inspect.Parameter]:
+    @property
+    def generate_parameters(self) -> List["inspect.Parameter"]:
         """Returns the parameters of the `generate` method.
 
         Returns:

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -27,7 +27,6 @@ from distilabel.mixins.runtime_parameters import (
     RuntimeParametersMixin,
 )
 from distilabel.utils.docstring import parse_google_docstring
-from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import _Serializable
 
 if TYPE_CHECKING:
@@ -49,11 +48,10 @@ class LLM(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
     )
 
     _values: Dict[str, Any] = PrivateAttr(default_factory=dict)
-    _logger: logging.Logger = PrivateAttr(get_logger("llm"))
+    _logger: Union[logging.Logger, None] = PrivateAttr(...)
 
-    @abstractmethod
     def load(self) -> None:
-        pass
+        self._logger = logging.getLogger(f"llm.{self.model_name}")
 
     @property
     @abstractmethod

--- a/src/distilabel/llm/huggingface/inference_endpoints.py
+++ b/src/distilabel/llm/huggingface/inference_endpoints.py
@@ -123,6 +123,7 @@ class InferenceEndpointsLLM(AsyncLLM):
             ValueError: if the model is not currently deployed or is not running the TGI framework.
             ImportError: if the `transformers` Python client is not installed.
         """
+        super().load()
 
         try:
             from huggingface_hub import (

--- a/src/distilabel/llm/huggingface/transformers.py
+++ b/src/distilabel/llm/huggingface/transformers.py
@@ -79,6 +79,8 @@ class TransformersLLM(LLM, CudaDevicePlacementMixin):
     def load(self) -> None:
         """Loads the model and tokenizer and creates the text generation pipeline. In addition,
         it will configure the tokenizer chat template."""
+        super().load()
+
         if self.device == "cuda":
             CudaDevicePlacementMixin.load(self)
 

--- a/src/distilabel/llm/litellm.py
+++ b/src/distilabel/llm/litellm.py
@@ -43,6 +43,7 @@ class LiteLLM(AsyncLLM):
         """
         Loads the `acompletion` LiteLLM client to benefit from async requests.
         """
+        super().load()
 
         try:
             import litellm

--- a/src/distilabel/llm/llamacpp.py
+++ b/src/distilabel/llm/llamacpp.py
@@ -46,7 +46,6 @@ class LlamaCppLLM(LLM):
 
     def load(self) -> None:
         """Loads the `Llama` model from the `model_path`."""
-        super().load()
 
         try:
             from llama_cpp import Llama
@@ -61,6 +60,8 @@ class LlamaCppLLM(LLM):
             n_gpu_layers=self.n_gpu_layers,
             verbose=self.verbose,
         )
+
+        super().load()
 
     @property
     def model_name(self) -> str:

--- a/src/distilabel/llm/llamacpp.py
+++ b/src/distilabel/llm/llamacpp.py
@@ -46,6 +46,7 @@ class LlamaCppLLM(LLM):
 
     def load(self) -> None:
         """Loads the `Llama` model from the `model_path`."""
+        super().load()
 
         try:
             from llama_cpp import Llama

--- a/src/distilabel/llm/mistral.py
+++ b/src/distilabel/llm/mistral.py
@@ -61,6 +61,7 @@ class MistralLLM(AsyncLLM):
 
     def load(self) -> None:
         """Loads the `MistralAsyncClient` client to benefit from async requests."""
+        super().load()
 
         try:
             from mistralai.async_client import MistralAsyncClient

--- a/src/distilabel/llm/ollama.py
+++ b/src/distilabel/llm/ollama.py
@@ -46,6 +46,8 @@ class OllamaLLM(AsyncLLM):
 
     def load(self) -> None:
         """Loads the `AsyncClient` to use Ollama async API."""
+        super().load()
+
         try:
             from ollama import AsyncClient
 

--- a/src/distilabel/llm/openai.py
+++ b/src/distilabel/llm/openai.py
@@ -60,6 +60,7 @@ class OpenAILLM(AsyncLLM):
 
     def load(self) -> None:
         """Loads the `AsyncOpenAI` client to benefit from async requests."""
+        super().load()
 
         try:
             from openai import AsyncOpenAI

--- a/src/distilabel/llm/vertexai.py
+++ b/src/distilabel/llm/vertexai.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, List, Optional, Type
 from pydantic import PrivateAttr
 
 from distilabel.llm.base import AsyncLLM
-from distilabel.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from vertexai.generative_models import (
@@ -66,10 +65,10 @@ class VertexAILLM(AsyncLLM):
     _content_class: Optional[Type["Content"]] = PrivateAttr(...)
     _part_class: Optional[Type["Part"]] = PrivateAttr(...)
     _generation_config_class: Optional["GenerationConfig"] = PrivateAttr(...)
-    _logger = PrivateAttr(default=get_logger("llm"))
 
     def load(self) -> None:
         """Loads the `GenerativeModel` class which has access to `generate_content_async` to benefit from async requests."""
+        super().load()
 
         try:
             from vertexai.generative_models import (

--- a/src/distilabel/llm/vllm.py
+++ b/src/distilabel/llm/vllm.py
@@ -57,6 +57,8 @@ class vLLM(LLM, CudaDevicePlacementMixin):
         parse the list of OpenAI formatted inputs using the expected format by the model, otherwise, the
         default value is ChatML format, unless explicitly provided.
         """
+        super().load()
+
         CudaDevicePlacementMixin.load(self)
 
         try:

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -122,6 +122,8 @@ class BasePipeline(_Serializable):
         else:
             self._cache_dir = BASE_CACHE_DIR
 
+        self._logger = logging.getLogger("pipeline")
+
         # It's set to None here, will be created in the call to run
         self._batch_manager: Optional["_BatchManager"] = None
 

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import hashlib
+import logging
 import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -35,7 +36,6 @@ from typing_extensions import Self
 from distilabel import __version__
 from distilabel.pipeline._dag import DAG
 from distilabel.utils.files import list_files_in_dir
-from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
 
 if TYPE_CHECKING:
@@ -826,7 +826,7 @@ class _WriteBuffer:
         }
         self._buffer_last_schema = {}
         self._buffers_last_file: Dict[str, int] = {step: 1 for step in leaf_steps}
-        self._logger = get_logger("write_buffer")
+        self._logger = logging.getLogger("write_buffer")
 
     def _get_filename(self, step_name: str) -> Path:
         """Creates the filename for the step.

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -35,7 +35,7 @@ from typing_extensions import Self
 from distilabel import __version__
 from distilabel.pipeline._dag import DAG
 from distilabel.utils.files import list_files_in_dir
-from distilabel.utils.logging import get_logger
+from distilabel.utils.logging import get_logger, setup_logging
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
 
 if TYPE_CHECKING:
@@ -121,6 +121,8 @@ class BasePipeline(_Serializable):
             self._cache_dir = Path(env_cache_dir)
         else:
             self._cache_dir = BASE_CACHE_DIR
+
+        setup_logging()
 
         self._logger = get_logger("pipeline")
 

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -35,7 +35,7 @@ from typing_extensions import Self
 from distilabel import __version__
 from distilabel.pipeline._dag import DAG
 from distilabel.utils.files import list_files_in_dir
-from distilabel.utils.logging import get_logger, setup_logging
+from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
 
 if TYPE_CHECKING:
@@ -121,10 +121,6 @@ class BasePipeline(_Serializable):
             self._cache_dir = Path(env_cache_dir)
         else:
             self._cache_dir = BASE_CACHE_DIR
-
-        setup_logging()
-
-        self._logger = get_logger("pipeline")
 
         # It's set to None here, will be created in the call to run
         self._batch_manager: Optional["_BatchManager"] = None

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -72,7 +72,10 @@ class Pipeline(BasePipeline):
         Raises:
             RuntimeError: If the pipeline fails to load all the steps.
         """
-        mp.set_start_method("forkserver")
+        try:
+            mp.set_start_method("forkserver")
+        except RuntimeError:
+            pass
         log_queue = mp.Queue()
         setup_logging(log_queue)  # type: ignore
         self._logger = logging.getLogger("distilabel.pipeline.local")

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing as mp
 import signal
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
-
-import multiprocess as mp
 
 from distilabel.llm.mixins import CudaDevicePlacementMixin
 from distilabel.pipeline.base import BasePipeline, _Batch, _BatchManager, _WriteBuffer

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -72,6 +72,7 @@ class Pipeline(BasePipeline):
         Raises:
             RuntimeError: If the pipeline fails to load all the steps.
         """
+        mp.set_start_method("forkserver")
         log_queue = mp.Queue()
         setup_logging(log_queue)  # type: ignore
         self._logger = logging.getLogger("distilabel.pipeline.local")
@@ -517,7 +518,6 @@ class _ProcessWrapper:
 
         try:
             self.step.load()
-            print(f"{self.step._logger=}")
             self.step._logger.debug(f"Step '{self.step.name}' loaded!")
         except Exception as e:
             raise _ProcessWrapperException.create_load_error(str(e), self.step) from e

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import multiprocessing as mp
 import signal
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+
+import multiprocess as mp
 
 from distilabel.llm.mixins import CudaDevicePlacementMixin
 from distilabel.pipeline.base import BasePipeline, _Batch, _BatchManager, _WriteBuffer

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -24,11 +24,12 @@ from typing_extensions import Annotated
 
 from distilabel.mixins.runtime_parameters import RuntimeParametersMixin
 from distilabel.pipeline.base import BasePipeline, _GlobalPipelineManager
-from distilabel.utils.logging import get_logger
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
 from distilabel.utils.typing_ import is_parameter_annotated_with
 
 if TYPE_CHECKING:
+    from logging import Logger
+
     from distilabel.steps.typing import GeneratorStepOutput, StepOutput
 
 DEFAULT_INPUT_BATCH_SIZE = 50
@@ -99,7 +100,7 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
     output_mappings: Dict[str, str] = {}
 
     _built_from_decorator: bool = PrivateAttr(default=False)
-    _logger: logging.Logger = PrivateAttr(get_logger("steps"))
+    _logger: Union["Logger", None] = PrivateAttr(...)
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
@@ -138,7 +139,9 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
         """Method to perform any initialization logic before the `process` method is
         called. For example, to load an LLM, stablish a connection to a database, etc.
         """
-        pass
+        # self._logger = logging.getLogger(f"step.{self.name}")
+        # self._logger.info("WHY THE FUCK IS THIS NOT WORKING")
+        self._logger = logging.getLogger(f"step.{self.name}")
 
     @property
     def is_generator(self) -> bool:

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -95,6 +95,8 @@ class LoadHubDataset(GeneratorStep):
 
     def load(self) -> None:
         """Load the dataset from the Hugging Face Hub"""
+        super().load()
+
         self._dataset = load_dataset(
             self.repo_id,  # type: ignore
             self.config,

--- a/src/distilabel/steps/task/base.py
+++ b/src/distilabel/steps/task/base.py
@@ -54,6 +54,7 @@ class _Task(_Step, ABC):
 
     def load(self) -> None:
         """Loads the LLM via the `LLM.load()` method (done for safer serialization)."""
+        super().load()
         self.llm.load()
 
     @abstractmethod

--- a/src/distilabel/steps/task/generate_embeddings.py
+++ b/src/distilabel/steps/task/generate_embeddings.py
@@ -45,6 +45,8 @@ class GenerateEmbeddings(Step):
     llm: LLM
 
     def load(self) -> None:
+        """Loads the `LLM` used to generate the embeddings."""
+        super().load()
         self.llm.load()
 
     @property

--- a/src/distilabel/utils/distiset.py
+++ b/src/distilabel/utils/distiset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
 from pathlib import Path
 from typing import Optional
@@ -25,9 +26,6 @@ from distilabel.utils.card.dataset_card import (
     size_categories_parser,
 )
 from distilabel.utils.files import list_files_in_dir
-from distilabel.utils.logging import get_logger
-
-logger = get_logger("utils.distiset")
 
 
 class Distiset(dict):
@@ -166,6 +164,8 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
         The dataset created from the buffer folder, where the different leaf steps will
         correspond to different configurations of the dataset.
     """
+    logger = logging.getLogger("distiset")
+
     distiset = Distiset()
     for file in data_dir.iterdir():
         if file.is_file():

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -34,7 +34,6 @@ def setup_logging(log_queue: "Queue[Any]") -> None:
     # If the current process is the main process, set up a `QueueListener`
     # to handle logs from all subprocesses
     if mp.current_process().name == "MainProcess":
-        print(f"SETTING UP QUEUE LISTENER {mp.current_process().name=}")
         # Only in the main process, set up a listener to handle logs from the queue
         handlers = [RichHandler(rich_tracebacks=True)]
         queue_listener = QueueListener(log_queue, *handlers, respect_handler_level=True)

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -31,6 +31,7 @@ def setup_logging(log_queue: "Queue[Any]") -> None:
     # Disable overly verbose loggers
     logging.getLogger("argilla.client.feedback.dataset.local.mixins").disabled = True
     logging.getLogger("datasets").setLevel(logging.CRITICAL)
+    logging.getLogger("httpx").setLevel(logging.CRITICAL)
 
     # If the current process is the main process, set up a `QueueListener`
     # to handle logs from all subprocesses

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -14,6 +14,8 @@
 
 import logging
 import multiprocessing as mp
+import os
+import warnings
 from logging.handlers import QueueHandler, QueueListener
 from typing import TYPE_CHECKING, Any
 
@@ -29,7 +31,6 @@ def setup_logging(log_queue: "Queue[Any]") -> None:
     # Disable overly verbose loggers
     logging.getLogger("argilla.client.feedback.dataset.local.mixins").disabled = True
     logging.getLogger("datasets").setLevel(logging.CRITICAL)
-    logging.getLogger("httpx").setLevel(logging.CRITICAL)
 
     # If the current process is the main process, set up a `QueueListener`
     # to handle logs from all subprocesses
@@ -39,14 +40,14 @@ def setup_logging(log_queue: "Queue[Any]") -> None:
         queue_listener = QueueListener(log_queue, *handlers, respect_handler_level=True)
         queue_listener.start()
 
-    # $ log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO").upper()
-    # $ if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
-    # $     warnings.warn(
-    # $         f"Invalid log level '{log_level}', using default 'INFO' instead.",
-    # $         stacklevel=2,
-    # $     )
-    # $     log_level = "INFO"
+    log_level = os.environ.get("DISTILABEL_LOG_LEVEL", "INFO").upper()
+    if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        warnings.warn(
+            f"Invalid log level '{log_level}', using default 'INFO' instead.",
+            stacklevel=2,
+        )
+        log_level = "INFO"
 
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(log_level)
     root_logger.addHandler(QueueHandler(log_queue))

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import logging
+import multiprocessing as mp
 import os
 import warnings
 from logging.handlers import QueueHandler, QueueListener
 from typing import TYPE_CHECKING, Any
 
-import multiprocess as mp
 from rich.logging import RichHandler
 
 if TYPE_CHECKING:

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import logging
-import multiprocessing as mp
 import os
 import warnings
 from logging.handlers import QueueHandler, QueueListener
 from typing import TYPE_CHECKING, Any
 
+import multiprocess as mp
 from rich.logging import RichHandler
 
 if TYPE_CHECKING:

--- a/tests/unit/llm/test_mixins.py
+++ b/tests/unit/llm/test_mixins.py
@@ -40,6 +40,7 @@ def mock_pynvml() -> Generator[None, None, None]:
 
 class DummyCudaLLM(LLM, CudaDevicePlacementMixin):
     def load(self) -> None:
+        super().load()
         CudaDevicePlacementMixin.load(self)
 
     @property

--- a/tests/unit/steps/task/evol_instruct/test_base.py
+++ b/tests/unit/steps/task/evol_instruct/test_base.py
@@ -59,6 +59,7 @@ class TestEvolInstruct:
         task = EvolInstruct(
             name="task", llm=dummy_llm, num_evolutions=2, pipeline=pipeline
         )
+        task.load()
         assert list(task.process([{"instruction": "test"}])) == [
             [
                 {
@@ -78,6 +79,7 @@ class TestEvolInstruct:
             store_evolutions=True,
             pipeline=pipeline,
         )
+        task.load()
         assert list(task.process([{"instruction": "test"}])) == [
             [
                 {
@@ -97,6 +99,7 @@ class TestEvolInstruct:
             generate_answers=True,
             pipeline=pipeline,
         )
+        task.load()
         assert list(task.process([{"instruction": "test"}])) == [
             [
                 {
@@ -113,9 +116,7 @@ class TestEvolInstruct:
         task = EvolInstruct(
             name="task", llm=dummy_llm, num_evolutions=2, pipeline=pipeline
         )
-        import json
-
-        print(json.dumps(task.dump(), indent=2))
+        task.load()
         assert task.dump() == {
             "name": "task",
             "input_mappings": task.input_mappings,

--- a/tests/unit/steps/task/evol_instruct/test_generator.py
+++ b/tests/unit/steps/task/evol_instruct/test_generator.py
@@ -66,6 +66,7 @@ class TestEvolInstructGenerator:
             max_length=10,
             pipeline=pipeline,
         )
+        task.load()
         assert list(task.process()) == [
             (
                 [
@@ -89,6 +90,7 @@ class TestEvolInstructGenerator:
             generate_answers=True,
             pipeline=pipeline,
         )
+        task.load()
         assert list(task.process()) == [
             (
                 [
@@ -107,6 +109,7 @@ class TestEvolInstructGenerator:
         task = EvolInstructGenerator(
             name="task", llm=dummy_llm, num_instructions=2, pipeline=pipeline
         )
+        task.load()
 
         assert task.dump() == {
             "name": "task",

--- a/tests/unit/steps/task/evol_quality/test_base.py
+++ b/tests/unit/steps/task/evol_quality/test_base.py
@@ -37,6 +37,7 @@ class TestEvoQuality:
         task = EvolQuality(
             name="task", llm=dummy_llm, num_evolutions=2, pipeline=pipeline
         )
+        task.load()
         assert list(task.process([{"instruction": "test", "response": "mock"}])) == [
             [
                 {
@@ -57,6 +58,7 @@ class TestEvoQuality:
             store_evolutions=True,
             pipeline=pipeline,
         )
+        task.load()
         assert list(task.process([{"instruction": "test", "response": "mock"}])) == [
             [
                 {
@@ -73,6 +75,7 @@ class TestEvoQuality:
         task = EvolQuality(
             name="task", llm=dummy_llm, num_evolutions=2, pipeline=pipeline
         )
+        task.load()
         assert task.dump() == {
             "name": "task",
             "input_mappings": task.input_mappings,


### PR DESCRIPTION
## Description

This PR updates the logging setup for the local `Pipeline` to use a `QueueHandler` and a `QueueListener` (a thread in the main process). With this setup, child processes send log messages using a `multiprocessing.Queue` and the `QueueHandler` to the `QueueListener`, which will be in charge of handling the log messages.

This change was mainly motivated to improve the logging messages in environments like Google Colab and IPython Notebooks, in which not all the logging messages (from the child processes) were being displayed.

<img width="883" alt="image" src="https://github.com/argilla-io/distilabel/assets/29572918/cf56a712-97f7-4c3c-af69-d5a67a078be9">
