### PR TITLE
Infer step name

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -247,9 +247,16 @@ class BasePipeline(_Serializable):
             parameters: A dictionary with the step name as the key and a dictionary with
             the parameter name as the key and the parameter value as the value.
         """
+        step_names = set(self.dag.G)
         for step_name, step_parameters in parameters.items():
-            step: "_Step" = self.dag.get_step(step_name)["step"]
-            step.set_runtime_parameters(step_parameters)
+            if step_name not in step_names:
+                self._logger.warning(
+                    f"❓ Step '{step_name}' not found in the pipeline, the runtime parameters will be ignored."
+                    f" Available steps are: {set(step_names)}."
+                )
+            else:
+                step: "_Step" = self.dag.get_step(step_name)["step"]
+                step.set_runtime_parameters(step_parameters)
 
     def _model_dump(self, obj: Any, **kwargs: Any) -> Dict[str, Any]:
         """Dumps the DAG content to a dict.

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -251,8 +251,8 @@ class BasePipeline(_Serializable):
         for step_name, step_parameters in parameters.items():
             if step_name not in step_names:
                 self._logger.warning(
-                    f"❓ Step '{step_name}' not found in the pipeline, the runtime parameters will be ignored."
-                    f" Available steps are: {set(step_names)}."
+                    f"❓ Step '{step_name}' provided in `Pipeline.run(parameters={{...}})` not found in the pipeline."
+                    f" Available steps are: {step_names}."
                 )
             else:
                 step: "_Step" = self.dag.get_step(step_name)["step"]

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -143,9 +143,6 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
 
         super().model_post_init(__context)
 
-        if not self.name:
-            self.name = _infer_step_name(type(self).__name__, self.pipeline)
-
         if self.pipeline is None:
             self.pipeline = _GlobalPipelineManager.get_pipeline()
 
@@ -155,6 +152,12 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
                 " created within a `Pipeline` context. Please, use"
                 " `with Pipeline() as pipeline:` and create the step within the context."
             )
+
+        if not self.name:
+            # This must be done before the check for repeated names, but assuming
+            # we are passing the pipeline from the _GlobalPipelineManager, should
+            # be done after that.
+            self.name = _infer_step_name(type(self).__name__, self.pipeline)
 
         self.pipeline._add_step(self)
 

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -73,8 +73,12 @@ def _infer_step_name(step_cls_name: str, pipeline: Optional["Pipeline"] = None) 
     name = re.sub(PATTERN_PASCAL_NAME, "_", step_cls_name).lower() + "_0"
     if pipeline:
         # Check the name doesn't already exist in the pipeline
-        if name in set(pipeline.dag.G):
-            name = f"{name[:-1]}{int(name[-1])+1}"
+        step_names = set(pipeline.dag.G)
+        parts = name.split("_")
+        base_name = "_".join(parts[:-1])
+        while name in step_names:
+            idx = int(name.split("_")[-1])
+            name = f"{base_name}_{idx+1}"
     return name
 
 

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -212,6 +212,43 @@ class TestBasePipeline:
             pipeline = BasePipeline(name="unit-test-pipeline")
             assert pipeline._cache_dir == Path("/tmp/unit-test")
 
+    @pytest.mark.parametrize(
+        "in_pipeline, names",
+        (
+            (
+                True,
+                [
+                    "dummy_generator_step_0",
+                    "dummy_step1_0",
+                    "dummy_step2_0",
+                    "dummy_step1_1",
+                ],
+            ),
+            # TODO: Activate this test once we merge the option of not passing a Pipeline
+            # (
+            #     False, ["dummy_generator_step", "dummy_step1", "dummy_step2"]
+            # )
+        ),
+    )
+    def test_step_names_inferred(self, in_pipeline: bool, names: List[str]) -> None:
+        if in_pipeline:
+            with BasePipeline(name="unit-test-pipeline"):
+                gen_step = DummyGeneratorStep()
+                step1_0 = DummyStep1()
+                step2 = DummyStep2()
+                step1_1 = DummyStep1()
+                gen_step.connect(step1_0).connect(step2).connect(step1_1)
+        else:
+            gen_step = DummyGeneratorStep()
+            step1_0 = DummyStep1()
+            step2 = DummyStep2()
+            step1_1 = DummyStep1()
+
+        assert gen_step.name == names[0]
+        assert step1_0.name == names[1]
+        assert step2.name == names[2]
+        assert step1_1.name == names[3]
+
 
 class TestBatch:
     def test_next_batch(self) -> None:

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -249,6 +249,14 @@ class TestBasePipeline:
         assert step2.name == names[2]
         assert step1_1.name == names[3]
 
+    def test_infer_step_names_big_pipeline(self) -> None:
+        # Tests that the name of the steps are inferred correctly when the pipeline is big (say 50 steps).
+        with BasePipeline(name="unit-test-pipeline") as pipe:
+            gen_step = DummyGeneratorStep()
+            for _ in range(50):
+                gen_step.connect(DummyStep1())
+        assert list(pipe.dag.G)[-1] == "dummy_step1_49"
+
 
 class TestBatch:
     def test_next_batch(self) -> None:

--- a/tests/unit/steps/test_base.py
+++ b/tests/unit/steps/test_base.py
@@ -77,6 +77,10 @@ class TestStep:
         with pytest.raises(ValidationError):
             DummyStep(name="this is not valid because spaces", pipeline=pipeline)
 
+    def test_create_step_and_infer_name(self) -> None:
+        dummy_step = DummyStep(pipeline=Pipeline(name="unit-test-pipeline"))
+        assert dummy_step.name == "dummy_step_0"
+
     def test_create_step_passing_pipeline(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         step = DummyStep(name="dummy", pipeline=pipeline)


### PR DESCRIPTION
## Description

This PR includes the option to generate a default name for a step if not given. For example:

```python
# do
generate_with_llama3 = TextGeneration(
    llm=InferenceEndpointsLLM(
        model_id="meta-llama/Meta-Llama-3-70B-Instruct",
        tokenizer_id="meta-llama/Meta-Llama-3-70B-Instruct",
        api_key=userdata.get('HF_TOKEN')
    ),
)
# instead of
generate_with_llama3 = TextGeneration(
    name="generate_with_llama3",
    llm=InferenceEndpointsLLM(
        model_id="meta-llama/Meta-Llama-3-70B-Instruct",
        tokenizer_id="meta-llama/Meta-Llama-3-70B-Instruct",
        api_key=userdata.get('HF_TOKEN')
    ),
)
```

When retrieving the name of the step, it would result in the following:

```python
>>> generate_with_llama3.name
'text_generation_0'
```

Also if a user passes a wrong step name for the runtime parameters a warning will be thrown instead of raising a `ValueError`.

### Note

This should be merged after #566 to test under that behaviour.

Closes #572.