### PR TITLE
Fix `llm_blender` installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           else
             pip install -e .[dev,tests,cohere,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,llama-cpp,anthropic,litellm]
           fi
-          pip install git+https://github.com/yuchenlin/LLM-Blender.git@3c2d71f
+          pip install git+https://github.com/argilla-io/LLM-Blender.git
 
       - name: Lint
         run: make lint


### PR DESCRIPTION
## Description

This PR fixes the `llm_blender` installation to install it from https://github.com/argilla-io/llm_blender, which is a fork from https://github.com/yuchenlin/LLM-Blender, but pinning the `spaCy` version according to the `requirements.txt` file, in order to fix the installation of `llm_blender`.