### PR TITLE
Fix generator yielding batches all at once if `batch_size` == `input_batch_size`

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -675,19 +675,12 @@ class _BatchManager(_Serializable):
     def get_last_batch(self, step_name: str) -> Union[_Batch, None]:
         return self._last_batch_received.get(step_name)
 
-    def add_batch(self, to_step: str, batch: _Batch) -> Union[_Batch, None]:
-        """Add an output batch from `batch.step_name` to `to_step`. If there is enough
-        data for creating a `_Batch` for `to_step`, then it will return the batch to be
-        processed. Otherwise, it will return `None`.
+    def add_batch(self, to_step: str, batch: _Batch) -> None:
+        """Add an output batch from `batch.step_name` to `to_step`.
 
         Args:
             to_step: The name of the step that will process the batch.
             batch: The output batch of an step to be processed by `to_step`.
-            callback: A callback to be called after the batch is added.
-
-        Returns:
-            If there is enough data for creating a batch for `to_step`, then it will return
-            the batch to be processed. Otherwise, it will return `None`.
 
         Raises:
             ValueError: If `to_step` is not found in the batch manager.
@@ -697,7 +690,6 @@ class _BatchManager(_Serializable):
 
         step = self._steps[to_step]
         step.add_batch(batch)
-        return step.get_batch()
 
     def get_batch(self, step_name: str) -> Union[_Batch, None]:
         """Get the next batch to be processed by the step.

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -318,6 +318,7 @@ class BasePipeline(_Serializable):
                 self._cache_location["batch_manager"],
                 format=self._cache_location["batch_manager"].suffix.replace(".", ""),
             )
+        self._logger.debug("Pipeline and batch manager saved to cache.")
 
     def _load_from_cache(self) -> None:
         """Will try to load the `BasePipeline` from the cache dir if found, updating
@@ -888,7 +889,7 @@ class _WriteBuffer:
         data = batch.data[0]
         self._buffers[step_name].extend(data)
         self._logger.debug(
-            f"Added batch to buffer for step '{step_name}' with {len(data)} rows."
+            f"Added batch to write buffer for step '{step_name}' with {len(data)} rows."
         )
         if self.is_full(step_name):
             self._logger.debug(

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -153,31 +153,14 @@ class Pipeline(BasePipeline):
                 break
 
             self._logger.debug(
-                f"Received {batch.seq_no} from step '{batch.step_name}' from output"
-                f" queue: {batch}"
+                f"Received batch with seq_no {batch.seq_no} from step '{batch.step_name}'"
+                f" from output queue: {batch}"
             )
 
             self._manage_batch_flow(batch)
 
             if batch.step_name in self.dag.leaf_steps:
                 write_buffer.add_batch(batch.step_name, batch)
-
-    def _add_batch_to_batch_manager(self, batch: "_Batch") -> None:
-        """Registers the batch in the `_BatchManager` and adds the batch to input buffer
-        of the successors steps from the step that generated the batch. If there's enough
-        data for creating a batch for a successor step, then the batch is created and sent
-        to that step.
-
-        Args:
-            batch: The batch to add to the `_BatchManager`.
-        """
-        assert self._batch_manager, "Batch manager is not set"
-
-        self._batch_manager.register_batch(batch)
-        for to_step in self.dag.get_step_successors(batch.step_name):
-            if new_batch := self._batch_manager.add_batch(to_step, batch):
-                self._send_batch_to_step(new_batch)
-        self._cache()
 
     def _manage_batch_flow(self, batch: "_Batch") -> None:
         """Checks if the step that generated the batch has more data in its buffer to
@@ -192,14 +175,10 @@ class Pipeline(BasePipeline):
 
         self._batch_manager.register_batch(batch)
 
-        if batch.last_batch:
-            return
-
         step: "Step" = self.dag.get_step(batch.step_name)["step"]
 
         for successor in self.dag.get_step_successors(step.name):
             self._batch_manager.add_batch(successor, batch)
-            self._cache()
 
             # Check if the step is a generator and if there are successors that need data
             # from this step. This usually happens when the generator `batch_size` is smaller
@@ -217,16 +196,13 @@ class Pipeline(BasePipeline):
         if step.is_generator:
             return
 
-        empty_buffers = self._batch_manager.step_empty_buffers(step.name)
-
-        # Step has data in its buffers, send a new batch
-        if not empty_buffers and (
-            next_batch := self._batch_manager.get_batch(step.name)
-        ):
+        # Step has enough data on its buffers to create a new batch
+        if next_batch := self._batch_manager.get_batch(step.name):
             self._send_batch_to_step(next_batch)
             return
 
         # Request more batches to the predecessors generator steps
+        empty_buffers = self._batch_manager.step_empty_buffers(step.name)
         for previous_step_name in empty_buffers:
             if previous_step_name not in self.dag.root_steps:
                 continue
@@ -237,6 +213,8 @@ class Pipeline(BasePipeline):
                     " empty. Requesting new batch..."
                 )
                 self._send_batch_to_step(last_batch.next_batch())
+
+        self._cache()
 
     def _create_shared_info_dict(self, manager: "SyncManager") -> "DictProxy[str, Any]":
         """Creates the shared information dictionary to be used by the processes.

--- a/src/distilabel/steps/generators/data.py
+++ b/src/distilabel/steps/generators/data.py
@@ -28,11 +28,7 @@ class LoadDataFromDicts(GeneratorStep):
     This step will load the dataset and yield the transformed data as it is loaded from the list of dictionaries.
 
     Runtime parameters:
-
-    - `batch_size`: The batch size to use when processing the data.
-
-    Input columns:
-        None
+        - `batch_size`: The batch size to use when processing the data.
 
     Output columns:
         Dynamic, based on the keys found on the first dictionary of the list
@@ -45,10 +41,11 @@ class LoadDataFromDicts(GeneratorStep):
         """Yields batches from a list of dictionaries.
 
         Args:
-            offset: The offset to start the generation from. Defaults to 0.
+            offset: The offset to start the generation from. Defaults to `0`.
 
         Yields:
-            A list of Python dictionaries as read from the inputs (propagated in batches) and a flag indicating whether the yield batch is the last one.
+            A list of Python dictionaries as read from the inputs (propagated in batches)
+            and a flag indicating whether the yield batch is the last one.
         """
         if offset:
             self.data = self.data[offset:]

--- a/tests/integration/test_pipe_simple.py
+++ b/tests/integration/test_pipe_simple.py
@@ -18,7 +18,90 @@ from distilabel.distiset import Distiset
 from distilabel.mixins.runtime_parameters import RuntimeParameter
 from distilabel.pipeline.local import Pipeline
 from distilabel.steps.base import Step, StepInput
-from distilabel.steps.generators.huggingface import LoadHubDataset
+from distilabel.steps.generators.data import LoadDataFromDicts
+
+DATA = [
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+    {"prompt": "Tell me a joke"},
+    {"prompt": "Write a short haiku"},
+    {"prompt": "Translate 'My name is Alvaro' to Spanish"},
+    {"prompt": "What's the capital of Spain?"},
+]
 
 
 class RenameColumns(Step):
@@ -63,28 +146,28 @@ class GenerateResponse(Step):
 
 def run_pipeline():
     with Pipeline(name="unit-test-pipeline") as pipeline:
-        load_hub_dataset = LoadHubDataset(name="load_dataset", batch_size=8)
+        load_dataset = LoadDataFromDicts(name="load_dataset", data=DATA, batch_size=8)
         rename_columns = RenameColumns(name="rename_columns", input_batch_size=12)
         generate_response = GenerateResponse(
             name="generate_response", input_batch_size=16
         )
 
-        load_hub_dataset.connect(rename_columns)
+        load_dataset.connect(rename_columns)
         rename_columns.connect(generate_response)
 
-        return pipeline.run(
-            parameters={
-                "load_dataset": {
-                    "repo_id": "plaguss/test",
-                    "split": "train",
+    return pipeline.run(
+        parameters={
+            "load_dataset": {
+                "repo_id": "plaguss/test",
+                "split": "train",
+            },
+            "rename_columns": {
+                "rename_mappings": {
+                    "prompt": "instruction",
                 },
-                "rename_columns": {
-                    "rename_mappings": {
-                        "prompt": "instruction",
-                    },
-                },
-            }
-        )
+            },
+        }
+    )
 
 
 def test_pipeline_cached():

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -811,17 +811,12 @@ class TestBatchManager:
             data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
         )
 
-        batch = batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
+        batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
 
-        assert batch == _Batch(
-            step_name="step3",
-            seq_no=0,
-            last_batch=False,
-            data=[
-                [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}],
-                [{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}],
-            ],
-        )
+        assert batch_manager._steps["step3"].data == {
+            "step1": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}],
+            "step2": [{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}],
+        }
 
     def test_from_dag(
         self,


### PR DESCRIPTION
## Description

In a pipeline like the one below, it was happening that the generator was yielding all the batches at once. This was happening because a bug handling how the batches were added to the batch manager, and how it was checked if the buffers of an step were empty. This PR fixes this issue, avoiding generator steps to yield all the batches at once when `generator.batch_size` == `generator_successors.input_batch_size`.

```python
from distilabel.pipeline import Pipeline
from distilabel.steps import LoadHubDataset
from distilabel.llms import MistralLLM
from distilabel.steps.tasks import TextGeneration

with Pipeline(name="quick-example") as pipeline:
    load_dataset = LoadHubDataset(
        name="load_dataset", output_mappings={"prompt": "instruction"}
    )

    text_generation = TextGeneration(
        name="text_generation", llm=MistralLLM(model="mistral-small")
    )

    load_dataset.connect(text_generation)

if __name__ == "__main__":
    pipeline.run(
        parameters={
            "load_dataset": {
                "repo_id": "HuggingFaceH4/instruction-dataset",
                "split": "test",
                "batch_size": 8,
            },
            "text_generation": {
                "input_batch_size": 8,
            },
        }
    )
```