### PR TITLE
Fix `title` in `RatingQuestion` of `PreferenceToArgilla`

### DIFF
--- a/src/distilabel/steps/argilla/preference.py
+++ b/src/distilabel/steps/argilla/preference.py
@@ -152,7 +152,7 @@ class PreferenceToArgilla(Argilla):
                 [
                     rg.RatingQuestion(  # type: ignore
                         name=f"{self._generations}-{idx}-rating",
-                        title=f"Rate {self._generations}-{idx} given {self._instruction} based on the annotation guidelines.",
+                        title=f"Rate {self._generations}-{idx} given {self._instruction}.",
                         description=f"Ignore this question if the corresponding `{self._generations}-{idx}` field is not available."
                         if idx != 0
                         else None,

--- a/src/distilabel/steps/argilla/preference.py
+++ b/src/distilabel/steps/argilla/preference.py
@@ -128,7 +128,8 @@ class PreferenceToArgilla(Argilla):
                 questions=self._rating_rationale_pairs(),  # type: ignore
             )
             self._rg_dataset = _rg_dataset.push_to_argilla(
-                name=self.dataset_name, workspace=self.dataset_workspace
+                name=self.dataset_name,  # type: ignore
+                workspace=self.dataset_workspace,
             )
 
     def _generation_fields(self) -> List["TextField"]:

--- a/src/distilabel/steps/argilla/text_generation.py
+++ b/src/distilabel/steps/argilla/text_generation.py
@@ -73,7 +73,7 @@ class TextGenerationToArgilla(Argilla):
         self._generation = self.input_mappings.get("generation", "generation")
 
         if self._rg_dataset_exists():
-            _rg_dataset = rg.FeedbackDataset.from_argilla(
+            _rg_dataset = rg.FeedbackDataset.from_argilla(  # type: ignore
                 name=self.dataset_name,
                 workspace=self.dataset_workspace,
             )
@@ -91,7 +91,7 @@ class TextGenerationToArgilla(Argilla):
 
             self._rg_dataset = _rg_dataset
         else:
-            _rg_dataset = rg.FeedbackDataset(
+            _rg_dataset = rg.FeedbackDataset(  # type: ignore
                 fields=[
                     rg.TextField(name=self._id, title=self._id),  # type: ignore
                     rg.TextField(name=self._instruction, title=self._instruction),  # type: ignore
@@ -106,7 +106,8 @@ class TextGenerationToArgilla(Argilla):
                 ],
             )
             self._rg_dataset = _rg_dataset.push_to_argilla(
-                name=self.dataset_name, workspace=self.dataset_workspace
+                name=self.dataset_name,  # type: ignore
+                workspace=self.dataset_workspace,
             )
 
     @property
@@ -148,7 +149,7 @@ class TextGenerationToArgilla(Argilla):
                 generations_set.add(generation)
 
                 records.append(
-                    rg.FeedbackRecord(
+                    rg.FeedbackRecord(  # type: ignore
                         fields={
                             self._id: instruction_id,
                             self._instruction: input["instruction"],

--- a/tests/unit/steps/argilla/test_preference.py
+++ b/tests/unit/steps/argilla/test_preference.py
@@ -31,7 +31,7 @@ def mock_feedback_dataset() -> rg.FeedbackDataset:
         questions=[
             rg.RatingQuestion(  # type: ignore
                 name="generations-0-rating",
-                title="Rate generations-0 given instruction based on the annotation guidelines.",
+                title="Rate generations-0 given instruction.",
                 description=None,
                 values=[1, 2, 3, 4, 5],
                 required=True,
@@ -44,7 +44,7 @@ def mock_feedback_dataset() -> rg.FeedbackDataset:
             ),
             rg.RatingQuestion(  # type: ignore
                 name="generations-1-rating",
-                title="Rate generations-1 given instruction based on the annotation guidelines.",
+                title="Rate generations-1 given instruction.",
                 description="Ignore this question if the corresponding `generations-1` field is not available.",
                 values=[1, 2, 3, 4, 5],
                 required=False,


### PR DESCRIPTION
## Description

This PR fixes the `title` of the `RatingQuestion` in `PreferenceToArgilla` to remove the "based on the annotation guidelines", since by default there are no annotation guidelines, so specifying that within the title is misleading.

Closes #589