### PR TITLE
Fix error in README.md when pushing the custom dataset card

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -95,7 +95,6 @@ class Distiset(dict):
 
         card = DistilabelDatasetCard.from_template(
             card_data=DatasetCardData(
-                config_names=sorted(self.keys()),
                 size_categories=size_categories_parser(
                     max(len(dataset) for dataset in self.values())
                 ),


### PR DESCRIPTION
## Description

We have a bug when calling `Distiset.push_to_hub(generate_card=True)` as the metadata is overwritten. This PR fixes it by downloading the current README.md and updating the information. 