### PR TITLE
Remove `flash-attn` from `vllm` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ mistralai = ["mistralai >= 0.1.0"]
 ollama = ["ollama >= 0.1.7"]
 openai = ["openai >= 1.0.0"]
 vertexai = ["google-cloud-aiplatform >= 1.38.0"]
-vllm = ["vllm >= 0.2.1", "filelock >= 3.13.4", "flash-attn >= 2.5.7"]
+vllm = ["vllm >= 0.2.1", "filelock >= 3.13.4"]
 
 [project.urls]
 Documentation = "https://distilabel.argilla.io/"


### PR DESCRIPTION
## Description

This PR removes the `flash-attn` dependency from the extra `vllm`, since it will be ignored by `vllm` and `xformers` will be used instead. Instead, `flash-attn` will need to be installed after `vllm` as follows `pip install flash-attn --no-build-isolation`.