### PR TITLE
Fix typo in readme and remove the ToArgilla step

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,7 @@ if __name__ == "__main__":
                     }
                 }
             },
-            "to_argilla": {
-                "dataset_name": "text-generations-with-gpt35",
-                "dataset_workspace": "admin",
-            },
         },
-    )
-    distiset.push_to_hub(
-        "instruction-dataset-mini-with-generations"
     )
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To run the following example you must install `distilabel` with both `openai` ex
 pip install "distilabel[openai]" --upgrade
 ```
 
-Then run the following example:
+Then run:
 
 ```python
 from distilabel.llms import OpenAILLM

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ In addition, the following extras are available:
 
 ### Example
 
-To run the following example you must install `distilabel` with both `openai` and `argilla` extras:
+To run the following example you must install `distilabel` with both `openai` extra:
 
 ```sh
-pip install "distilabel[openai,argilla]" --upgrade
+pip install "distilabel[openai]" --upgrade
 ```
 
 Then run the following example:
@@ -102,7 +102,7 @@ Then run the following example:
 ```python
 from distilabel.llms import OpenAILLM
 from distilabel.pipeline import Pipeline
-from distilabel.steps import LoadHubDataset, TextGenerationToArgilla
+from distilabel.steps import LoadHubDataset
 from distilabel.steps.tasks import TextGeneration
 
 with Pipeline(
@@ -115,14 +115,10 @@ with Pipeline(
     )
 
     generate_with_openai = TextGeneration(
-        name="generate_with_gpt3.5", llm=OpenAILLM(model="gpt-3.5-turbo")
+        name="generate_with_gpt35", llm=OpenAILLM(model="gpt-3.5-turbo")
     )
 
-    to_argilla = TextGenerationToArgilla(name="to_argilla")
-
     load_dataset.connect(generate_with_openai)
-    generate_with_openai.connect(to_argilla)
-
 
 if __name__ == "__main__":
     distiset = pipeline.run(
@@ -146,12 +142,9 @@ if __name__ == "__main__":
         },
     )
     distiset.push_to_hub(
-        "distilabel-internal-testing/instruction-dataset-mini-with-generations"
+        "instruction-dataset-mini-with-generations"
     )
 ```
-
-Distilabel integrates smoothly with Argilla and provides all the necessary configurations to make giving a final human touch as easy as possible.
-
 
 ## Badges
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,10 +34,18 @@ In addition, the following extras are available:
 
 ## Quick example
 
+To run the following example you must install `distilabel` with both `openai` extra:
+
+```sh
+pip install "distilabel[openai]" --upgrade
+```
+
+Then run:
+
 ```python
 from distilabel.llms import OpenAILLM
 from distilabel.pipeline import Pipeline
-from distilabel.steps import LoadHubDataset, TextGenerationToArgilla
+from distilabel.steps import LoadHubDataset
 from distilabel.steps.tasks import TextGeneration
 
 with Pipeline(
@@ -50,14 +58,10 @@ with Pipeline(
     )
 
     generate_with_openai = TextGeneration(
-        name="generate_with_gpt3.5", llm=OpenAILLM(model="gpt-3.5-turbo")
+        name="generate_with_gpt35", llm=OpenAILLM(model="gpt-3.5-turbo")
     )
 
-    to_argilla = TextGenerationToArgilla(name="to_argilla")
-
     load_dataset.connect(generate_with_openai)
-    generate_with_openai.connect(to_argilla)
-
 
 if __name__ == "__main__":
     distiset = pipeline.run(
@@ -74,13 +78,6 @@ if __name__ == "__main__":
                     }
                 }
             },
-            "to_argilla": {
-                "dataset_name": "text-generations-with-gpt35",
-                "dataset_workspace": "admin",
-            },
         },
-    )
-    distiset.push_to_hub(
-        "distilabel-internal-testing/instruction-dataset-mini-with-generations"
     )
 ```


### PR DESCRIPTION
* Fixes an issue with the step name
* Removes the push_to_hub step as it assumes write access to distilabel internal testing 
* Removes the Argilla step as it adds too much config for a quick example. Running like this resulted in:

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /usr/local/lib/python3.10/dist-packages/distilabel/steps/argilla/base.py:104 in _rg_init         │
│                                                                                                  │
│   101 │   def _rg_init(self) -> None:                                                            │
│   102 │   │   """Initializes the Argilla API client with the provided `api_url` and `api_key`.   │
│   103 │   │   try:                                                                               │
│ ❱ 104 │   │   │   if "hf.space" in self.api_url and "HF_TOKEN" in os.environ:                    │
│   105 │   │   │   │   headers = {"Authorization": f"Bearer {os.environ['HF_TOKEN']}"}            │
│   106 │   │   │   else:                                                                          │
│   107 │   │   │   │   headers = None                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: Failed to initialize the Argilla API: argument of type 'NoneType' is not iterable

The above exception was the direct cause of the following exception:

