### PR TITLE
Add `stop` and `stop_sequences` in `LLM.generate` subclasses

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -327,10 +327,6 @@ class InferenceEndpointsLLM(AsyncLLM):
         Returns:
             A list of lists of strings containing the generated responses for each input.
         """
-
-        if stop_sequences is None and self._tokenizer is not None:
-            stop_sequences = [self._tokenizer.eos_token]
-
         if stop_sequences is not None:
             if isinstance(stop_sequences, str):
                 stop_sequences = [stop_sequences]

--- a/src/distilabel/llms/openai.py
+++ b/src/distilabel/llms/openai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from pydantic import Field, PrivateAttr, SecretStr, validate_call
 
@@ -101,7 +101,7 @@ class OpenAILLM(AsyncLLM):
         self._aclient = AsyncOpenAI(
             base_url=self.base_url,
             api_key=self.api_key.get_secret_value(),
-            max_retries=self.max_retries,
+            max_retries=self.max_retries,  # type: ignore
             timeout=self.timeout,
         )
 
@@ -120,6 +120,7 @@ class OpenAILLM(AsyncLLM):
         presence_penalty: float = 0.0,
         temperature: float = 1.0,
         top_p: float = 1.0,
+        stop: Optional[Union[str, List[str]]] = None,
     ) -> GenerateOutput:
         """Generates `num_generations` responses for the given input using the OpenAI async
         client.
@@ -136,6 +137,8 @@ class OpenAILLM(AsyncLLM):
                 `0.0`.
             temperature: the temperature to use for the generation. Defaults to `0.1`.
             top_p: the top-p value to use for the generation. Defaults to `1.0`.
+            stop: a string or a list of strings to use as a stop sequence for the generation.
+                Defaults to `None`.
 
         Returns:
             A list of lists of strings containing the generated responses for each input.
@@ -149,12 +152,13 @@ class OpenAILLM(AsyncLLM):
             presence_penalty=presence_penalty,
             temperature=temperature,
             top_p=top_p,
+            stop=stop,
             timeout=50,
         )
         generations = []
         for choice in completion.choices:
             if (content := choice.message.content) is None:
-                self._logger.warning(
+                self._logger.warning(  # type: ignore
                     f"Received no response using OpenAI client (model: '{self.model}')."
                     f" Finish reason was: {choice.finish_reason}"
                 )

--- a/src/distilabel/llms/vllm.py
+++ b/src/distilabel/llms/vllm.py
@@ -149,6 +149,10 @@ class vLLM(LLM, CudaDevicePlacementMixin):
         """
         if extra_sampling_params is None:
             extra_sampling_params = {}
+
+        if "stop_token_ids" not in extra_sampling_params:
+            extra_sampling_params["stop_token_ids"] = [self._tokenizer.eos_token_id]
+
         sampling_params = SamplingParams(  # type: ignore
             n=num_generations,
             presence_penalty=presence_penalty,

--- a/src/distilabel/llms/vllm.py
+++ b/src/distilabel/llms/vllm.py
@@ -150,9 +150,6 @@ class vLLM(LLM, CudaDevicePlacementMixin):
         if extra_sampling_params is None:
             extra_sampling_params = {}
 
-        if "stop_token_ids" not in extra_sampling_params:
-            extra_sampling_params["stop_token_ids"] = [self._tokenizer.eos_token_id]
-
         sampling_params = SamplingParams(  # type: ignore
             n=num_generations,
             presence_penalty=presence_penalty,


### PR DESCRIPTION
## Description

This PR adds both `stop` to `OpenAILLM` and all their subclasses in consequence, `stop_sequences` to `InferenceEndpointsLLM`, and sets the `stop_token_ids` if not present in `vllm.SamplingParams`, all to match the existing EOS token ID if available.

If not set, both vLLM and TGI tend to eventually generate until `max_new_tokens`, which is not intended in most of the cases, so setting the EOS token to let the generation know when to stop is highly recommended.