### PR TITLE
Fix `RuntimeParamater` validation when provided as `_Step` attr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           else
             pip install -e .[dev,tests,cohere,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,llama-cpp,anthropic,litellm]
           fi
-          pip install git+https://github.com/yuchenlin/LLM-Blender.git@3c2d71f
+          pip install git+https://github.com/argilla-io/LLM-Blender.git
 
       - name: Lint
         run: make lint

--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/mixins/runtime_parameters.py
+++ b/src/distilabel/mixins/runtime_parameters.py
@@ -112,6 +112,7 @@ class RuntimeParametersMixin(BaseModel):
             attr = getattr(self, name)
             if isinstance(attr, RuntimeParametersMixin):
                 attr.set_runtime_parameters(value)
+                self._runtime_parameters[name] = value
                 continue
 
             # Handle settings values for `_SecretField`

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -403,9 +403,10 @@ class DAG(_Serializable):
             if (
                 not is_optional_or_nested
                 and param_name not in runtime_parameters
-                and not _get_attribute_default(
+                and _get_attribute_default(
                     step=step, composed_param_name=composed_param_name
                 )
+                is not None
             ):
                 aux_code = _get_pipeline_aux_code(step.name, composed_param_name)
                 raise ValueError(

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -409,7 +409,7 @@ class DAG(_Serializable):
                 and _get_attribute_default(
                     step=step, composed_param_name=composed_param_name
                 )
-                is not None
+                is None
             ):
                 aux_code = _get_pipeline_aux_code(step.name, composed_param_name)
                 raise ValueError(

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -395,7 +395,10 @@ class DAG(_Serializable):
                         param_name=subparam,
                         composed_param_name=f"{composed_param_name}.{subparam}",
                         is_optional_or_nested=value,
-                        runtime_parameters=runtime_parameters.get(subparam, {}),
+                        # NOTE: `runtime_parameters` get is for the specific case of `LLM` in `Task`
+                        runtime_parameters=runtime_parameters.get(
+                            param_name, runtime_parameters
+                        ),
                         runtime_parameters_names=runtime_parameters_names,
                     )
                 return

--- a/tests/unit/pipeline/test_dag.py
+++ b/tests/unit/pipeline/test_dag.py
@@ -319,7 +319,7 @@ class TestDAG:
             def outputs(self) -> List[str]:
                 return ["response"]
 
-            def process(self) -> "GeneratorStepOutput":
+            def process(self, offset: int = 0) -> "GeneratorStepOutput":
                 yield [{"response": "response1"}], False
 
         step = DummyGeneratorStep(name="dummy_generator_step", pipeline=pipeline)  # type: ignore
@@ -333,6 +333,34 @@ class TestDAG:
             match="Step 'dummy_generator_step' is missing required runtime parameter 'runtime_param1'",
         ):
             dag.validate()
+
+    def test_validate_step_process_runtime_parameters(
+        self, pipeline: "Pipeline"
+    ) -> None:
+        class DummyGeneratorStep(GeneratorStep):
+            runtime_param1: RuntimeParameter[int]
+            runtime_param2: RuntimeParameter[int] = 5
+
+            @property
+            def inputs(self) -> List[str]:
+                return ["instruction"]
+
+            @property
+            def outputs(self) -> List[str]:
+                return ["response"]
+
+            def process(self, offset: int = 0) -> "GeneratorStepOutput":  # type: ignore
+                yield [{"response": "response1"}], False
+
+        step = DummyGeneratorStep(
+            name="dummy_generator_step", runtime_param1=2, pipeline=pipeline
+        )
+        step.set_runtime_parameters({})
+
+        dag = DAG()
+        dag.add_step(step)
+
+        dag.validate()
 
     def test_step_invalid_input_mappings(self, pipeline: "Pipeline") -> None:
         class DummyStep(Step):
@@ -402,7 +430,9 @@ class TestDAG:
             def outputs(self) -> List[str]:
                 return ["response"]
 
-            def process(self, *inputs: StepInput) -> "GeneratorStepOutput":  # type: ignore
+            def process(
+                self, *inputs: StepInput, offset: int = 0
+            ) -> "GeneratorStepOutput":  # type: ignore
                 yield [{"response": "response1"}], False
 
         step = DummyGeneratorStep(name="dummy_generator_step", pipeline=pipeline)
@@ -428,7 +458,7 @@ class TestDAG:
             def outputs(self) -> List[str]:
                 return ["response"]
 
-            def process(self) -> "GeneratorStepOutput":  # type: ignore
+            def process(self, offset: int = 0) -> "GeneratorStepOutput":  # type: ignore
                 yield [{"response": "response1"}], False
 
         step = DummyGeneratorStep(name="dummy_generator_step", pipeline=pipeline)

--- a/tests/unit/pipeline/test_dag.py
+++ b/tests/unit/pipeline/test_dag.py
@@ -458,7 +458,7 @@ class TestDAG:
             def outputs(self) -> List[str]:
                 return ["response"]
 
-            def process(self, offset: int = 0) -> "GeneratorStepOutput":  # type: ignore
+            def process(self) -> "GeneratorStepOutput":  # type: ignore
                 yield [{"response": "response1"}], False
 
         step = DummyGeneratorStep(name="dummy_generator_step", pipeline=pipeline)


### PR DESCRIPTION
## Description

This PR fixes a bug within the `RuntimeParameter` validation, since it was failing even when the mandatory values where provided via `_Step` attributes.

This way, the mandatory `RuntimeParameters` are ensured to be not `None`, while the optional ones can indeed be `None`.

For traceability the bug was introduced in https://github.com/argilla-io/distilabel/pull/493, but related to https://github.com/argilla-io/distilabel/pull/466

Closes #563 