### PR TITLE
Fix creating empty `Dataset` in `create_distiset` function

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -122,7 +122,7 @@ class BasePipeline(_Serializable):
         else:
             self._cache_dir = BASE_CACHE_DIR
 
-        self._logger = logging.getLogger("pipeline")
+        self._logger = logging.getLogger("distilabel.pipeline")
 
         # It's set to None here, will be created in the call to run
         self._batch_manager: Optional["_BatchManager"] = None
@@ -828,7 +828,7 @@ class _WriteBuffer:
         }
         self._buffer_last_schema = {}
         self._buffers_last_file: Dict[str, int] = {step: 1 for step in leaf_steps}
-        self._logger = logging.getLogger("write_buffer")
+        self._logger = logging.getLogger("distilabel.write_buffer")
 
     def _get_filename(self, step_name: str) -> Path:
         """Creates the filename for the step.

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -139,9 +139,7 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
         """Method to perform any initialization logic before the `process` method is
         called. For example, to load an LLM, stablish a connection to a database, etc.
         """
-        # self._logger = logging.getLogger(f"step.{self.name}")
-        # self._logger.info("WHY THE FUCK IS THIS NOT WORKING")
-        self._logger = logging.getLogger(f"step.{self.name}")
+        self._logger = logging.getLogger(f"distilabel.step.{self.name}")
 
     @property
     def is_generator(self) -> bool:

--- a/src/distilabel/utils/distiset.py
+++ b/src/distilabel/utils/distiset.py
@@ -172,7 +172,7 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
             continue
 
         try:
-            files = list_files_in_dir(file)
+            files = [str(file) for file in list_files_in_dir(file)]
             if files:
                 distiset[file.stem] = load_dataset(
                     "parquet", name=file.stem, data_files={"train": files}

--- a/src/distilabel/utils/distiset.py
+++ b/src/distilabel/utils/distiset.py
@@ -164,7 +164,7 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
         The dataset created from the buffer folder, where the different leaf steps will
         correspond to different configurations of the dataset.
     """
-    logger = logging.getLogger("distiset")
+    logger = logging.getLogger("distilabel.distiset")
 
     distiset = Distiset()
     for file in data_dir.iterdir():
@@ -172,11 +172,16 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
             continue
 
         try:
-            distiset[file.stem] = load_dataset(
-                "parquet",
-                name=file.stem,
-                data_files={"train": [str(f) for f in list_files_in_dir(file)]},
-            )
+            files = list_files_in_dir(file)
+            if files:
+                distiset[file.stem] = load_dataset(
+                    "parquet", name=file.stem, data_files={"train": files}
+                )
+            else:
+                logger.warning(
+                    f"No output files for step '{file.stem}', can't create a dataset."
+                    " Did the step produce any data?"
+                )
         except ArrowInvalid:
             logger.warning(f"❌ Failed to load the subset from '{file}' directory.")
             continue

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -17,7 +17,7 @@ import multiprocessing as mp
 import os
 import warnings
 from logging.handlers import QueueHandler, QueueListener
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from rich.logging import RichHandler
 
@@ -37,9 +37,12 @@ _SILENT_LOGGERS = [
     "asyncio",
 ]
 
+queue_listener: Union[QueueListener, None] = None
+
 
 def setup_logging(log_queue: "Queue[Any]") -> None:
     """Sets up logging to use a queue across all processes."""
+    global queue_listener
 
     # Disable overly verbose loggers
     logging.getLogger("argilla.client.feedback.dataset.local.mixins").disabled = True
@@ -66,3 +69,11 @@ def setup_logging(log_queue: "Queue[Any]") -> None:
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
     root_logger.addHandler(QueueHandler(log_queue))
+
+
+def stop_logging() -> None:
+    """Stops the `QueueListener` if it's running."""
+    global queue_listener
+    if queue_listener is not None:
+        queue_listener.stop()
+        queue_listener = None


### PR DESCRIPTION
## Description

When calling the `create_distiset` function and there were no output files from a step, `load_dataset` would raise an error because it cannot create an empty dataset. This PR updates the code so it first checks if there are files to create the dataset, and if there isn't any then warns the user.

In addition, this PR updates the logging setup to stop the `QueueListener` after running the pipeline.