### PR TITLE
Set `extra="forbid"` in `_Step.model_config`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           else
             pip install -e .[dev,tests,cohere,hf-transformers,hf-inference-endpoints,vertexai,ollama,openai,together,argilla,llama-cpp,anthropic,litellm]
           fi
-          pip install git+https://github.com/yuchenlin/LLM-Blender.git@3c2d71f
+          pip install git+https://github.com/argilla-io/LLM-Blender.git
 
       - name: Lint
         run: make lint

--- a/docs/api/steps/tasks/preference_tasks.md
+++ b/docs/api/steps/tasks/preference_tasks.md
@@ -1,3 +1,4 @@
-# Preference tasks
+# Preference Tasks
 
+::: distilabel.steps.tasks.instruction_backtranslation
 ::: distilabel.steps.tasks.ultrafeedback

--- a/docs/api/steps/tasks/text_generation.md
+++ b/docs/api/steps/tasks/text_generation.md
@@ -4,17 +4,21 @@ This section contains the API reference for the distilabel tasks. For an example
 
 ::: distilabel.steps.tasks.base
 
-## General Text Generation
+## Text Generation
 
-::: distilabel.steps.tasks.text_generation
+::: distilabel.steps.tasks.text_generation.TextGeneration
 
-## Evol Instruct
+## Chat Generation
+
+::: distilabel.steps.tasks.text_generation.ChatGeneration
+
+## Evol Instruct
 
 ::: distilabel.steps.tasks.evol_instruct.base
 ::: distilabel.steps.tasks.evol_instruct.generator
 ::: distilabel.steps.tasks.evol_instruct.utils
 
-### Evol Complexity
+### Evol Complexity
 
 ::: distilabel.steps.tasks.evol_instruct.evol_complexity.base
 ::: distilabel.steps.tasks.evol_instruct.evol_complexity.generator

--- a/docs/sections/learn/tasks/text_generation.md
+++ b/docs/sections/learn/tasks/text_generation.md
@@ -20,7 +20,7 @@ text_generation = TextGeneration(
         api_key=os.getenv("MISTRALAI_API_KEY"),  # type: ignore
     ),
     input_batch_size=8,
-    pipeline=Pipeline(name="text-gen-pipeline")
+    pipeline=Pipeline(name="text-gen-pipeline"),
 )
 
 # remember to call .load() if testing outside of a Pipeline context
@@ -56,6 +56,84 @@ print(result[0]["generation"])
 # 5. Motown: The Beatles' influence extended beyond rock music, and their success paved the way for other genres to gain mainstream acceptance in the US. Motown, for instance, would have faced more resistance in breaking into the US market without The Beatles' paving the way.
 
 # It's also worth noting that The Beatles' influence extends far beyond their music. They were trendsetters in fashion, hairstyles, and cultural norms. Their break-up in 1970 marked the end of an era in popular culture, and the music industry has never been the same since. So, even if other bands and artists had taken their place, The Beatles' impact on music and culture would still be felt.
+```
+
+Additionally, note that the `TextGeneration` task admits an optional `system_prompt` within the input, that can be used to prepend a system message to the input instruction or conversation, and is controlled via the `use_system_prompt` attribute, meaning that when set to `True` i.e. the default scenario, the system prompt will be inserted into the conversation if the `system_prompt` column is available within the input; alternatively, if set to `False` even if the `system_prompt` key exists, it won't be used. This can be useful to provide context or additional information to the model, as shown in the following example:
+
+```python
+import os
+
+from distilabel.pipeline import Pipeline
+from distilabel.llms.mistral import MistralLLM
+from distilabel.steps.tasks.text_generation import TextGeneration
+
+text_generation = TextGeneration(
+    name="chat-generation",
+    llm=MistralLLM(
+        model="mistral-tiny",
+        api_key=os.getenv("MISTRALAI_API_KEY"),  # type: ignore
+    ),
+    use_system_prompt=True,
+    input_batch_size=8,
+    pipeline=Pipeline(name="text-gen-pipeline"),
+)
+
+# remember to call .load() if testing outside of a Pipeline context
+text_generation.load()
+
+result = next(
+    text_generation.process(
+        [
+            {
+                "instruction": "What if the Beatles had never formed as a band?",
+                "system_prompt": "You are a helpful assistant, that knows everything about The Beatles."
+            },
+        ] 
+    )
+)
+```
+
+---
+
+Alternatively, we can also define the [`ChatGeneration`][distilabel.steps.tasks.text_generation.ChatGeneration] task, which has the same goal as the `TextGeneration` task, but expects a list of messages from a conversation formatted using the [OpenAI format](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models) instead of a single instruction, so that the last assistant response is generated no matter how long the conversation is.
+
+So that the task can be used in the same way as the previous one, we can instantiate it as follows:
+
+```python
+import os
+
+from distilabel.pipeline import Pipeline
+from distilabel.llms.mistral import MistralLLM
+from distilabel.steps.tasks.text_generation import ChatGeneration
+
+chat_generation = ChatGeneration(
+    name="chat-generation",
+    llm=MistralLLM(
+        model="mistral-tiny",
+        api_key=os.getenv("MISTRALAI_API_KEY"),  # type: ignore
+    ),
+    input_batch_size=8,
+    pipeline=Pipeline(name="text-gen-pipeline"),
+)
+
+# remember to call .load() if testing outside of a Pipeline context
+chat_generation.load()
+```
+
+We can just pass a simple task to test it:
+
+```python
+result = next(
+    chat_generation.process(
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "What if the Beatles had never formed as a band?"},
+                ],
+            },
+        ] 
+    )
+)
 ```
 
 Let's see now how we can tweak this task to adhere a bit more to another more customized task.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ theme:
     - header.autohide # header disappears as you scroll
     - content.code.copy
     - content.code.annotate
+    - content.tabs.link
   palette:
     - media: "(prefers-color-scheme)"
       primary: white

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -93,7 +93,10 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
     """
 
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, validate_default=True, validate_assignment=True
+        arbitrary_types_allowed=True,
+        validate_default=True,
+        validate_assignment=True,
+        extra="forbid",
     )
 
     name: str = Field(pattern=r"^[a-zA-Z0-9_-]+$")

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -123,7 +123,7 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
 
     def connect(
         self, step: "_Step", input_mappings: Union[Dict[str, str], None] = None
-    ) -> None:
+    ) -> "_Step":
         """Connects the current step to another step in the pipeline, which means that
         the output of this step will be the input of the other step.
 
@@ -134,10 +134,61 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
                 columns will be mapped by name. This is useful when the names of the
                 output columns of the current step are different from the names of the
                 input columns of the other step. Defaults to `None`.
+
+        Returns:
+            The step connected, to allow nested calls to the `connect` method.
         """
         if input_mappings is not None:
             step.input_mappings = input_mappings
         self.pipeline._add_edge(self.name, step.name)  # type: ignore
+        return step
+
+    def __rshift__(self, other: Union["_Step", List["_Step"]]) -> "_Step":
+        """Allows using the `>>` operator to connect steps in the pipeline.
+
+        Args:
+            other: The step to connect to or a list of steps to connect to.
+
+        Returns:
+            The connected step, or the last one of the list of steps if a list is passed.
+
+        Example:
+            ```python
+            step1 >> step2
+            # Would be equivalent to:
+            step1.connect(step2)
+
+            # It also allows to connect a list of steps
+            step1 >> [step2, step3]
+            ```
+        """
+        if isinstance(other, list):
+            for step in other:
+                self.connect(step)
+            return other
+        return self.connect(other)
+
+    def __rrshift__(self, other: List["_Step"]) -> "_Step":
+        """Allows using the [step1, step2] >> step3 operator to connect a list of steps in the pipeline
+        to a single step, as the list doesn't have the __rshift__ operator.
+
+        Args:
+            step: The step to connect to.
+
+        Returns:
+            The connected step
+
+        Example:
+            ```python
+            [step2, step3] >> step1
+            # Would be equivalent to:
+            step2.connect(step1)
+            step3.connect(step1)
+            ```
+        """
+        for o in other:
+            o.connect(self)
+        return self
 
     def load(self) -> None:
         """Method to perform any initialization logic before the `process` method is

--- a/src/distilabel/steps/tasks/__init__.py
+++ b/src/distilabel/steps/tasks/__init__.py
@@ -28,13 +28,14 @@ from distilabel.steps.tasks.instruction_backtranslation import (
 from distilabel.steps.tasks.pair_rm import PairRM
 from distilabel.steps.tasks.quality_scorer import QualityScorer
 from distilabel.steps.tasks.self_instruct import SelfInstruct
-from distilabel.steps.tasks.text_generation import TextGeneration
+from distilabel.steps.tasks.text_generation import ChatGeneration, TextGeneration
 from distilabel.steps.tasks.typing import ChatItem, ChatType
 from distilabel.steps.tasks.ultrafeedback import UltraFeedback
 
 __all__ = [
     "Task",
     "GeneratorTask",
+    "ChatGeneration",
     "ChatItem",
     "ChatType",
     "ComplexityScorer",

--- a/src/distilabel/steps/tasks/generate_embeddings.py
+++ b/src/distilabel/steps/tasks/generate_embeddings.py
@@ -37,6 +37,7 @@ class GenerateEmbeddings(Step):
 
     Output columns:
         - embedding (`List[float]`): The embedding of the input text or conversation.
+        - model_name (`str`): The model name used to generate the embeddings.
 
     References:
         - [What Makes Good Data for Alignment? A Comprehensive Study of Automatic Data Selection in Instruction Tuning](https://arxiv.org/abs/2312.15685)
@@ -47,6 +48,7 @@ class GenerateEmbeddings(Step):
     def load(self) -> None:
         """Loads the `LLM` used to generate the embeddings."""
         super().load()
+
         self.llm.load()
 
     @property
@@ -59,7 +61,7 @@ class GenerateEmbeddings(Step):
     def outputs(self) -> List[str]:
         """The outputs for the task is an `embedding` column containing the embedding of
         the `text` input."""
-        return ["embedding"]
+        return ["embedding", "model_name"]
 
     def format_input(self, input: Dict[str, Any]) -> "ChatType":
         """Formats the input to be used by the LLM to generate the embeddings. The input
@@ -99,4 +101,5 @@ class GenerateEmbeddings(Step):
         last_hidden_states = self.llm.get_last_hidden_states(formatted_inputs)
         for input, hidden_state in zip(inputs, last_hidden_states):
             input["embedding"] = hidden_state[-1].tolist()
+            input["model_name"] = self.llm.model_name
         yield inputs

--- a/src/distilabel/steps/tasks/instruction_backtranslation.py
+++ b/src/distilabel/steps/tasks/instruction_backtranslation.py
@@ -41,6 +41,8 @@ class InstructionBacktranslation(Task):
 
     Output columns:
         - score (`str`): The score for the generation based on the given instruction.
+        - reason (`str`): The reason for the provided score.
+        - model_name (`str`): The model name used to score the generation.
 
     References:
         - [`Self-Alignment with Instruction Backtranslation`](https://arxiv.org/abs/2308.06259)
@@ -49,7 +51,7 @@ class InstructionBacktranslation(Task):
     _template: Optional["Template"] = PrivateAttr(default=...)
 
     def load(self) -> None:
-        """Loads the Jinja2 template with the Instruction Backtranslation prompt."""
+        """Loads the Jinja2 template."""
         super().load()
 
         _path = str(

--- a/src/distilabel/steps/tasks/pair_rm.py
+++ b/src/distilabel/steps/tasks/pair_rm.py
@@ -28,7 +28,6 @@ class PairRM(Step):
 
     Attributes:
         model: The model to use for the ranking. Defaults to `"llm-blender/PairRM"`.
-        input_batch_size: The batch size to use when processing the input. Defaults to `8`.
         instructions: The instructions to use for the model. Defaults to `None`.
 
     Input columns:
@@ -38,6 +37,7 @@ class PairRM(Step):
     Output columns:
         - ranks (`List[int]`): The ranks of the candidates based on the input.
         - ranked_candidates (`List[Dict[str, Any]]`): The candidates ranked based on the input.
+        - model_name (`str`): The model name used to rank the candidate responses. Defaults to `"llm-blender/PairRM"`.
 
     References:
         - [LLM-Blender: Ensembling Large Language Models with Pairwise Ranking and Generative Fusion](https://arxiv.org/abs/2306.02561).
@@ -49,10 +49,11 @@ class PairRM(Step):
     """
 
     model: str = "llm-blender/PairRM"
-    input_batch_size: int = 8
     instructions: Optional[str] = None
 
     def load(self) -> None:
+        """Loads the PairRM model provided via `model` with `llm_blender.Blender`, which is the
+        custom library for running the inference for the PairRM models."""
         try:
             import llm_blender
         except ImportError as e:
@@ -60,6 +61,7 @@ class PairRM(Step):
                 "The `llm_blender` package is required to use the `PairRM` class."
                 "Please install it with `pip install git+https://github.com/yuchenlin/LLM-Blender.git`."
             ) from e
+
         self._blender = llm_blender.Blender()
         self._blender.loadranker(self.model)
 
@@ -72,14 +74,14 @@ class PairRM(Step):
     @property
     def outputs(self) -> List[str]:
         """The outputs will include the `ranks` and the `ranked_candidates`."""
-        return ["ranks", "ranked_candidates"]
+        return ["ranks", "ranked_candidates", "model_name"]
 
     def format_input(self, input: Dict[str, Any]) -> Dict[str, Any]:
         """The input is expected to be a dictionary with the keys `input` and `candidates`,
         where the `input` corresponds to the instruction of a model and `candidates` are a
         list of responses to be ranked.
         """
-        return input
+        return {"input": input["input"], "candidates": input["candidates"]}
 
     def process(self, inputs: StepInput) -> "StepOutput":  # type: ignore
         """Generates the ranks for the candidates based on the input.
@@ -92,7 +94,7 @@ class PairRM(Step):
             inputs: A list of Python dictionaries with the inputs of the task.
 
         Yields:
-            An iterator with the inputs containing the `ranks` and the `ranked_candidates`.
+            An iterator with the inputs containing the `ranks`, `ranked_candidates`, and `model_name`.
         """
         input_texts = []
         candidates = []
@@ -120,5 +122,6 @@ class PairRM(Step):
         for input, rank, ranked_candidate in zip(inputs, ranks, ranked_candidates):
             input["ranks"] = rank
             input["ranked_candidates"] = ranked_candidate
+            input["model_name"] = self.model
 
         yield inputs

--- a/src/distilabel/steps/tasks/templates/complexity-scorer.jinja2
+++ b/src/distilabel/steps/tasks/templates/complexity-scorer.jinja2
@@ -1,0 +1,9 @@
+Ranking the following questions according to the difficulty and complexity. Score 1-{{ instructions|length }}.
+You can give a score of {{ (instructions|length) + 1 }} if the question is too complex for you to answer it. You should
+respond with the format:
+[1] Score: 1
+[2] Score: 2
+...
+{% for instruction in instructions %}
+[{{ loop.index }}] {{ instruction }}
+{%- endfor %}

--- a/src/distilabel/steps/tasks/templates/quality-scorer.jinja2
+++ b/src/distilabel/steps/tasks/templates/quality-scorer.jinja2
@@ -1,0 +1,10 @@
+Rank the following pair of instructions and responses according to their quality. Your evaluation should consider factors such as helpfulness, relevance, accuracy, depth, creativity, and level of detail of the response. Score 1-{{ responses|length }}.
+Score each response from 1 to {{ responses|length }}, with {{ (responses|length) + 1}} reserved for responses that are already very well written and cannot be improved further. You should respond with the format:
+[1] Score: 1
+[2] Score: 2
+...
+#Question#: {{ instruction }}
+#Response List#:
+{% for response in responses %}
+[{{ loop.index }}] {{ response }}
+{%- endfor %}

--- a/src/distilabel/steps/tasks/ultrafeedback.py
+++ b/src/distilabel/steps/tasks/ultrafeedback.py
@@ -150,8 +150,7 @@ class UltraFeedback(Task):
             "overall-rating",
         ]:
             return self._format_ratings_rationales_output(output, input)
-        else:
-            return self._format_types_ratings_rationales_output(output, input)
+        return self._format_types_ratings_rationales_output(output, input)
 
     def _format_ratings_rationales_output(
         self, output: Union[str, None], input: Dict[str, Any]

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1190,6 +1190,151 @@ class TestPipelineSerialization:
                 else:
                     assert not pipe._batch_manager
 
+    def test_connect_successive_steps(self) -> None:
+        from distilabel.pipeline.local import Pipeline
+
+        from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
+
+        with Pipeline(name="unit-test-pipeline-1") as pipeline_1:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator.connect(dummy_step_1)
+            dummy_step_1.connect(dummy_step_2)
+
+            signature_1 = pipeline_1._create_signature()
+
+        with Pipeline(name="unit-test-pipeline-2") as pipeline_2:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator.connect(dummy_step_1).connect(dummy_step_2)
+
+            signature_2 = pipeline_2._create_signature()
+
+        assert signature_1 == signature_2
+
+    def test_binary_rshift_operator(self) -> None:
+        # Tests the steps can be connected using the >> operator.
+        from distilabel.pipeline.local import Pipeline
+
+        from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
+
+        with Pipeline(name="unit-test-pipeline-1") as pipeline_1:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator.connect(dummy_step_1)
+            dummy_step_1.connect(dummy_step_2)
+
+            signature_1 = pipeline_1._create_signature()
+
+        with Pipeline(name="unit-test-pipeline-3") as pipeline_2:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator >> dummy_step_1 >> dummy_step_2
+
+            signature_2 = pipeline_2._create_signature()
+
+        assert signature_1 == signature_2
+
+    def test_binary_rshift_operator_with_list(self) -> None:
+        # Tests the steps can be connected using the >> operator when using a list.
+        from distilabel.pipeline.local import Pipeline
+
+        from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
+
+        with Pipeline(name="unit-test-pipeline-1") as pipeline_1:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator.connect(dummy_step_1)
+            dummy_generator.connect(dummy_step_2)
+
+            signature_1 = pipeline_1._create_signature()
+
+        with Pipeline(name="unit-test-pipeline-2") as pipeline_2:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+
+            dummy_generator >> [dummy_step_1, dummy_step_2]
+
+            signature_2 = pipeline_2._create_signature()
+
+        assert signature_1 == signature_2
+
+    def test_binary_rrshift_operator(self) -> None:
+        # Tests that a list of steps can be connected to a single step using the >> operator.
+        # It usses the __rrshift__ method instead of the __rshift__ as it applies to the list
+        # instead of the Step.
+
+        from distilabel.pipeline.local import Pipeline
+
+        from tests.unit.pipeline.utils import DummyGlobalStep, DummyStep1, DummyStep2
+
+        with Pipeline(name="unit-test-pipeline-1") as pipeline_1:
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+            dummy_global = DummyGlobalStep(name="dummy_global_step")
+
+            dummy_step_1.connect(dummy_global)
+            dummy_step_2.connect(dummy_global)
+
+            signature_1 = pipeline_1._create_signature()
+
+        with Pipeline(name="unit-test-pipeline-2") as pipeline_2:
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+            dummy_global = DummyGlobalStep(name="dummy_global_step")
+
+            [dummy_step_1, dummy_step_2] >> dummy_global
+            signature_2 = pipeline_2._create_signature()
+
+        assert signature_1 == signature_2
+
+    def test_binary_operators(self) -> None:
+        # Tests the steps can be connected with the binary operators,
+        # the general case of step1 >> [step2, step3] >> step4
+        from distilabel.pipeline.local import Pipeline
+
+        from tests.unit.pipeline.utils import (
+            DummyGeneratorStep,
+            DummyGlobalStep,
+            DummyStep1,
+            DummyStep2,
+        )
+
+        with Pipeline(name="unit-test-pipeline-1") as pipeline_1:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+            dummy_global = DummyGlobalStep(name="dummy_global_step")
+
+            dummy_generator.connect(dummy_step_1)
+            dummy_generator.connect(dummy_step_2)
+            dummy_step_1.connect(dummy_global)
+            dummy_step_2.connect(dummy_global)
+
+            signature_1 = pipeline_1._create_signature()
+
+        with Pipeline(name="unit-test-pipeline-2") as pipeline_2:
+            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
+            dummy_step_1 = DummyStep1(name="dummy_step_1")
+            dummy_step_2 = DummyStep2(name="dummy_step_2")
+            dummy_global = DummyGlobalStep(name="dummy_global_step")
+
+            dummy_generator >> [dummy_step_1, dummy_step_2] >> dummy_global
+            signature_2 = pipeline_2._create_signature()
+
+        assert signature_1 == signature_2
+
 
 class TestWriteBuffer:
     def test_create(self) -> None:

--- a/tests/unit/steps/tasks/test_pair_rm.py
+++ b/tests/unit/steps/tasks/test_pair_rm.py
@@ -42,12 +42,14 @@ class TestPairRM:
                 "candidates": ["fine", "good", "bad"],
                 "ranks": [2, 1, 3],
                 "ranked_candidates": ["good", "fine", "bad"],
+                "model_name": "llm-blender/PairRM",
             },
             {
                 "input": "Anybody there?",
                 "candidates": ["get out", "yep", "nope"],
                 "ranks": [2, 1, 3],
                 "ranked_candidates": ["yep", "get out", "nope"],
+                "model_name": "llm-blender/PairRM",
             },
         ]
 
@@ -62,6 +64,12 @@ class TestPairRM:
             "input_batch_size": ranker.input_batch_size,
             "model": ranker.model,
             "instructions": None,
-            "runtime_parameters_info": [],
+            "runtime_parameters_info": [
+                {
+                    "description": "The number of rows that will contain the batches processed by the step.",
+                    "name": "input_batch_size",
+                    "optional": True,
+                },
+            ],
             "type_info": {"module": "distilabel.steps.tasks.pair_rm", "name": "PairRM"},
         }

--- a/tests/unit/steps/tasks/test_text_generation.py
+++ b/tests/unit/steps/tasks/test_text_generation.py
@@ -12,45 +12,139 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from distilabel.pipeline.local import Pipeline
-from distilabel.steps.tasks.text_generation import TextGeneration
+from distilabel.steps.tasks.text_generation import ChatGeneration, TextGeneration
 
 from tests.unit.steps.tasks.utils import DummyLLM
 
 
 class TestTextGeneration:
-    def test_format_input_with_str(self) -> None:
+    def test_format_input(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
-        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+        task = TextGeneration(
+            name="task", llm=llm, pipeline=pipeline, use_system_prompt=False
+        )
 
-        assert task.format_input({"instruction": "test"}) == [
+        assert task.format_input({"instruction": "test", "system_prompt": "test"}) == [
             {"role": "user", "content": "test"}
         ]
 
-    def test_format_input_with_conversation(self) -> None:
+    def test_format_input_with_system_prompt(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
-        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+        task = TextGeneration(
+            name="task",
+            llm=llm,
+            pipeline=pipeline,
+            use_system_prompt=True,
+        )
 
-        assert task.format_input(
-            {
-                "instruction": [
-                    {"role": "system", "content": "You're a helpful assistant"},
-                    {"role": "user", "content": "How much is 2+2?"},
-                    {"role": "system", "content": "4"},
-                ]
-            }
-        ) == [
-            {"role": "system", "content": "You're a helpful assistant"},
-            {"role": "user", "content": "How much is 2+2?"},
-            {"role": "system", "content": "4"},
+        assert task.format_input({"instruction": "test", "system_prompt": "test"}) == [
+            {"role": "system", "content": "test"},
+            {"role": "user", "content": "test"},
         ]
+
+    def test_format_input_errors(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = TextGeneration(
+            name="task", llm=llm, pipeline=pipeline, use_system_prompt=True
+        )
+
+        with pytest.raises(
+            ValueError, match=r"Input \`instruction\` must be a string. Got: 1."
+        ):
+            task.format_input({"instruction": 1})
+
+        with pytest.warns(
+            UserWarning,
+            match=r"\`use_system_prompt\` is set to \`True\`, but no \`system_prompt\` in input batch, so it will be ignored.",
+        ):
+            assert task.format_input({"instruction": "test"}) == [
+                {"role": "user", "content": "test"}
+            ]
 
     def test_process(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
         task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+
         assert next(task.process([{"instruction": "test"}])) == [
             {"instruction": "test", "generation": "output", "model_name": "test"}
+        ]
+
+    def test_deprecation_warning(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"Providing \`instruction\` formatted as an OpenAI chat \/ conversation is about to be deprecated in \`distilabel v1.2.0\`",
+        ):
+            task.format_input(
+                {
+                    "instruction": [
+                        {"role": "user", "content": "Tell me a joke."},
+                    ]
+                }
+            )
+
+
+class TestChatGeneration:
+    def test_format_input(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = ChatGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        assert task.format_input(
+            {
+                "messages": [
+                    {"role": "system", "content": "You're a helpful assistant"},
+                    {"role": "user", "content": "How much is 2+2?"},
+                ]
+            }
+        ) == [
+            {"role": "system", "content": "You're a helpful assistant"},
+            {"role": "user", "content": "How much is 2+2?"},
+        ]
+
+    def test_format_input_errors(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = ChatGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        with pytest.raises(ValueError, match="The last message must be from the user"):
+            task.format_input(
+                {
+                    "messages": [
+                        {"role": "user", "content": "How much is 2+2?"},
+                        {"role": "assistant", "content": "4"},
+                    ]
+                }
+            )
+
+    def test_process(self) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        llm = DummyLLM()
+        task = ChatGeneration(name="task", llm=llm, pipeline=pipeline)
+
+        assert next(
+            task.process(
+                [
+                    {
+                        "messages": [
+                            {"role": "user", "content": "Tell me a joke."},
+                        ]
+                    }
+                ]
+            )
+        ) == [
+            {
+                "messages": [{"role": "user", "content": "Tell me a joke."}],
+                "generation": "output",
+                "model_name": "test",
+            }
         ]


### PR DESCRIPTION
## Description

This PR sets the `extra="forbid"` value within the `model_config` of `_Step` so as to disallow the usage of extra attributes / fields not defined within the original `pydantic.BaseModel`.

The original idea of adding this PR was based on the issue #576, since `input_columns` was being used instead of `input_mappings`, but no exception was being raised, so the issue was not easy to identify without the `ValidationError`.