### PR TITLE
Add missing `model_name`, update docstrings, and add `*.jinja2` templates to `Task` subclasses

### DIFF
--- a/src/distilabel/steps/tasks/complexity_scorer.py
+++ b/src/distilabel/steps/tasks/complexity_scorer.py
@@ -35,18 +35,20 @@ _PARSE_SCORE_LINE_REGEX = re.compile(r"\[\d+\] score: (\d+)", re.IGNORECASE)
 
 
 class ComplexityScorer(Task):
-    """This task is used to rank a list of instructions based on their complexity. It's
-    an implementation of the complexity score task from the paper 'What Makes Good Data
-    for Alignment? A Comprehensive Study of Automatic Data Selection in Instruction Tuning'.
+    """ComplexityScorer is a pre-defined task used to rank a list of instructions based in
+    their complexity. It's an implementation of the complexity score task from the paper
+    'What MakesGood Data for Alignment? A Comprehensive Study of Automatic Data Selection
+    in Instruction Tuning'.
 
     Attributes:
-        _template: The Jinja2 template used to format the input data.
+        _template: a Jinja2 template used to format the input for the LLM.
 
     Input columns:
         - instructions (`List[str]`): The list of instructions to be scored.
 
     Output columns:
-        - complexity_score (`List[float]`): The complexity score for each instruction.
+        - scores (`List[float]`): The score for each instruction.
+        - model_name (`str`): The model name used to generate the scores.
 
     References:
         - [`What Makes Good Data for Alignment? A Comprehensive Study of Automatic Data Selection in Instruction Tuning`](https://arxiv.org/abs/2312.15685)
@@ -70,18 +72,37 @@ class ComplexityScorer(Task):
 
     @property
     def inputs(self) -> List[str]:
+        """The inputs for the task are the `instructions`."""
         return ["instructions"]
+
+    def format_input(self, input: Dict[str, Any]) -> "ChatType":
+        """The input is formatted as a `ChatType` assuming that the instruction
+        is the first interaction from the user within a conversation."""
+        return [
+            {
+                "role": "user",
+                "content": self._template.render(instructions=input["instructions"]),  # type: ignore
+            }
+        ]
 
     @property
     def outputs(self) -> List[str]:
-        return ["scores"]
-
-    def format_input(self, input: Dict[str, Any]) -> "ChatType":
-        return [{"role": "user", "content": self._template.render(**input)}]  # type: ignore
+        """The output for the task are: a list of `scores` containing the complexity score for each
+        instruction in `instructions`, and the `model_name`."""
+        return ["scores", "model_name"]
 
     def format_output(
         self, output: Union[str, None], input: Dict[str, Any]
     ) -> Dict[str, Any]:
+        """The output is formatted as a list with the score of each instruction.
+
+        Args:
+            output: the raw output of the LLM.
+            input: the input to the task. Used for obtaining the number of responses.
+
+        Returns:
+            A dict with the key `scores` containing the scores for each instruction.
+        """
         if output is None:
             return {"scores": [None] * len(input["instructions"])}
 
@@ -93,5 +114,4 @@ class ComplexityScorer(Task):
             scores.append(score)
             if i == len(input["instructions"]) - 1:
                 break
-
         return {"scores": scores}

--- a/src/distilabel/steps/tasks/generate_embeddings.py
+++ b/src/distilabel/steps/tasks/generate_embeddings.py
@@ -37,6 +37,7 @@ class GenerateEmbeddings(Step):
 
     Output columns:
         - embedding (`List[float]`): The embedding of the input text or conversation.
+        - model_name (`str`): The model name used to generate the embeddings.
 
     References:
         - [What Makes Good Data for Alignment? A Comprehensive Study of Automatic Data Selection in Instruction Tuning](https://arxiv.org/abs/2312.15685)
@@ -47,6 +48,7 @@ class GenerateEmbeddings(Step):
     def load(self) -> None:
         """Loads the `LLM` used to generate the embeddings."""
         super().load()
+
         self.llm.load()
 
     @property
@@ -59,7 +61,7 @@ class GenerateEmbeddings(Step):
     def outputs(self) -> List[str]:
         """The outputs for the task is an `embedding` column containing the embedding of
         the `text` input."""
-        return ["embedding"]
+        return ["embedding", "model_name"]
 
     def format_input(self, input: Dict[str, Any]) -> "ChatType":
         """Formats the input to be used by the LLM to generate the embeddings. The input
@@ -99,4 +101,5 @@ class GenerateEmbeddings(Step):
         last_hidden_states = self.llm.get_last_hidden_states(formatted_inputs)
         for input, hidden_state in zip(inputs, last_hidden_states):
             input["embedding"] = hidden_state[-1].tolist()
+            input["model_name"] = self.llm.model_name
         yield inputs

--- a/src/distilabel/steps/tasks/instruction_backtranslation.py
+++ b/src/distilabel/steps/tasks/instruction_backtranslation.py
@@ -41,6 +41,8 @@ class InstructionBacktranslation(Task):
 
     Output columns:
         - score (`str`): The score for the generation based on the given instruction.
+        - reason (`str`): The reason for the provided score.
+        - model_name (`str`): The model name used to score the generation.
 
     References:
         - [`Self-Alignment with Instruction Backtranslation`](https://arxiv.org/abs/2308.06259)
@@ -49,7 +51,7 @@ class InstructionBacktranslation(Task):
     _template: Optional["Template"] = PrivateAttr(default=...)
 
     def load(self) -> None:
-        """Loads the Jinja2 template with the Instruction Backtranslation prompt."""
+        """Loads the Jinja2 template."""
         super().load()
 
         _path = str(

--- a/src/distilabel/steps/tasks/pair_rm.py
+++ b/src/distilabel/steps/tasks/pair_rm.py
@@ -28,7 +28,6 @@ class PairRM(Step):
 
     Attributes:
         model: The model to use for the ranking. Defaults to `"llm-blender/PairRM"`.
-        input_batch_size: The batch size to use when processing the input. Defaults to `8`.
         instructions: The instructions to use for the model. Defaults to `None`.
 
     Input columns:
@@ -49,7 +48,6 @@ class PairRM(Step):
     """
 
     model: str = "llm-blender/PairRM"
-    input_batch_size: int = 8
     instructions: Optional[str] = None
 
     def load(self) -> None:

--- a/src/distilabel/steps/tasks/quality_scorer.py
+++ b/src/distilabel/steps/tasks/quality_scorer.py
@@ -47,7 +47,8 @@ class QualityScorer(Task):
         - responses (`List[str]`): The responses to be scored. Each response forms a pair with the instruction.
 
     Output columns:
-        - quality_score (`List[float]`): The quality score for each instruction.
+        - scores (`List[float]`): The score for each instruction.
+        - model_name (`str`): The model name used to generate the scores.
 
     References:
         - [`What Makes Good Data for Alignment? A Comprehensive Study of Automatic Data Selection in Instruction Tuning`](https://arxiv.org/abs/2312.15685)
@@ -56,6 +57,7 @@ class QualityScorer(Task):
     _template: Union[Template, None] = PrivateAttr(...)
 
     def load(self) -> None:
+        """Loads the Jinja2 template."""
         super().load()
 
         _path = str(
@@ -70,19 +72,26 @@ class QualityScorer(Task):
 
     @property
     def inputs(self) -> List[str]:
-        """The input for the task are `instruction` and `responses`."""
+        """The inputs for the task are `instruction` and `responses`."""
         return ["instruction", "responses"]
 
     def format_input(self, input: Dict[str, Any]) -> ChatType:  # type: ignore
         """The input is formatted as a `ChatType` assuming that the instruction
         is the first interaction from the user within a conversation."""
-        return [{"role": "user", "content": self._template.render(**input)}]  # type: ignore
+        return [
+            {
+                "role": "user",
+                "content": self._template.render(  # type: ignore
+                    instruction=input["instruction"], responses=input["responses"]
+                ),
+            }
+        ]
 
     @property
     def outputs(self):
-        """The output for the task is a list of `quality_scores` containing the quality score for each
+        """The output for the task is a list of `scores` containing the quality score for each
         response in `responses`."""
-        return ["scores"]
+        return ["scores", "model_name"]
 
     def format_output(
         self, output: Union[str, None], input: Dict[str, Any]
@@ -94,11 +103,10 @@ class QualityScorer(Task):
             input: the input to the task. Used for obtaining the number of responses.
 
         Returns:
-            A dict with containing the scores for each instruction-response pair.
+            A dict with the key `scores` containing the scores for each instruction-response pair.
         """
-
         if output is None:
-            return {self.outputs[0]: [None] * len(input["responses"])}
+            return {"scores": [None] * len(input["responses"])}
 
         scores = []
         score_lines = output.split("\n")
@@ -109,5 +117,4 @@ class QualityScorer(Task):
             scores.append(score)
             if i == len(input["responses"]) - 1:
                 break
-
-        return {self.outputs[0]: scores}
+        return {"scores": scores}

--- a/src/distilabel/steps/tasks/templates/complexity-scorer.jinja2
+++ b/src/distilabel/steps/tasks/templates/complexity-scorer.jinja2
@@ -1,0 +1,9 @@
+Ranking the following questions according to the difficulty and complexity. Score 1-{{ instructions|length }}.
+You can give a score of {{ (instructions|length) + 1 }} if the question is too complex for you to answer it. You should
+respond with the format:
+[1] Score: 1
+[2] Score: 2
+...
+{% for instruction in instructions %}
+[{{ loop.index }}] {{ instruction }}
+{%- endfor %}

--- a/src/distilabel/steps/tasks/templates/quality-scorer.jinja2
+++ b/src/distilabel/steps/tasks/templates/quality-scorer.jinja2
@@ -1,0 +1,10 @@
+Rank the following pair of instructions and responses according to their quality. Your evaluation should consider factors such as helpfulness, relevance, accuracy, depth, creativity, and level of detail of the response. Score 1-{{ responses|length }}.
+Score each response from 1 to {{ responses|length }}, with {{ (responses|length) + 1}} reserved for responses that are already very well written and cannot be improved further. You should respond with the format:
+[1] Score: 1
+[2] Score: 2
+...
+#Question#: {{ instruction }}
+#Response List#:
+{% for response in responses %}
+[{{ loop.index }}] {{ response }}
+{%- endfor %}

--- a/src/distilabel/steps/tasks/ultrafeedback.py
+++ b/src/distilabel/steps/tasks/ultrafeedback.py
@@ -150,8 +150,7 @@ class UltraFeedback(Task):
             "overall-rating",
         ]:
             return self._format_ratings_rationales_output(output, input)
-        else:
-            return self._format_types_ratings_rationales_output(output, input)
+        return self._format_types_ratings_rationales_output(output, input)
 
     def _format_ratings_rationales_output(
         self, output: Union[str, None], input: Dict[str, Any]

--- a/tests/unit/steps/tasks/test_pair_rm.py
+++ b/tests/unit/steps/tasks/test_pair_rm.py
@@ -42,12 +42,14 @@ class TestPairRM:
                 "candidates": ["fine", "good", "bad"],
                 "ranks": [2, 1, 3],
                 "ranked_candidates": ["good", "fine", "bad"],
+                "model_name": "llm-blender/PairRM",
             },
             {
                 "input": "Anybody there?",
                 "candidates": ["get out", "yep", "nope"],
                 "ranks": [2, 1, 3],
                 "ranked_candidates": ["yep", "get out", "nope"],
+                "model_name": "llm-blender/PairRM",
             },
         ]
 
@@ -62,6 +64,12 @@ class TestPairRM:
             "input_batch_size": ranker.input_batch_size,
             "model": ranker.model,
             "instructions": None,
-            "runtime_parameters_info": [],
+            "runtime_parameters_info": [
+                {
+                    "description": "The number of rows that will contain the batches processed by the step.",
+                    "name": "input_batch_size",
+                    "optional": True,
+                },
+            ],
             "type_info": {"module": "distilabel.steps.tasks.pair_rm", "name": "PairRM"},
         }


### PR DESCRIPTION
## Description

This PR comes with a lot of minor fixes for most of the `Task` subclasses as listed below (see the commits for detailed information on what change is affecting which `Task` subclass):

* Move templates from variables to `*.jinja2` files to keep consistency with the rest of the `Task` subclasses that rely on a template
* Add missing `model_name` in most of the `Task` subclasses, not only in the `outputs` property, but also when overriding the `process` method
* Fix docstrings ensuring that the input/output keys match the ones mentioned in the docstrings, while also fixing some grammar errors; in some cases, the whole docstrings have been rewritten for clarity