### PR TITLE
Draw Pipeline DAG using graphviz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,9 @@ jobs:
           python_version=$(python -c "import sys; print(sys.version_info[:2])")
 
           if [ "${python_version}" != "(3, 8)" ]; then
-            pip install -e .[dev,tests,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,mistralai,llama-cpp,anthropic,litellm]
+            pip install -e .[dev,tests,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,mistralai,llama-cpp,anthropic,litellm,graphviz]
           else
-            pip install -e .[dev,tests,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,llama-cpp,anthropic,litellm]
+            pip install -e .[dev,tests,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,llama-cpp,anthropic,litellm,graphviz]
           fi
           pip install git+https://github.com/yuchenlin/LLM-Blender.git@3c2d71f
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ tests = ["pytest >= 7.4.0", "pytest-asyncio", "nest-asyncio"]
 together = ["together"]
 vllm = ["vllm >= 0.2.1"]
 vertexai = ["google-cloud-aiplatform >= 1.38.0"]
+graphviz = ["graphviz >= 0.20.3"]
 
 [project.urls]
 Documentation = "https://distilabel.argilla.io/"

--- a/src/distilabel/mixins/graph_viz.py
+++ b/src/distilabel/mixins/graph_viz.py
@@ -1,0 +1,184 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import graphviz
+except ImportError as e:
+    raise ImportError(
+        "graphviz is not installed. Please install it using"
+        " `pip install graphviz`, and follow the instructions at:"
+        " https://graphviz.readthedocs.io/en/stable/manual.html#installation"
+    ) from e
+
+import textwrap
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class GraphvizMixin:
+    """Mixin for `BasePipeline` to visualize the underlying `DAG` graph using `graphviz`.
+
+    Attributes:
+        _dot: The `graphviz.Digraph` object to store the graph visualization.
+    """
+
+    _dot: Optional[graphviz.Digraph] = None
+    # The filename will be used in case we want to find the easily afterwards
+    _graph_filename: Optional[str] = None
+
+    def create_graphviz(self) -> None:
+        """Creates a graph visualization of the pipeline."""
+        self._dot = graphviz.Digraph(comment=self.name, filename=self.name, strict=True)
+
+        def label_info(step):
+            # Extracts the relevant info from the step to be used as a label
+            not_required = {
+                "name",
+                "input_mappings",
+                "output_mappings",
+                "type_info",
+                "runtime_parameters_info",
+            }
+            dump = step.dump()
+            # More info in the '\l': https://graphviz.org/docs/attrs/nojustify/
+            name = dump.pop("name") + r"\l"
+            for key in not_required:
+                dump.pop(key, None)
+
+            params = ""
+            for key, value in dump.items():
+                # If the step is an LLM, get just the model name to avoid long strings,
+                # otherwise, shorten the string to 30 characters max.
+                value = (
+                    step.llm.model_name
+                    if key == "llm"
+                    else textwrap.shorten(str(value), width=30)
+                )
+                params += rf"    - {key}: {value}\l"
+
+            return name + "".join(params)
+
+        # Import here to avoid circular imports
+        from distilabel.steps.base import GeneratorStep, GlobalStep
+        from distilabel.steps.task.base import Task
+
+        def get_fillcolor(step):
+            # Use different colors depending on the type of Step
+            if isinstance(step, Task):
+                return "#fff0f6"
+            if isinstance(step, GlobalStep):
+                return "#e3fafc"
+            if isinstance(step, GeneratorStep):
+                return "#f3f0ff"
+            return "#fff5f5"
+
+        prepare_label = True
+        for node_name in self.dag:
+            step = self.dag.get_step(node_name)["step"]
+            label = label_info(step) if prepare_label else node_name
+            self._dot.node(
+                node_name,
+                label=label,
+                style="rounded,filled",
+                fillcolor=get_fillcolor(step),
+                nojustify="true",
+            )
+
+        for edge_tail, edge_head in self.dag.G.edges:
+            self._dot.edge(edge_tail, edge_head, constraint="true")
+
+    def apply_visualization_style(
+        self,
+        graph_attrs: Optional[Dict[str, str]] = None,
+        node_attrs: Optional[Dict[str, str]] = None,
+        edge_attrs: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Applies the visualization style to the graph.
+
+        Args:
+            graph_attrs: The attributes to apply to the graph.
+            node_attrs: The attributes to apply to the nodes.
+            edge_attrs: The attributes to apply to the edges.
+        """
+
+        if graph_attrs is not None:
+            self._dot.graph_attr.update(**graph_attrs)
+        else:
+            self._dot.graph_attr.update(
+                {
+                    # Sets the direction from Top to Bottom
+                    "rankdir": "TB",
+                    "splines": "ortho",
+                    # The name of the Pipeline that will be shown on the top of the graph
+                    "label": self.name,
+                    "pad": "2.0",
+                    "nodesep": "0.60",
+                    "ranksep": "0.5",
+                    "fontname": "Sans-Serif",
+                    "fontsize": "20",
+                    "fontcolor": "#2D3436",
+                    "labelloc": "t",
+                }
+            )
+        if node_attrs is not None:
+            self._dot.node_attr.update(**node_attrs)
+        else:
+            self._dot.node_attr.update(
+                {
+                    "shape": "box",
+                    "fixedsize": "false",
+                    "width": "0.4",
+                    "height": "0.25",
+                    "labelloc": "c",
+                    "imagescale": "true",
+                    "fontname": "Sans-Serif",
+                    "fontsize": "13",
+                    "fontcolor": "#000000",
+                }
+            )
+        if edge_attrs is not None:
+            self._dot.edge_attr.update(**edge_attrs)
+        else:
+            self._dot.edge_attr.update(
+                {
+                    "color": "#999999",
+                }
+            )
+
+    def render(
+        self, view: bool = False, format_: str = "png", cleanup: bool = True
+    ) -> None:
+        """Creates the graph and saves it to a file.
+
+        Args:
+            view: Whether to automatically open the file. Defaults to False.
+            format_: File format of the rendered graph. Defaults to "png".
+            cleanup: Whether to remove the files created in the folder other than the figure.
+                Defaults to True.
+        """
+        # NOTE: Should we allow the user to specify the path?
+        if self._dot is None:
+            self.create_graphviz()
+            self.apply_visualization_style()
+        formatted_name = self.name.replace(" ", "_")
+        # Write the file to the cache location
+        self._graph_filename = (
+            self._cache_location["pipeline"].parent
+            / f"distilabel-dag-graph/{formatted_name}"
+        )
+        self._dot.render(self._graph_filename, view=view, format=format_)
+        if cleanup:
+            for file in Path(self._graph_filename).parent.iterdir():
+                if file.name != f"{formatted_name}.{format_}":
+                    file.unlink()

--- a/src/distilabel/mixins/graph_viz.py
+++ b/src/distilabel/mixins/graph_viz.py
@@ -122,7 +122,7 @@ class GraphvizMixin:
                     "splines": "ortho",
                     # The name of the Pipeline that will be shown on the top of the graph
                     "label": self.name,
-                    "pad": "2.0",
+                    "pad": "0.5",
                     "nodesep": "0.60",
                     "ranksep": "0.5",
                     "fontname": "Sans-Serif",

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -34,6 +34,7 @@ import pyarrow.parquet as pq
 from typing_extensions import Self
 
 from distilabel import __version__
+from distilabel.mixins.graph_viz import GraphvizMixin
 from distilabel.pipeline._dag import DAG
 from distilabel.utils.files import list_files_in_dir
 from distilabel.utils.serialization import TYPE_INFO_KEY, _Serializable
@@ -85,7 +86,7 @@ class _GlobalPipelineManager:
         return cls._context_global_pipeline
 
 
-class BasePipeline(_Serializable):
+class BasePipeline(GraphvizMixin, _Serializable):
     """Base class for a `distilabel` pipeline.
 
     Attributes:

--- a/src/distilabel/steps/rename.py
+++ b/src/distilabel/steps/rename.py
@@ -1,0 +1,62 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Generator, List
+
+from distilabel.mixins.runtime_parameters import RuntimeParameter
+from distilabel.steps.base import Step, StepInput
+
+
+class RenameColumns(Step):
+    """RenameColumns is a Step that implements the `process` method that renames the columns
+    specified in the `rename_mappings` attribute. This can be handy if a dataset has a column
+    named differently than expected by the downstream tasks.
+
+    Args:
+        rename_mappings: Dict from str (original column) to str (new column).
+
+    Input columns:
+        - dynamic, based on the `rename_mappings` value provided.
+
+    Output columns:
+        - dynamic, based on the `rename_mappings` value provided.
+    """
+
+    rename_mappings: RuntimeParameter[Dict[str, str]]
+
+    @property
+    def inputs(self) -> List[str]:
+        """There are no inputs."""
+        return []
+
+    @property
+    def outputs(self) -> List[str]:
+        """The outputs for the task are the column names in `rename_mappings` values."""
+        return list(self.rename_mappings.values())  # type: ignore
+
+    def process(self, inputs: StepInput) -> Generator[List[Dict[str, Any]], None, None]:
+        """The `process` method keeps only the columns specified in the `columns` attribute.
+
+        Args:
+            inputs: A dictionary with the columns to update.
+
+        Yields:
+            A list of dictionaries with the output data.
+        """
+        outputs = []
+        for input in inputs:
+            outputs.append(
+                {self.rename_mappings.get(k, k): v for k, v in input.items()}  # type: ignore
+            )
+        yield outputs


### PR DESCRIPTION
## Description

This PR adds a mixin class to draw the `DAG` of the pipelines.

Also, it includes `RenameColumns` step as it is useful enough as to keep it as a module.

An example for the following pipeline:

```python
from distilabel.pipeline.local import Pipeline
from distilabel.steps.generators.huggingface import LoadHubDataset
from distilabel.steps.combine import CombineColumns
from distilabel.steps.rename import RenameColumns
from distilabel.steps.task.evol_instruct.base import EvolInstruct
from distilabel.llm.openai import OpenAILLM
from distilabel.llm.huggingface.inference_endpoints import InferenceEndpointsLLM
from distilabel.steps.task.pair_rm import PairRM


if __name__ == "__main__":
    with Pipeline(name="PairRM pipe") as pipeline:
        load_hub_dataset = LoadHubDataset(name="load_dataset", batch_size=8)
        rename_columns = RenameColumns(
            name="rename_columns",
            rename_mappings={"prompt": "instruction"},
            input_batch_size=12,
        )
        evol_instruction_complexity_1 = EvolInstruct(
            name="evol_complexity_openai",
            llm=OpenAILLM(model="gpt-3.5-turbo"),
            num_evolutions=5,
            store_evolutions=True,
            generate_answers=True,
            include_original_instruction=True,
        )
        evol_instruction_complexity_2 = EvolInstruct(
            name="evol_complexity_huggingface",
            llm=InferenceEndpointsLLM(model_id="mistralai/Mixtral-8x7B-Instruct-v0.1"),
            num_evolutions=5,
            store_evolutions=True,
            generate_answers=True,
            include_original_instruction=True,
        )
    
        load_hub_dataset.connect(rename_columns)
        rename_columns.connect(evol_instruction_complexity_1)
        rename_columns.connect(evol_instruction_complexity_2)

        # Will combine the outputs from the different LLMs (the candidates to rank)
        combine_columns = CombineColumns(
            name="combine_columns",
            columns=["response"],
            output_columns=["candidates"],
        )
        
        evol_instruction_complexity_1.connect(combine_columns)
        evol_instruction_complexity_2.connect(combine_columns)

        # Prepares the column names to the name expected from `PairRM`
        rename_for_pairrm = RenameColumns(
            name="rename_for_pairrm",
            input_batch_size=12,
        )
        combine_columns.connect(rename_for_pairrm)

        ranker = PairRM(name="pair_rm_ranker")
        rename_for_pairrm.connect(ranker)

    pipeline.render(view=True)
```

Can be seen at the following figure:
![PairRM_pipe](https://github.com/argilla-io/distilabel/assets/56895847/c1982342-e5dc-43e1-a0ee-59a018193f85)

There are certain "style" decisions that can be discussed if we want to include this:
- Currently it uses a different (random) color depending on the type of step (`GeneratorStep`, `GlobalStep`, `Task` or plain `Step`).
- Certain number of arguments are removed to simplify visualization of the nodes (steps) in the figure.
- Arguments are capped to 30 characters to keep the nodes relatively small.
- The figure could be optionally included when we push a `Distiset` to the hub, so it can be shown in the dataset card.
- The figure is saved in the same cache directory by default.