### PR TITLE
Fix `asyncio` in `AsyncLLM` to use the running event loop if any

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "importlib-resources >= 6.1.1; python_version < '3.9'",
     "Jinja2 >= 3.1.2",
     "multiprocess >= 0.70",
+    "nest-asyncio >= 1.6.0",
     "networkx >= 3.0",
     "pydantic >= 2.0",
     "rich >= 13.5.0",

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -27,7 +27,7 @@ from distilabel.mixins.runtime_parameters import (
     RuntimeParametersMixin,
 )
 from distilabel.utils.docstring import parse_google_docstring
-from distilabel.utils.notebook import is_notebook
+from distilabel.utils.notebook import in_notebook
 from distilabel.utils.serialization import _Serializable
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from distilabel.utils.docstring import Docstring
 
 
-if is_notebook():
+if in_notebook():
     import nest_asyncio
 
     nest_asyncio.apply()

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -217,9 +217,14 @@ class AsyncLLM(LLM):
 
     @property
     def event_loop(self) -> "asyncio.AbstractEventLoop":
-        if self._event_loop is None or self._event_loop.is_closed():
-            self._event_loop = asyncio.new_event_loop()  # type: ignore
-            asyncio.set_event_loop(self._event_loop)
+        if self._event_loop is None:
+            try:
+                self._event_loop = asyncio.get_running_loop()
+                if self._event_loop.is_closed():
+                    self._event_loop = asyncio.new_event_loop()  # type: ignore
+            except RuntimeError:
+                self._event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._event_loop)
         return self._event_loop
 
     @abstractmethod

--- a/src/distilabel/llm/base.py
+++ b/src/distilabel/llm/base.py
@@ -27,6 +27,7 @@ from distilabel.mixins.runtime_parameters import (
     RuntimeParametersMixin,
 )
 from distilabel.utils.docstring import parse_google_docstring
+from distilabel.utils.notebook import is_notebook
 from distilabel.utils.serialization import _Serializable
 
 if TYPE_CHECKING:
@@ -34,6 +35,12 @@ if TYPE_CHECKING:
     from distilabel.mixins.runtime_parameters import RuntimeParametersNames
     from distilabel.steps.task.typing import ChatType
     from distilabel.utils.docstring import Docstring
+
+
+if is_notebook():
+    import nest_asyncio
+
+    nest_asyncio.apply()
 
 
 class LLM(RuntimeParametersMixin, BaseModel, _Serializable, ABC):

--- a/src/distilabel/utils/notebook.py
+++ b/src/distilabel/utils/notebook.py
@@ -1,0 +1,36 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def in_notebook() -> bool:
+    """Checks if the current code is being executed from a Jupyter Notebook.
+    This is useful for better handling the `asyncio` events under `nest_asyncio`,
+    as Jupyter Notebook runs a separate event loop.
+
+    Returns:
+        Whether the current code is being executed from a Jupyter Notebook.
+
+    References:
+        - https://stackoverflow.com/a/22424821
+    """
+    try:
+        from IPython import get_ipython
+
+        if "IPKernelApp" not in get_ipython().config:  # pragma: no cover
+            return False
+    except ImportError:
+        return False
+    except AttributeError:
+        return False
+    return True


### PR DESCRIPTION
## Description

This PR adds a hot-fix for the `AsyncLLM` class and subclasses, since the `event_loop` is always created, but in Colab there's already an active running event loop, so that should be reused, otherwise the `AsyncLLM` subclasses or any other `asyncio` code creating `event_loop`s will fail in Colab with the following exception `RuntimeError: Cannot run the event loop while another loop is running`.

On top of that, an utils function named `in_notebook` has been included so as to identify whether the code is running in a notebook, and if so, use `nest-asyncio` so as to be able to successfully use `asyncio`.

Thanks @burtenshaw for reporting and @gabrielmbmb for the hints!