### PR TITLE
Fix not all exceptions being able to be pickled

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from rich import traceback as rich_traceback
-from tblib import pickling_support
 
 __version__ = "1.0.0"
 
 rich_traceback.install(show_locals=True)
-pickling_support.install()


### PR DESCRIPTION
## Description

This PR fix an issue in which not all the exceptions could be loaded back from its pickle form (with `tblib`) causing an error. To fix the issue and keep displaying a good traceback from the subprocess exception, the traceback is formatted to an string and then reconstructed in the main process.