### PR TITLE
Fix empty batches causing missaligment when branching

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -377,15 +377,6 @@ class _Batch(_Serializable):
             seq_no=self.seq_no + 1, step_name=self.step_name, last_batch=self.last_batch
         )
 
-    @property
-    def empty(self) -> bool:
-        """Checks if the batch is empty.
-
-        Returns:
-            `True` if the batch is empty. Otherwise, `False`.
-        """
-        return all(len(rows) == 0 for rows in self.data)
-
     @classmethod
     def from_batches(cls, step_name: str, batches: List["_Batch"]) -> "_Batch":
         """Create a `_Batch` instance with the outputs from the list of batches that
@@ -694,7 +685,6 @@ class _BatchManager(_Serializable):
                 if (
                     batch
                     and batch.last_batch
-                    and batch.empty
                     and batch_manager_step.data[predecessor] == []
                 ):
                     return False

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -674,24 +674,14 @@ class _BatchManager(_Serializable):
             `True` if there are still batches to be processed by the steps. Otherwise,
             `False`.
         """
+        for batch in self._last_batch_received.values():
+            if not batch:
+                return True
 
-        # Check if any step that hasn't finished producing data (we haven't received its
-        # last batch) still needs data from its predecessors, and those predecessors have
-        # already sent their last batch and it's empty. In this case, we cannot continue
-        # the pipeline.
-        for batch_manager_step in self._steps.values():
-            for predecessor in batch_manager_step.data.keys():
-                batch = self._last_batch_received.get(predecessor)
-                if (
-                    batch
-                    and batch.last_batch
-                    and batch_manager_step.data[predecessor] == []
-                ):
-                    return False
+            if not batch.last_batch:
+                return True
 
-        return not all(
-            batch and batch.last_batch for batch in self._last_batch_received.values()
-        )
+        return False
 
     def register_batch(self, batch: _Batch) -> None:
         """Method to register a batch received from a step. It will keep track of the

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -816,11 +816,18 @@ class _ProcessWrapper:
                 if self.step.is_global:
                     raise _ProcessWrapperException(str(e), self.step, 2, e) from e
 
+                # Impute step outputs columns with `None`
+                for row in batch.data[0]:
+                    data = row.copy()
+                    for output in self.step.outputs:
+                        data[output] = None
+                    result.append(data)
+
                 # if the step is not global then we can skip the batch which means sending
                 # an empty batch to the output queue
                 self.step._logger.warning(
                     f"⚠️ Processing batch {batch.seq_no} with step '{self.step.name}' failed."
-                    " Sending empty batch..."
+                    " Sending empty batch filled with `None`s..."
                 )
                 self.step._logger.warning(
                     f"Subprocess traceback:\n\n{traceback.format_exc()}"

--- a/tests/integration/test_branching_missaligmnent.py
+++ b/tests/integration/test_branching_missaligmnent.py
@@ -1,0 +1,55 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from distilabel.pipeline import Pipeline
+from distilabel.steps import CombineColumns, LoadDataFromDicts, StepInput, step
+
+if TYPE_CHECKING:
+    from distilabel.steps import StepOutput
+
+
+@step(inputs=["instruction"], outputs=["response"])
+def FailAlways(_: StepInput) -> "StepOutput":
+    raise Exception("This step always fails")
+
+
+@step(inputs=["instruction"], outputs=["response"])
+def SucceedAlways(inputs: StepInput) -> "StepOutput":
+    for input in inputs:
+        input["response"] = "This step always succeeds"
+    yield inputs
+
+
+def test_branching_missalignment_because_step_fails_processing_batch() -> None:
+    with Pipeline(name="") as pipeline:
+        load_data = LoadDataFromDicts(data=[{"instruction": i} for i in range(20)])
+
+        fail = FailAlways()
+        succeed = SucceedAlways()
+        combine = CombineColumns(columns=["response"])
+
+        load_data.connect(fail)
+        load_data.connect(succeed)
+
+        fail.connect(combine)
+        succeed.connect(combine)
+
+    distiset = pipeline.run(use_cache=False)
+
+    assert (
+        distiset["default"]["train"]["merged_response"]
+        == [[None, "This step always succeeds"]] * 20
+    )

--- a/tests/integration/test_branching_missaligmnent.py
+++ b/tests/integration/test_branching_missaligmnent.py
@@ -41,11 +41,7 @@ def test_branching_missalignment_because_step_fails_processing_batch() -> None:
         succeed = SucceedAlways()
         combine = CombineColumns(columns=["response"])
 
-        load_data.connect(fail)
-        load_data.connect(succeed)
-
-        fail.connect(combine)
-        succeed.connect(combine)
+        load_data >> [fail, succeed] >> combine
 
     distiset = pipeline.run(use_cache=False)
 

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1059,6 +1059,29 @@ class TestBatchManager:
             ),
         }
 
+    def test_can_generate(self) -> None:
+        batch_manager = _BatchManager(
+            steps={},
+            last_batch_received={
+                "step_1": _Batch(seq_no=0, step_name="step_1", last_batch=False),
+                "step_2": _Batch(seq_no=0, step_name="step_2", last_batch=False),
+                "step_3": _Batch(seq_no=0, step_name="step_3", last_batch=False),
+            },
+        )
+
+        assert batch_manager.can_generate()
+
+        batch_manager = _BatchManager(
+            steps={},
+            last_batch_received={
+                "step_1": _Batch(seq_no=0, step_name="step_1", last_batch=True),
+                "step_2": _Batch(seq_no=0, step_name="step_2", last_batch=True),
+                "step_3": _Batch(seq_no=0, step_name="step_3", last_batch=True),
+            },
+        )
+
+        assert not batch_manager.can_generate()
+
     def test_dump(self) -> None:
         batch_manager = _BatchManager(
             steps={

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -317,10 +317,6 @@ class TestBatch:
             [{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}, {"b": 6}],
         ]
 
-    def test_empty(self) -> None:
-        batch = _Batch(seq_no=0, step_name="step1", last_batch=False, data=[[]])
-        assert batch.empty
-
     def test_dump(self) -> None:
         batch = _Batch(seq_no=0, step_name="step1", last_batch=False)
         assert batch.dump() == {


### PR DESCRIPTION
## Description

This PR fixes an issue that caused batch miss-alignment in pipeline with steps like:  A -> [B, C] -> D. If for some reason, C or D failed, then we were sending an empty list causing creating miss-aligned batches for step D. To fix it, instead of sending an empty list, now we send the data of the input batch + the `outputs` of the step as new keys with `None` as value. 