### PR TITLE
Add `seed` with `random.randint` to ensure cache is not used

### DIFF
--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import os
+import random
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from pydantic import (
@@ -349,6 +350,9 @@ class InferenceEndpointsLLM(AsyncLLM):
                 temperature=temperature,
                 top_p=top_p,
                 top_k=top_k,
+                # NOTE: here to ensure that the cache is not used and a different response is
+                # generated every time
+                seed=random.randint(0, 2147483647),
             )
             return [completion]
         except Exception as e:


### PR DESCRIPTION
## Description

This PR sets the `seed` arg in `text_generation` to `random.randint` to ensure that a random seed is used every time, so as to be safer when `num_generations` > 1, since otherwise the cache will be used and no new generations will be generated.

For the moment the `cache` cannot be controlled via the `huggingface_hub.InferenceClient`, so this is a temporary workaround for it.