### PR TITLE
Fixes regarding `RuntimeParameter`s and `pydantic` model attributes

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -91,16 +91,16 @@ class Distiset(dict):
                 dataset[0] if not isinstance(dataset, dict) else dataset["train"][0]
             )
 
-        metadata = self._extract_readme_metadata(repo_id, token)
+        metadata = {
+            **self._extract_readme_metadata(repo_id, token),
+            "size_categories": size_categories_parser(
+                max(len(dataset) for dataset in self.values())
+            ),
+            "tags": ["synthetic", "distilabel", "rlaif"],
+        }
 
         card = DistilabelDatasetCard.from_template(
-            card_data=DatasetCardData(
-                size_categories=size_categories_parser(
-                    max(len(dataset) for dataset in self.values())
-                ),
-                tags=["synthetic", "distilabel", "rlaif"],
-                **metadata,
-            ),
+            card_data=DatasetCardData(**metadata),
             repo_id=repo_id,
             sample_records=sample_records,
         )

--- a/src/distilabel/llms/base.py
+++ b/src/distilabel/llms/base.py
@@ -60,7 +60,10 @@ class LLM(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
     """
 
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, protected_namespaces=(), validate_default=True
+        arbitrary_types_allowed=True,
+        protected_namespaces=(),
+        validate_default=True,
+        validate_assignment=True,
     )
 
     generation_kwargs: Optional[RuntimeParameter[Dict[str, Any]]] = Field(

--- a/src/distilabel/mixins/runtime_parameters.py
+++ b/src/distilabel/mixins/runtime_parameters.py
@@ -32,7 +32,7 @@ RuntimeParameter = Annotated[
 RuntimeParametersNames = Dict[str, Union[bool, "RuntimeParametersNames"]]
 
 
-class RuntimeParametersMixin(BaseModel, validate_assignment=True):
+class RuntimeParametersMixin(BaseModel):
     """Mixin for classes that have `RuntimeParameter`s attributes.
 
     Attributes:

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -205,10 +205,10 @@ class BasePipeline(_Serializable):
         Returns:
             The `Distiset` created by the pipeline.
         """
-        self._set_runtime_parameters(parameters or {})
-        self.dag.validate()
         if use_cache:
             self._load_from_cache()
+        self._set_runtime_parameters(parameters or {})
+        self.dag.validate()
 
     def get_runtime_parameters_info(self) -> Dict[str, List[Dict[str, Any]]]:
         """Get the runtime parameters for the steps in the pipeline.

--- a/src/distilabel/steps/argilla/base.py
+++ b/src/distilabel/steps/argilla/base.py
@@ -87,6 +87,8 @@ class Argilla(Step, ABC):
 
     def model_post_init(self, __context: Any) -> None:
         """Checks that the Argilla Python SDK is installed, and then filters the Argilla warnings."""
+        super().model_post_init(__context)
+
         try:
             import argilla as rg  # noqa
         except ImportError as ie:
@@ -95,7 +97,6 @@ class Argilla(Step, ABC):
             ) from ie
 
         warnings.filterwarnings("ignore")
-        return super().model_post_init(__context)
 
     def _rg_init(self) -> None:
         """Initializes the Argilla API client with the provided `api_url` and `api_key`."""

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -92,7 +92,9 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
     defined, validated, serialized and included in the `__init__` method of the step.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_default=True, validate_assignment=True
+    )
 
     name: str
     pipeline: Annotated[Any, Field(exclude=True, repr=False)] = None


### PR DESCRIPTION
## Description

This PR fixes several issues regarding the `RuntimeParameter`s and `pydantic.BaseModel` attributes:

1. The `pydantic.BaseModel` configuration of `Step` class didn't have the `validate_default=True` which was causing `Secret` attributes with a `default_factory` getting the value of an environment variable to not transform the value to the secret type. For example, `api_key` of `Argilla`s steps was not being transformed to `SecretStr` when provided using `ARGILLA_API_KEY`.

2. When loading the `Pipeline` from cache, the values of runtime parameters from the cache were taking precedence over the values provided in the `run` method. To avoid leading `api_key`s, `Secret` types are not serialised, but in combination with the previous issue, was causing that running a pipeline a second time when the `api_key` was provided in the runtime parameters to raise a missing runtime parameter error.

In addition, this PR also makes sure that `tags` and `size_categories` are not provided via both keyword argument and `kwargs` when creating the `DatasetCardInfo` instance, that was causing raising an exception.