### PR TITLE
Added authentication header to allow private/gated dataset use

### DIFF
--- a/src/distilabel/cli/pipeline/utils.py
+++ b/src/distilabel/cli/pipeline/utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
-import os
 
 import requests
 import yaml

--- a/src/distilabel/cli/pipeline/utils.py
+++ b/src/distilabel/cli/pipeline/utils.py
@@ -14,6 +14,7 @@
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+import os
 
 import requests
 import yaml
@@ -87,8 +88,11 @@ def get_config_from_url(url: str) -> Dict[str, Any]:
         raise ValueError(
             f"Unsupported file format for '{url}'. Only JSON and YAML are supported"
         )
-
-    response = requests.get(url)
+    if "huggingface.co" in url and "HF_TOKEN" in os.environ:
+        headers = {"Authorization": f"Bearer {os.environ['HF_TOKEN']}"}
+    else:
+        headers = None
+    response = requests.get(url, headers=headers)
     response.raise_for_status()
 
     if url.endswith((".yaml", ".yml")):

--- a/src/distilabel/steps/argilla/base.py
+++ b/src/distilabel/steps/argilla/base.py
@@ -79,7 +79,15 @@ class Argilla(Step, ABC):
     def _rg_init(self) -> None:
         """Initializes the Argilla API client with the provided `api_url` and `api_key`."""
         try:
-            rg.init(api_url=self.api_url, api_key=self.api_key.get_secret_value())  # type: ignore
+            if "hf.space" in self.api_url and "HF_TOKEN" in os.environ:
+                headers = {"Authorization": f"Bearer {os.environ['HF_TOKEN']}"}
+            else:
+                headers = None
+            rg.init(
+                api_url=self.api_url,
+                api_key=self.api_key.get_secret_value(),
+                extra_headers=headers,
+            )  # type: ignore
         except Exception as e:
             raise ValueError(f"Failed to initialize the Argilla API: {e}") from e
 

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -46,11 +47,18 @@ def _get_hf_dataset_info(
     if config is not None:
         params["config"] = config
 
+    if "HF_TOKEN" in os.environ:
+        headers = {"Authorization": f"Bearer {os.environ['HF_TOKEN']}"}
+    else:
+        headers = None
+
     response = requests.get(
-        "https://datasets-server.huggingface.co/info", params=params
+        "https://datasets-server.huggingface.co/info", params=params, headers=headers
     )
 
-    assert response.status_code == 200, f"Failed to get '{repo_id}' dataset info."
+    assert (
+        response.status_code == 200
+    ), f"Failed to get '{repo_id}' dataset info. Make sure you have set the HF_TOKEN environment variable if it is a private dataset."
 
     return response.json()["dataset_info"]
 


### PR DESCRIPTION
Before, I would receive a `Failed to get '{repo_id}' dataset info.` error when attempting to load a gated dataset. Now, this uses the `HF_TOKEN` env variable.

Probably there's a more principled way that would use the `HF_TOKEN` saved in the `HF_HOME` directory after calling `huggingface-cli login` if the `HF_TOKEN` env variable is not set. 