### PR TITLE
Add `Format{Chat,Text}Generation{DPO,SFT}`

### DIFF
--- a/src/distilabel/steps/formatting/__init__.py
+++ b/src/distilabel/steps/formatting/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distilabel.steps.formatting.dpo import (
+    FormatChatGenerationDPO,
+    FormatTextGenerationDPO,
+)
+from distilabel.steps.formatting.sft import (
+    FormatChatGenerationSFT,
+    FormatTextGenerationSFT,
+)
+
+__all__ = [
+    "FormatChatGenerationDPO",
+    "FormatChatGenerationSFT",
+    "FormatTextGenerationDPO",
+    "FormatTextGenerationSFT",
+]

--- a/src/distilabel/steps/formatting/dpo.py
+++ b/src/distilabel/steps/formatting/dpo.py
@@ -1,0 +1,159 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+from typing import TYPE_CHECKING, List
+
+from distilabel.steps.base import Step, StepInput
+
+if TYPE_CHECKING:
+    from distilabel.steps.typing import StepOutput
+
+
+class FormatTextGenerationDPO(Step):
+    # The formatting presented below will follow the standards defined within the main
+    # LLM fine-tuning libraries / frameworks being `axolotl`, and `alignment-handbook`
+    # i.e. `trl`
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["instruction", "generations", "ratings"]
+
+    @property
+    def optional_inputs(self) -> List[str]:
+        # Here for the sake of keeping things consistent, while not obscuring any input
+        return ["system_prompt", "generation_models"]
+
+    @property
+    def outputs(self) -> List[str]:
+        # Output format inspired in https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+        return [
+            "prompt",
+            "prompt_id",
+            "chosen",
+            "chosen_model",
+            "chosen_rating",
+            "rejected",
+            "rejected_model",
+            "rejected_rating",
+        ]
+
+    def process(self, *inputs: StepInput) -> "StepOutput":  # type: ignore
+        for input in inputs:
+            for item in input:
+                messages = [
+                    {"role": "user", "content": item["instruction"]},  # type: ignore
+                ]
+                if (
+                    "system_prompt" in item
+                    and isinstance(item["system_prompt"], str)  # type: ignore
+                    and len(item["system_prompt"]) > 0  # type: ignore
+                ):
+                    messages.insert(
+                        0,
+                        {"role": "system", "content": item["system_prompt"]},  # type: ignore
+                    )
+
+                item["prompt"] = item["instruction"]
+                item["prompt_id"] = hashlib.sha256(
+                    item["prompt"].encode("utf-8")  # type: ignore
+                ).hexdigest()
+
+                chosen_idx = max(enumerate(item["ratings"]), key=lambda x: x[1])[0]
+                item["chosen"] = messages + [
+                    {
+                        "role": "assistant",
+                        "content": item["generations"][chosen_idx],
+                    }
+                ]
+                item["chosen_model"] = item["generation_models"][chosen_idx]
+                item["chosen_rating"] = item["ratings"][chosen_idx]
+
+                rejected_idx = min(enumerate(item["ratings"]), key=lambda x: x[1])[0]
+                item["rejected"] = messages + [
+                    {
+                        "role": "assistant",
+                        "content": item["generations"][rejected_idx],
+                    }
+                ]
+                item["rejected_model"] = item["generation_models"][rejected_idx]
+                item["rejected_rating"] = item["ratings"][rejected_idx]
+
+            yield input
+
+
+class FormatChatGenerationDPO(Step):
+    # The formatting presented below will follow the standards defined within the main
+    # LLM fine-tuning libraries / frameworks being `axolotl`, and `alignment-handbook`
+    # i.e. `trl`
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["messages", "generations", "ratings"]
+
+    @property
+    def optional_inputs(self) -> List[str]:
+        # Here for the sake of keeping things consistent, while not obscuring any input
+        return ["generation_models"]
+
+    @property
+    def outputs(self) -> List[str]:
+        # Output format inspired in https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+        return [
+            "prompt",
+            "prompt_id",
+            "chosen",
+            "chosen_model",
+            "chosen_rating",
+            "rejected",
+            "rejected_model",
+            "rejected_rating",
+        ]
+
+    def process(self, *inputs: StepInput) -> "StepOutput":  # type: ignore
+        for input in inputs:
+            for item in input:
+                item["prompt"] = next(
+                    (
+                        turn["content"]
+                        for turn in item["messages"]
+                        if turn["role"] == "user"
+                    ),
+                    None,
+                )
+                item["prompt_id"] = hashlib.sha256(
+                    item["prompt"].encode("utf-8")  # type: ignore
+                ).hexdigest()
+
+                chosen_idx = max(enumerate(item["ratings"]), key=lambda x: x[1])[0]
+                item["chosen"] = item["messages"] + [
+                    {
+                        "role": "assistant",
+                        "content": item["generations"][chosen_idx],
+                    }
+                ]
+                item["chosen_model"] = item["generation_models"][chosen_idx]
+                item["chosen_rating"] = item["ratings"][chosen_idx]
+
+                rejected_idx = min(enumerate(item["ratings"]), key=lambda x: x[1])[0]
+                item["rejected"] = item["messages"] + [
+                    {
+                        "role": "assistant",
+                        "content": item["generations"][rejected_idx],
+                    }
+                ]
+                item["rejected_model"] = item["generation_models"][rejected_idx]
+                item["rejected_rating"] = item["ratings"][rejected_idx]
+
+            yield input

--- a/src/distilabel/steps/formatting/sft.py
+++ b/src/distilabel/steps/formatting/sft.py
@@ -1,0 +1,103 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+from typing import TYPE_CHECKING, List
+
+from distilabel.steps.base import Step, StepInput
+
+if TYPE_CHECKING:
+    from distilabel.steps.typing import StepOutput
+
+
+class FormatTextGenerationSFT(Step):
+    # The formatting presented below will follow the standards defined within the main
+    # LLM fine-tuning libraries / frameworks being `axolotl`, and `alignment-handbook`
+    # i.e. `trl`
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["instruction", "generation"]
+
+    @property
+    def optional_inputs(self) -> List[str]:
+        # Here for the sake of keeping things consistent, while not obscuring any input
+        return ["system_prompt"]
+
+    @property
+    def outputs(self) -> List[str]:
+        # Output format inspired in https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+        return ["prompt", "prompt_id", "messages"]
+
+    def process(self, *inputs: StepInput) -> "StepOutput":  # type: ignore
+        for input in inputs:
+            for item in input:
+                item["prompt"] = item["instruction"]
+
+                item["prompt_id"] = hashlib.sha256(
+                    item["prompt"].encode("utf-8")  # type: ignore
+                ).hexdigest()
+
+                item["messages"] = [
+                    {"role": "user", "content": item["instruction"]},  # type: ignore
+                    {"role": "assistant", "content": item["generation"]},  # type: ignore
+                ]
+                if (
+                    "system_prompt" in item
+                    and isinstance(item["system_prompt"], str)  # type: ignore
+                    and len(item["system_prompt"]) > 0  # type: ignore
+                ):
+                    item["messages"].insert(
+                        0,
+                        {"role": "system", "content": item["system_prompt"]},  # type: ignore
+                    )
+
+            yield input
+
+
+class FormatChatGenerationSFT(Step):
+    # The formatting presented below will follow the standards defined within the main
+    # LLM fine-tuning libraries / frameworks being `axolotl`, and `alignment-handbook`
+    # i.e. `trl`
+
+    @property
+    def inputs(self) -> List[str]:
+        return ["messages", "generation"]
+
+    @property
+    def outputs(self) -> List[str]:
+        # Output format inspired in https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+        return ["prompt", "prompt_id", "messages"]
+
+    def process(self, *inputs: StepInput) -> "StepOutput":  # type: ignore
+        for input in inputs:
+            for item in input:
+                item["prompt"] = next(
+                    (
+                        turn["content"]
+                        for turn in item["messages"]
+                        if turn["role"] == "user"
+                    ),
+                    None,
+                )
+
+                item["prompt_id"] = hashlib.sha256(
+                    item["prompt"].encode("utf-8")  # type: ignore
+                ).hexdigest()
+
+                item["messages"] = item["messages"] + [
+                    {"role": "assistant", "content": item["generation"]},  # type: ignore
+                ]
+
+            yield input

--- a/tests/unit/steps/formatting/__init__.py
+++ b/tests/unit/steps/formatting/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/steps/formatting/test_dpo.py
+++ b/tests/unit/steps/formatting/test_dpo.py
@@ -1,0 +1,141 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distilabel.pipeline import Pipeline
+from distilabel.steps.formatting.dpo import (
+    FormatChatGenerationDPO,
+    FormatTextGenerationDPO,
+)
+
+
+class TestFormatTextGenerationDPO:
+    def test_process(self) -> None:
+        step = FormatTextGenerationDPO(name="dpo", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "instruction": "What's 2+2?",
+                        "generations": ["4", "5", "6"],
+                        "generation_models": ["A", "B", "C"],
+                        "ratings": [1, 0, -1],
+                    }
+                ]
+            )
+        ) == [
+            {
+                "instruction": "What's 2+2?",
+                "generations": ["4", "5", "6"],
+                "generation_models": ["A", "B", "C"],
+                "ratings": [1, 0, -1],
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+                "chosen": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+                "chosen_rating": 1,
+                "chosen_model": "A",
+                "rejected": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "6"},
+                ],
+                "rejected_rating": -1,
+                "rejected_model": "C",
+            }
+        ]
+
+    def test_process_with_system_prompt(self) -> None:
+        step = FormatTextGenerationDPO(name="dpo", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "system_prompt": "You are a helpful assistant.",
+                        "instruction": "What's 2+2?",
+                        "generations": ["4", "5", "6"],
+                        "generation_models": ["A", "B", "C"],
+                        "ratings": [1, 0, -1],
+                    }
+                ]
+            )
+        ) == [
+            {
+                "system_prompt": "You are a helpful assistant.",
+                "instruction": "What's 2+2?",
+                "generations": ["4", "5", "6"],
+                "generation_models": ["A", "B", "C"],
+                "ratings": [1, 0, -1],
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+                "chosen": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+                "chosen_rating": 1,
+                "chosen_model": "A",
+                "rejected": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "6"},
+                ],
+                "rejected_rating": -1,
+                "rejected_model": "C",
+            }
+        ]
+
+
+class TestFormatChatGenerationdpo:
+    def test_process(self) -> None:
+        step = FormatChatGenerationDPO(name="dpo", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "messages": [{"role": "user", "content": "What's 2+2?"}],
+                        "generations": ["4", "5", "6"],
+                        "generation_models": ["A", "B", "C"],
+                        "ratings": [1, 0, -1],
+                    }
+                ]
+            )
+        ) == [
+            {
+                "messages": [{"role": "user", "content": "What's 2+2?"}],
+                "generations": ["4", "5", "6"],
+                "generation_models": ["A", "B", "C"],
+                "ratings": [1, 0, -1],
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+                "chosen": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+                "chosen_rating": 1,
+                "chosen_model": "A",
+                "rejected": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "6"},
+                ],
+                "rejected_rating": -1,
+                "rejected_model": "C",
+            }
+        ]

--- a/tests/unit/steps/formatting/test_sft.py
+++ b/tests/unit/steps/formatting/test_sft.py
@@ -1,0 +1,103 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distilabel.pipeline import Pipeline
+from distilabel.steps.formatting.sft import (
+    FormatChatGenerationSFT,
+    FormatTextGenerationSFT,
+)
+
+
+class TestFormatTextGenerationSFT:
+    def test_process(self) -> None:
+        step = FormatTextGenerationSFT(name="sft", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "instruction": "What's 2+2?",
+                        "generation": "4",
+                    }
+                ]
+            )
+        ) == [
+            {
+                "instruction": "What's 2+2?",
+                "generation": "4",
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+                "messages": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+            }
+        ]
+
+    def test_process_with_system_prompt(self) -> None:
+        step = FormatTextGenerationSFT(name="sft", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "system_prompt": "You are a helpful assistant.",
+                        "instruction": "What's 2+2?",
+                        "generation": "4",
+                    }
+                ]
+            )
+        ) == [
+            {
+                "system_prompt": "You are a helpful assistant.",
+                "instruction": "What's 2+2?",
+                "generation": "4",
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+            }
+        ]
+
+
+class TestFormatChatGenerationSFT:
+    def test_process(self) -> None:
+        step = FormatChatGenerationSFT(name="sft", pipeline=Pipeline(name="pipeline"))
+        step.load()
+
+        assert next(
+            step.process(
+                [
+                    {
+                        "messages": [{"role": "user", "content": "What's 2+2?"}],
+                        "generation": "4",
+                    }
+                ]
+            )
+        ) == [
+            {
+                "messages": [
+                    {"role": "user", "content": "What's 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                ],
+                "generation": "4",
+                "prompt": "What's 2+2?",
+                "prompt_id": "7762ecf17ad41479767061a8f4a7bfa3b63d371672af5180872f9b82b4cd4e29",
+            }
+        ]


### PR DESCRIPTION
## Description

This PR adds the following steps in order to format the batches into what the main fine-tuning frameworks / libraries (i.e. `axolotl` and `alignment-handbook`) expect for both DPO (ORPO too) and SFT.

* `FormatTextGenerationSFT`: when the inputs are single turn i.e. an `instruction` as input, generating a `generation` as output, optionally including a `system_prompt`. Can be directly plugged after a `TextGeneration` task and it will work out of the box, no mappings required.

    It will generate the following output columns: `prompt`, `prompt_id`, and `messages`.

* `FormatTextGenerationDPO`: when the inputs are single turn i.e. an `instruction` as input, generating a list of `generations` as output with either the same or a different LLM, optionally including a `system_prompt`; and then ranked with a preference task like `UltraFeedback` so as to generate the `ratings` for each generation in `generations. Will need some `{input,output}_mappings` to work, but should be straight forward combining `TextGeneration` tasks with say `UltraFeedback`.

    It will generate the following output columns: `prompt`, `prompt_id`, `chosen`, `chosen_model` (optional, TBD), `chosen_rating`, `rejected`, `rejected_rating` (optional, TBD), and `rejected_rating`.

* `FormatChatGenerationSFT`: when the inputs are either single or multi turn conversations, but already formatted with the OpenAI format i.e. `messages` contains the conversation as input without the last assistant response, and `generation` contains the last assistant response. Can be directly plugged after a `ChatGeneration` task and it will work out of the box, no mappings required.

    It will generate the following output columns: `prompt`, `prompt_id`, and `messages`.

* `FormatChatGenerationDPO`: when the inputs are either single or multi turn conversations, but already formatted with the OpenAI format i.e. `messages` contains the conversation as input without the last assistant response, generating a list of `generations` as output with either the same or a different LLM, optionally including a `system_prompt`; and then ranked with a preference task like `UltraFeedback` so as to generate the `ratings` for each generation in `generations. Will need some `{input,output}_mappings` to work, but should be straight forward combining `TextGeneration` tasks with say `UltraFeedback`.

    It will generate the following output columns: `prompt`, `prompt_id`, `chosen`, `chosen_model` (optional, TBD), `chosen_rating`, `rejected`, `rejected_rating` (optional, TBD), and `rejected_rating`

Closes #513 