### PR TITLE
Update `TextGeneration.format_input` method to allow OpenAI format

### DIFF
--- a/src/distilabel/steps/tasks/text_generation.py
+++ b/src/distilabel/steps/tasks/text_generation.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Union
 
 from distilabel.steps.tasks.base import Task
 from distilabel.steps.tasks.typing import ChatType
+from distilabel.utils.chat import is_openai_format
 
 
 class TextGeneration(Task):
@@ -39,9 +40,19 @@ class TextGeneration(Task):
     def format_input(self, input: Dict[str, Any]) -> ChatType:
         """The input is formatted as a `ChatType` assuming that the instruction
         is the first interaction from the user within a conversation."""
-        return [
-            {"role": "user", "content": input["instruction"]},
-        ]
+
+        instruction = input["instruction"]
+
+        if isinstance(instruction, str):
+            return [{"role": "user", "content": input["instruction"]}]
+
+        if not is_openai_format(instruction):
+            raise ValueError(
+                f"Input `instruction` must be a string or an OpenAI chat-like format. "
+                f"Got: {instruction}. Please check: 'https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models'."
+            )
+
+        return instruction
 
     @property
     def outputs(self) -> List[str]:

--- a/tests/unit/steps/tasks/test_text_generation.py
+++ b/tests/unit/steps/tasks/test_text_generation.py
@@ -19,6 +19,34 @@ from tests.unit.steps.tasks.utils import DummyLLM
 
 
 class TestTextGeneration:
+    def test_format_input_with_str(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        assert task.format_input({"instruction": "test"}) == [
+            {"role": "user", "content": "test"}
+        ]
+
+    def test_format_input_with_conversation(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        assert task.format_input(
+            {
+                "instruction": [
+                    {"role": "system", "content": "You're a helpful assistant"},
+                    {"role": "user", "content": "How much is 2+2?"},
+                    {"role": "system", "content": "4"},
+                ]
+            }
+        ) == [
+            {"role": "system", "content": "You're a helpful assistant"},
+            {"role": "user", "content": "How much is 2+2?"},
+            {"role": "system", "content": "4"},
+        ]
+
     def test_process(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()

--- a/tests/unit/utils/test_chat.py
+++ b/tests/unit/utils/test_chat.py
@@ -37,6 +37,31 @@ from distilabel.utils.chat import is_openai_format
             ],
             True,
         ),
+        (
+            [
+                {"role": "system", "content": "You're a helpful assistant"},
+                {"role": "user", "content": "Hello!"},
+                {"role": "assistant", "content": "Hi! How can I help you?"},
+            ],
+            True,
+        ),
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What’s in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                            },
+                        },
+                    ],
+                }
+            ],
+            True,
+        ),
     ],
 )
 def test_is_openai_format(input: Any, expected: bool) -> None:


### PR DESCRIPTION
## Description

This PR updates `format_input` from `TextGeneration` task to allow passing a conversation using OpenAI's format in the `instruction` input column.