### PR TITLE
Add `filelock` and `flash-attn` to `vllm` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ mistralai = ["mistralai >= 0.1.0"]
 ollama = ["ollama >= 0.1.7"]
 openai = ["openai >= 1.0.0"]
 vertexai = ["google-cloud-aiplatform >= 1.38.0"]
-vllm = ["vllm >= 0.2.1"]
+vllm = ["vllm >= 0.2.1", "filelock >= 3.13.4", "flash-attn >= 2.5.7"]
 
 [project.urls]
 Documentation = "https://distilabel.argilla.io/"


### PR DESCRIPTION
## Description

This PR adds both:
* `filelock` to avoid `BaseFileLock.__init__() got an unexpected keyword argument 'mode'`
* `flash-attn` as it's recommended over the default `xformers`

So on, now after installing `distilabel[vllm]`, the `vLLM` integration will work with no issues. 