### PR TITLE
Empty input queues when `CTRL + C`

### DIFF
--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -180,7 +180,6 @@ class Pipeline(BasePipeline):
             # slower.
             if _STOP_CALLED:
                 self._handle_batch_on_stop(batch)
-                self._handle_stop(write_buffer)
                 break
 
             self._logger.debug(
@@ -264,15 +263,16 @@ class Pipeline(BasePipeline):
         # Send `None` to the input queues of all the steps to notify them to stop
         # processing batches.
         for step_name in self.dag:
-            if input_queue := self._wait_step_input_queue_empty(step_name):
-                if self._check_step_not_loaded_or_finished(step_name):
-                    self._logger.debug(
-                        f"Step '{step_name}' not loaded or already finished. Skipping sending"
-                        " sentinel `None`"
+            if input_queue := self.dag.get_step(step_name).get("input_queue"):
+                while not input_queue.empty():
+                    batch = input_queue.get()
+                    self._batch_manager.add_batch(  # type: ignore
+                        to_step=step_name, batch=batch, prepend=True
                     )
-                    continue
+                    self._logger.debug(
+                        f"Adding batch back to the batch manager: {batch}"
+                    )
                 input_queue.put(None)
-                self._logger.debug(f"Send `None` to step '{step_name}' input queue.")
 
         # Wait for the input queue to be empty, which means that all the steps finished
         # processing the batches that were sent before the stop flag.
@@ -385,6 +385,9 @@ class Pipeline(BasePipeline):
 
         for step in self._batch_manager._steps.values():
             if batch := step.get_batch():
+                self._logger.debug(
+                    f"Sending initial batch to '{step.step_name}' step: {batch}"
+                )
                 self._send_batch_to_step(batch)
 
         for step_name in self.dag.root_steps:
@@ -392,6 +395,9 @@ class Pipeline(BasePipeline):
             if last_batch := self._batch_manager.get_last_batch(step_name):
                 seq_no = last_batch.seq_no + 1
             batch = _Batch(seq_no=seq_no, step_name=step_name, last_batch=False)
+            self._logger.debug(
+                f"Requesting initial batch to '{step_name}' generator step: {batch}"
+            )
             self._send_batch_to_step(batch)
 
     def _send_batch_to_step(self, batch: "_Batch") -> None:

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -264,6 +264,46 @@ class TestBatchManagerStep:
         assert batch_manager_step.data["step1"] == [{"a": 1}, {"a": 2}, {"a": 3}]
         assert batch_manager_step.last_batch_received == []
 
+    def test_add_batch_with_prepend(self) -> None:
+        batch_manager_step = _BatchManagerStep(
+            step_name="step2",
+            accumulate=False,
+            input_batch_size=10,
+            data={
+                "step1": [
+                    {"a": 6},
+                    {"a": 7},
+                    {"a": 8},
+                    {"a": 9},
+                    {"a": 10},
+                ]
+            },
+        )
+
+        batch_manager_step.add_batch(
+            _Batch(
+                seq_no=0,
+                step_name="step1",
+                last_batch=False,
+                data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
+            ),
+            prepend=True,
+        )
+
+        assert batch_manager_step.data["step1"] == [
+            {"a": 1},
+            {"a": 2},
+            {"a": 3},
+            {"a": 4},
+            {"a": 5},
+            {"a": 6},
+            {"a": 7},
+            {"a": 8},
+            {"a": 9},
+            {"a": 10},
+        ]
+        assert batch_manager_step.last_batch_received == []
+
     def test_add_batch_last_batch(self) -> None:
         batch_manager_step = _BatchManagerStep(
             step_name="step2", accumulate=False, input_batch_size=10, data={"step1": []}
@@ -784,9 +824,56 @@ class TestBatchManager:
             last_batch=False,
             data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
         )
-        batch = batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
+        batch_manager.add_batch(to_step="step3", batch=batch_from_step_1)
 
-        assert batch is None
+        assert batch_manager._steps["step3"].data == {
+            "step1": [
+                {"a": 1},
+                {"a": 2},
+                {"a": 3},
+                {"a": 4},
+                {"a": 5},
+            ],
+            "step2": [],
+        }
+
+    def test_add_batch_with_prepend(self) -> None:
+        batch_manager = _BatchManager(
+            steps={
+                "step3": _BatchManagerStep(
+                    step_name="step3",
+                    accumulate=False,
+                    input_batch_size=5,
+                    data={
+                        "step1": [{"a": 6}, {"a": 7}, {"a": 8}, {"a": 9}, {"a": 10}],
+                        "step2": [],
+                    },
+                )
+            },
+            last_batch_received={"step3": None},
+        )
+        batch_from_step_1 = _Batch(
+            seq_no=0,
+            step_name="step1",
+            last_batch=False,
+            data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
+        )
+        batch_manager.add_batch(to_step="step3", batch=batch_from_step_1, prepend=True)
+        assert batch_manager._steps["step3"].data == {
+            "step1": [
+                {"a": 1},
+                {"a": 2},
+                {"a": 3},
+                {"a": 4},
+                {"a": 5},
+                {"a": 6},
+                {"a": 7},
+                {"a": 8},
+                {"a": 9},
+                {"a": 10},
+            ],
+            "step2": [],
+        }
 
     def test_add_batch_enough_data(self) -> None:
         batch_manager = _BatchManager(


### PR DESCRIPTION
## Description

This PR updates the `_handle_stop` function to empty and add back to the batch manager the batches that were sent to the steps. This allows a faster stop, as the step won't have to process all the batches that were sent to it before pressing CTRL + C before stopping the pipeline. The main process will consume the remaining batches in the input queue of each step and add it back to the batch manager, so when the pipeline is executed again, the data would have been cached and the pipeline can continue it's execution normally.