### PR TITLE
Warn user about unknown runtime parameters

### DIFF
--- a/src/distilabel/mixins/runtime_parameters.py
+++ b/src/distilabel/mixins/runtime_parameters.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import difflib
 import inspect
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, TypeVar, Union
 
@@ -105,8 +106,18 @@ class RuntimeParametersMixin(BaseModel):
             runtime_parameters: A dictionary containing the values of the runtime parameters
                 to set.
         """
+        runtime_parameters_names = list(self.runtime_parameters_names.keys())
         for name, value in runtime_parameters.items():
             if name not in self.runtime_parameters_names:
+                closest = difflib.get_close_matches(
+                    name, runtime_parameters_names, cutoff=0.5
+                )
+                msg = f"⚠️  Runtime parameter '{name}' unknown in step '{self.name}'."
+                if closest:
+                    msg += f" Did you mean any of: {closest}"
+                else:
+                    msg += f" Available runtime parameters for the step: {runtime_parameters_names}."
+                self.pipeline._logger.warning(msg)
                 continue
 
             attr = getattr(self, name)

--- a/src/distilabel/mixins/runtime_parameters.py
+++ b/src/distilabel/mixins/runtime_parameters.py
@@ -109,15 +109,19 @@ class RuntimeParametersMixin(BaseModel):
         runtime_parameters_names = list(self.runtime_parameters_names.keys())
         for name, value in runtime_parameters.items():
             if name not in self.runtime_parameters_names:
-                closest = difflib.get_close_matches(
-                    name, runtime_parameters_names, cutoff=0.5
-                )
-                msg = f"⚠️  Runtime parameter '{name}' unknown in step '{self.name}'."
-                if closest:
-                    msg += f" Did you mean any of: {closest}"
-                else:
-                    msg += f" Available runtime parameters for the step: {runtime_parameters_names}."
-                self.pipeline._logger.warning(msg)
+                # Check done just to ensure the unit tests for the mixin run
+                if getattr(self, "pipeline", None):
+                    closest = difflib.get_close_matches(
+                        name, runtime_parameters_names, cutoff=0.5
+                    )
+                    msg = (
+                        f"⚠️  Runtime parameter '{name}' unknown in step '{self.name}'."
+                    )
+                    if closest:
+                        msg += f" Did you mean any of: {closest}"
+                    else:
+                        msg += f" Available runtime parameters for the step: {runtime_parameters_names}."
+                    self.pipeline._logger.warning(msg)
                 continue
 
             attr = getattr(self, name)


### PR DESCRIPTION
## Description

This PR adds a warning in case a runtime parameter passed thorugh

```python
pipeline.run(parameters={...}
```

In case a runtime parameter is passed there are two cases:

- If a parameter is found as similar (using `difflib.get_close_matches`):

  ⚠️  Runtime parameter 'runtime_param_unknown' unknown in step 'dummy_step_2'. Did you mean any of: ['runtime_param4', 'runtime_param3']

- If the parameter is not similar to any of the ones:

  ⚠️  Runtime parameter 'weird_name' unknown in step 'dummy_step_2'. Available runtime parameters for the step: ['input_batch_size', 'runtime_param3', 'runtime_param4'].

Closes #547