### PR TITLE
Dump logs within a file in .cache/distilabel/pipelines dir

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -36,9 +36,12 @@ class Distiset(dict):
 
     Attributes:
         pipeline_path: Optional path to the pipeline.yaml file that generated the dataset.
+        log_filename_path: Optional path to the pipeline.log file that generated was written by the
+            pipeline.
     """
 
     pipeline_path: Optional[Path] = None
+    log_filename_path: Optional[Path] = None
 
     def push_to_hub(
         self,
@@ -122,6 +125,15 @@ class Distiset(dict):
                 repo_type="dataset",
                 token=token,
             )
+        if self.log_filename_path:
+            # The same we had with "pipeline.yaml" but with the log file.
+            HfApi().upload_file(
+                path_or_fileobj=self.log_filename_path,
+                path_in_repo="pipeline.log",
+                repo_id=repo_id,
+                repo_type="dataset",
+                token=token,
+            )
 
     def _extract_readme_metadata(
         self, repo_id: str, token: Optional[str]
@@ -187,7 +199,11 @@ class Distiset(dict):
         return f"Distiset({{\n{repr}\n}})"
 
 
-def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Distiset:
+def create_distiset(
+    data_dir: Path,
+    pipeline_path: Optional[Path] = None,
+    log_filename_path: Optional[Path] = None,
+) -> Distiset:
     """Creates a `Distiset` from the buffer folder.
 
     Args:
@@ -196,6 +212,9 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
         pipeline_path: Optional path to the pipeline.yaml file that generated the dataset.
             Internally this will be passed to the `Distiset` object on creation to allow
             uploading the `pipeline.yaml` file to the repo upon `Distiset.push_to_hub`.
+        pipeline_path: Optional path to the pipeline.log file that was generated during the pipeline run.
+            Internally this will be passed to the `Distiset` object on creation to allow
+            uploading the `pipeline.log` file to the repo upon `Distiset.push_to_hub`.
 
     Returns:
         The dataset created from the buffer folder, where the different leaf steps will
@@ -237,5 +256,12 @@ def create_distiset(data_dir: Path, pipeline_path: Optional[Path] = None) -> Dis
         pipeline_path = data_dir.parent / "pipeline.yaml"
         if pipeline_path.exists():
             distiset.pipeline_path = pipeline_path
+
+    if log_filename_path:
+        distiset.log_filename_path = log_filename_path
+    else:
+        log_filename_path = data_dir.parent / "pipeline.log"
+        if log_filename_path.exists():
+            distiset.log_filename_path = log_filename_path
 
     return distiset

--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -212,7 +212,7 @@ def create_distiset(
         pipeline_path: Optional path to the pipeline.yaml file that generated the dataset.
             Internally this will be passed to the `Distiset` object on creation to allow
             uploading the `pipeline.yaml` file to the repo upon `Distiset.push_to_hub`.
-        pipeline_path: Optional path to the pipeline.log file that was generated during the pipeline run.
+        log_filename_path: Optional path to the pipeline.log file that was generated during the pipeline run.
             Internally this will be passed to the `Distiset` object on creation to allow
             uploading the `pipeline.log` file to the repo upon `Distiset.push_to_hub`.
 

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -55,6 +55,7 @@ class CacheLocation(TypedDict):
     pipeline: Path
     batch_manager: Path
     data: Path
+    log_file: Path
 
 
 class _GlobalPipelineManager:
@@ -305,6 +306,7 @@ class BasePipeline(_Serializable):
             "pipeline": folder / "pipeline.yaml",
             "batch_manager": folder / "batch_manager.json",
             "data": folder / "data",
+            "log_file": folder / "pipeline.log",
         }
 
     def _cache(self) -> None:

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -107,6 +107,7 @@ class Pipeline(BasePipeline):
             return create_distiset(
                 self._cache_location["data"],
                 pipeline_path=self._cache_location["pipeline"],
+                log_filename_path=self._cache_location["log_file"],
             )
 
         buffer_data_path = self._cache_location["data"]
@@ -151,7 +152,9 @@ class Pipeline(BasePipeline):
 
         write_buffer.close()
         distiset = create_distiset(
-            self._cache_location["data"], pipeline_path=self._cache_location["pipeline"]
+            self._cache_location["data"],
+            pipeline_path=self._cache_location["pipeline"],
+            log_filename_path=self._cache_location["log_file"],
         )
         stop_logging()
         return distiset

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -55,9 +55,9 @@ _STEPS_FINISHED_LOCK = threading.Lock()
 _SUBPROCESS_EXCEPTION: Union[Exception, None] = None
 
 
-def _init_worker(queue: "Queue[Any]", log_filename: str = "pipeline.log") -> None:
+def _init_worker(queue: "Queue[Any]") -> None:
     signal.signal(signal.SIGINT, signal.SIG_IGN)
-    setup_logging(queue, filename=log_filename)
+    setup_logging(queue)
 
 
 class Pipeline(BasePipeline):
@@ -119,7 +119,7 @@ class Pipeline(BasePipeline):
         with ctx.Manager() as manager, ctx.Pool(
             num_processes,
             initializer=_init_worker,
-            initargs=(log_queue, str(self._cache_location["log_file"])),
+            initargs=(log_queue,),
         ) as pool:
             self.output_queue: "Queue[Any]" = manager.Queue()
             self.shared_info = self._create_shared_info_dict(manager)

--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -77,6 +77,11 @@ def setup_logging(log_queue: "Queue[Any]", filename: str = "pipeline.log") -> No
     root_logger.handlers.clear()
     root_logger.setLevel(log_level)
     root_logger.addHandler(QueueHandler(log_queue))
+
+    # Check done to ensure the pipeline.log file can be created because
+    # when setup_logging is called, the current working directory might not exist.
+    if not Path(filename).parent.exists():
+        Path(filename).parent.mkdir(parents=True)
     root_logger.addHandler(FileHandler(filename))
 
 


### PR DESCRIPTION
## Description

Dump the logs to a file under the `.cache/distilabel/pipelines` to allow pushing the file to the dataset in the Hugging Face hub.

A new file will be generated under the cache folder of a pipeline `pipeline.log` that will contain the same logs that are passed to the console and with the same format.

An example log file can be seen at this [dummy dataset](https://huggingface.co/datasets/distilabel-internal-testing/test-file-upload/blob/main/pipeline.log).

Closes #567 