### PR TITLE
select num_examples from HF dataset

### DIFF
--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -132,7 +132,10 @@ class LoadHubDataset(GeneratorStep):
             the last one.
         """
         # num_examples = self._get_dataset_num_examples()
-        num_examples = self.num_examples if self.num_examples else self._get_dataset_num_examples()
+        if self.num_examples:
+            num_example = min(self.num_examples, self._get_datset_num_examples())
+        else:    
+            num_examples = self._get_dataset_num_examples()
         num_returned_rows = 0
         for batch_num, batch in enumerate(
             self._dataset.iter(batch_size=self.batch_size)  # type: ignore

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -119,8 +119,6 @@ class LoadHubDataset(GeneratorStep):
             split=self.split,
             streaming=True,
         )
-        if self.num_examples:
-            self._dataset = self._dataset.select(range(self.num_examples))
 
     def process(self, offset: int = 0) -> "GeneratorStepOutput":
         """Yields batches from the loaded dataset from the Hugging Face Hub.
@@ -133,8 +131,8 @@ class LoadHubDataset(GeneratorStep):
             A tuple containing a batch of rows and a boolean indicating if the batch is
             the last one.
         """
-        num_examples = self._get_dataset_num_examples()
-        # num_examples = self.num_examples if self.num_examples else self._get_dataset_num_examples()
+        # num_examples = self._get_dataset_num_examples()
+        num_examples = self.num_examples if self.num_examples else self._get_dataset_num_examples()
         num_returned_rows = 0
         for batch_num, batch in enumerate(
             self._dataset.iter(batch_size=self.batch_size)  # type: ignore

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -133,7 +133,7 @@ class LoadHubDataset(GeneratorStep):
         """
         # num_examples = self._get_dataset_num_examples()
         if self.num_examples:
-            num_example = min(self.num_examples, self._get_datset_num_examples())
+            num_example = min(self.num_examples, self._get_dataset_num_examples())
         else:    
             num_examples = self._get_dataset_num_examples()
         num_returned_rows = 0


### PR DESCRIPTION
In some cases, e.g. testing your pipeline before running it, one would like to select only a couple of examples from the HF dataset loaded in `src.distilabel.steps.generators.huggingface.LoadHubDataset`.

Therefore I offer two ways of selecting `num_examples` from a HF dataset:

- either pretty straight forwardly by `self._dataset.select(range(self.num_examples)`:

https://github.com/rasdani/distilabel/blob/d70076df8b360d4bb09a713af46578669d3c3d54/src/distilabel/steps/generators/huggingface.py#L122

- or by modifying the already existing `num_examples`. I'm not sure though, if this has any downstream effects for batching/yielding:

https://github.com/rasdani/distilabel/blob/d70076df8b360d4bb09a713af46578669d3c3d54/src/distilabel/steps/generators/huggingface.py#L137

We could change `num_examples` inside `_get_dataset_num_examples(self)`, too.