### PR TITLE
Fix CTRL + C when still loading steps

### DIFF
--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -350,7 +350,7 @@ class Pipeline(BasePipeline):
 
         self._logger.info("⏳ Waiting for all the steps to load...")
         previous_message = None
-        while True:
+        while not _STOP_CALLED:
             with self.shared_info[_STEPS_LOADED_LOCK_KEY]:
                 steps_loaded = self.shared_info[_STEPS_LOADED_KEY]
                 num_steps_loaded = (
@@ -376,6 +376,8 @@ class Pipeline(BasePipeline):
                     return False
 
             time.sleep(2.5)
+
+        return not _STOP_CALLED
 
     def _request_initial_batches(self) -> None:
         """Requests the initial batches to the generator steps."""

--- a/tests/unit/steps/argilla/test_base.py
+++ b/tests/unit/steps/argilla/test_base.py
@@ -19,7 +19,6 @@ import pytest
 from distilabel.pipeline.local import Pipeline
 from distilabel.steps.argilla.base import Argilla
 from distilabel.steps.base import StepInput
-from pydantic import ValidationError
 
 if TYPE_CHECKING:
     from distilabel.steps.typing import StepOutput
@@ -83,17 +82,6 @@ class TestArgilla:
             )
 
         with pytest.raises(
-            ValidationError, match="dataset_name\n  Field required \\[type=missing"
-        ):
-            CustomArgilla(
-                name="step",
-                api_url="https://example.com",
-                api_key="api.key",  # type: ignore
-                dataset_workspace="argilla",
-                pipeline=Pipeline(name="unit-test-pipeline"),
-            )
-
-        with pytest.raises(
             TypeError,
             match="Can't instantiate abstract class Argilla with abstract methods inputs, process",
         ):
@@ -134,6 +122,18 @@ class TestArgilla:
                 {
                     "description": "The number of rows that will contain the batches processed by the step.",
                     "name": "input_batch_size",
+                    "optional": True,
+                },
+                {
+                    "description": "The name of the dataset in Argilla.",
+                    "name": "dataset_name",
+                    "optional": False,
+                },
+                {
+                    "description": "The workspace where the dataset will be created in Argilla. "
+                    "Defaultsto `None` which means it will be created in the default "
+                    "workspace.",
+                    "name": "dataset_workspace",
                     "optional": True,
                 },
                 {

--- a/tests/unit/steps/argilla/test_preference.py
+++ b/tests/unit/steps/argilla/test_preference.py
@@ -110,6 +110,18 @@ class TestPreferenceToArgilla:
                     "optional": True,
                 },
                 {
+                    "description": "The name of the dataset in Argilla.",
+                    "name": "dataset_name",
+                    "optional": False,
+                },
+                {
+                    "description": "The workspace where the dataset will be created in Argilla. "
+                    "Defaultsto `None` which means it will be created in the default "
+                    "workspace.",
+                    "name": "dataset_workspace",
+                    "optional": True,
+                },
+                {
                     "name": "api_url",
                     "optional": True,
                     "description": "The base URL to use for the Argilla API requests.",

--- a/tests/unit/steps/argilla/test_text_generation.py
+++ b/tests/unit/steps/argilla/test_text_generation.py
@@ -83,6 +83,18 @@ class TestTextGenerationToArgilla:
                     "optional": True,
                 },
                 {
+                    "description": "The name of the dataset in Argilla.",
+                    "name": "dataset_name",
+                    "optional": False,
+                },
+                {
+                    "description": "The workspace where the dataset will be created in Argilla. "
+                    "Defaultsto `None` which means it will be created in the default "
+                    "workspace.",
+                    "name": "dataset_workspace",
+                    "optional": True,
+                },
+                {
                     "name": "api_url",
                     "optional": True,
                     "description": "The base URL to use for the Argilla API requests.",


### PR DESCRIPTION
## Description

When pressing CTRL + C when not all the steps had been loaded, the pipeline will get stuck. This PR fixes this and also remove the duplicate `_STOP_LOOP` global variable. Apart from that, some fixes in Argilla unit tests.