### PR TITLE
Check that `Step.name` doesn't contain dots or spaces

### DIFF
--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -96,7 +96,7 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
         arbitrary_types_allowed=True, validate_default=True, validate_assignment=True
     )
 
-    name: str
+    name: str = Field(pattern=r"^[a-zA-Z0-9_-]+$")
     pipeline: Annotated[Any, Field(exclude=True, repr=False)] = None
     input_mappings: Dict[str, str] = {}
     output_mappings: Dict[str, str] = {}

--- a/tests/unit/steps/test_base.py
+++ b/tests/unit/steps/test_base.py
@@ -25,6 +25,7 @@ from distilabel.steps.base import (
 )
 from distilabel.steps.typing import GeneratorStepOutput, StepOutput
 from distilabel.utils.serialization import TYPE_INFO_KEY
+from pydantic import ValidationError
 
 
 class DummyStep(Step):
@@ -65,6 +66,17 @@ class DummyGlobalStep(GlobalStep):
 
 
 class TestStep:
+    def test_create_step_with_invalid_name(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+
+        with pytest.raises(ValidationError):
+            DummyStep(
+                name="this-is-not-va.li.d-because-it-contains-dots", pipeline=pipeline
+            )
+
+        with pytest.raises(ValidationError):
+            DummyStep(name="this is not valid because spaces", pipeline=pipeline)
+
     def test_create_step_passing_pipeline(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         step = DummyStep(name="dummy", pipeline=pipeline)


### PR DESCRIPTION
## Description

This PR adds a validation to the name of the `Step`s so it cannot contain dots or spaces. This is mainly because the CLI, uses the `.` to parse the runtime parameters.