### PR TITLE
Fix pipeline stuck when empty batches

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -368,6 +368,15 @@ class _Batch(_Serializable):
             seq_no=self.seq_no + 1, step_name=self.step_name, last_batch=self.last_batch
         )
 
+    @property
+    def empty(self) -> bool:
+        """Checks if the batch is empty.
+
+        Returns:
+            `True` if the batch is empty. Otherwise, `False`.
+        """
+        return all(len(rows) == 0 for rows in self.data)
+
     @classmethod
     def from_batches(cls, step_name: str, batches: List["_Batch"]) -> "_Batch":
         """Create a `_Batch` instance with the outputs from the list of batches that
@@ -665,6 +674,22 @@ class _BatchManager(_Serializable):
             `True` if there are still batches to be processed by the steps. Otherwise,
             `False`.
         """
+
+        # Check if any step that hasn't finished producing data (we haven't received its
+        # last batch) still needs data from its predecessors, and those predecessors have
+        # already sent their last batch and it's empty. In this case, we cannot continue
+        # the pipeline.
+        for batch_manager_step in self._steps.values():
+            for predecessor in batch_manager_step.data.keys():
+                batch = self._last_batch_received.get(predecessor)
+                if (
+                    batch
+                    and batch.last_batch
+                    and batch.empty
+                    and batch_manager_step.data[predecessor] == []
+                ):
+                    return False
+
         return not all(
             batch and batch.last_batch for batch in self._last_batch_received.values()
         )

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -541,6 +541,8 @@ class Pipeline(BasePipeline):
         self._logger.info(
             "🛑 Stopping pipeline. Waiting for steps to finish processing batches..."
         )
+        self._logger.debug("Sending `None` to the output queue to notify stop...")
+        self.output_queue.put(None)
 
     def _handle_keyboard_interrupt(self) -> None:
         """Handles KeyboardInterrupt signal sent during the Pipeline.run method.

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -202,6 +202,10 @@ class TestBatch:
             [{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}, {"b": 6}],
         ]
 
+    def test_empty(self) -> None:
+        batch = _Batch(seq_no=0, step_name="step1", last_batch=False, data=[[]])
+        assert batch.empty
+
     def test_dump(self) -> None:
         batch = _Batch(seq_no=0, step_name="step1", last_batch=False)
         assert batch.dump() == {


### PR DESCRIPTION
## Description

The pipeline was getting stuck when a dependant step received empty batches from its predecessor step because `_BatchManager.can_generate` method was not taking this into account. This PR fix this issue, and also one that could get the pipeline stuck when pressing CTRL + C if the main process was waiting for getting a batch from the output queue.