### PR TITLE
Run output queue loop in thread and improve stop

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -879,13 +879,13 @@ class _WriteBuffer:
         """
         return len(self._buffers[step_name]) >= self._buffers_dump_batch_size[step_name]
 
-    def add_batch(self, step_name: str, batch: "_Batch") -> None:
+    def add_batch(self, batch: "_Batch") -> None:
         """Adds a batch to the buffer and writes the buffer to the file if it's full.
 
         Args:
-            step_name (str): Name of the step to which the data pertains.
-            batch (_Batch): Batch to add to the buffer.
+            batch: batch to add to the buffer.
         """
+        step_name = batch.step_name
         data = batch.data[0]
         self._buffers[step_name].extend(data)
         self._logger.debug(

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1144,26 +1144,26 @@ class TestWriteBuffer:
 
             # Add one batch with 5 rows, shouldn't write anything 5 < 50
             batch = batch_gen(dummy_step_2.name)
-            write_buffer.add_batch(batch.step_name, batch)
+            write_buffer.add_batch(batch)
 
             # Add 45 more rows, should write now
             for _ in range(9):
                 batch = batch_gen(dummy_step_2.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             assert Path(folder, "dummy_step_2", "00001.parquet").exists()
 
             # Add 50 more rows, we should have a new file
             for _ in range(10):
                 batch = batch_gen(dummy_step_2.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             assert Path(folder, "dummy_step_2", "00002.parquet").exists()
 
             # Add more rows and close the write buffer, we should have a new file
             for _ in range(5):
                 batch = batch_gen(dummy_step_2.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             write_buffer.close()
 
@@ -1193,23 +1193,23 @@ class TestWriteBuffer:
 
             for _ in range(10):
                 batch = batch_gen(dummy_step_2.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             assert Path(folder, "dummy_step_2", "00001.parquet").exists()
 
             for _ in range(10):
                 batch = batch_gen(dummy_step_3.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             assert Path(folder, "dummy_step_3", "00001.parquet").exists()
 
             for _ in range(5):
                 batch = batch_gen(dummy_step_2.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             for _ in range(5):
                 batch = batch_gen(dummy_step_3.name)
-                write_buffer.add_batch(batch.step_name, batch)
+                write_buffer.add_batch(batch)
 
             write_buffer.close()
 

--- a/tests/unit/pipeline/test_local.py
+++ b/tests/unit/pipeline/test_local.py
@@ -23,6 +23,8 @@ from .utils import DummyGeneratorStep, DummyStep1, DummyStep2
 if TYPE_CHECKING:
     from distilabel.steps.base import GeneratorStep
 
+
+class TestLocalPipeline:
     def test_request_initial_batches(
         self, dummy_generator_step: "GeneratorStep"
     ) -> None:
@@ -102,14 +104,17 @@ if TYPE_CHECKING:
             [
                 mock.call(
                     process_wrapper_mock.return_value.run,
+                    callback=pipeline._finished_callback,
                     error_callback=pipeline._error_callback,
                 ),
                 mock.call(
                     process_wrapper_mock.return_value.run,
+                    callback=pipeline._finished_callback,
                     error_callback=pipeline._error_callback,
                 ),
                 mock.call(
                     process_wrapper_mock.return_value.run,
+                    callback=pipeline._finished_callback,
                     error_callback=pipeline._error_callback,
                 ),
             ]


### PR DESCRIPTION
## Description

This PR improves (and fix) the stop process by:

1. Running the output queue loop in a thread (not "MainThread"). This is because the signal handlers runs also in the "MainThread", therefore if CTRL+C is pressed, the signal handler will be executed and the output queue loop will be stopped. We need the output queue loop to continue its execution at the same time as the signal handler is running to process the remaining output batches that were sent by the step before calling stop.
2. The logic for handling the stop is no longer executed in the signal handler but in the thread running the output queue loop. This makes the signal handler much more lighter and makes the stop process more reliable.