### PR TITLE
Update `ValueError` on missing inputs message

### DIFF
--- a/docs/sections/learn/pipelines/index.md
+++ b/docs/sections/learn/pipelines/index.md
@@ -212,8 +212,8 @@ if __name__ == "__main__":
 But if we run it, we will see that the `run` method will fail:
 
 ```
-ValueError: Step 'text_generation_with_gpt-4-0125-preview' requires inputs ['instruction'] which are not available when the step gets to be executed in the pipeline. Please make sure previous steps to 'text_generation_with_gpt-4-0125-preview' are 
-generating the required inputs. Available inputs are: ['prompt', 'completion', 'meta']
+ValueError: Step 'text_generation_with_gpt-4-0125-preview' requires inputs ['instruction'], but only the inputs=['prompt', 'completion', 'meta'] are available, which means that the inputs=['instruction'] are missing or not available
+when the step gets to be executed in the pipeline. Please make sure previous steps to 'text_generation_with_gpt-4-0125-preview' are generating the required inputs.
 ```
 
 This is because, before actually running the pipeline, the pipeline is validated to verify that everything is correct and all the steps in the pipeline are chainable i.e. each step has the necessary inputs to be executed. In this case, the `TextGeneration` task requires the `instruction` column, but the `LoadHubDataset` step generates the `prompt` column. To solve this, we can use the `output_mappings` argument that every `Step` has, to map or rename the output columns of a step to the required input columns of another step:

--- a/src/distilabel/llms/llamacpp.py
+++ b/src/distilabel/llms/llamacpp.py
@@ -76,7 +76,7 @@ class LlamaCppLLM(LLM):
     extra_kwargs: Optional[RuntimeParameter[Dict[str, Any]]] = Field(
         default_factory=dict,
         description="Additional dictionary of keyword arguments that will be passed to the"
-        " `Llama` class of `llama_cpp` library. See all the suported arguments at: "
+        " `Llama` class of `llama_cpp` library. See all the supported arguments at: "
         "https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.__init__",
     )
 

--- a/src/distilabel/llms/vllm.py
+++ b/src/distilabel/llms/vllm.py
@@ -87,7 +87,7 @@ class vLLM(LLM, CudaDevicePlacementMixin):
     extra_kwargs: Optional[RuntimeParameter[Dict[str, Any]]] = Field(
         default_factory=dict,
         description="Additional dictionary of keyword arguments that will be passed to the"
-        " `vLLM` class of `vllm` library. See all the suported arguments at: "
+        " `vLLM` class of `vllm` library. See all the supported arguments at: "
         "https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/llm.py",
     )
 

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -275,10 +275,12 @@ class DAG(_Serializable):
         step_inputs = step.get_inputs()
         if not all(input in inputs_available_for_step for input in step_inputs):
             raise ValueError(
-                f"Step '{step.name}' requires inputs {step_inputs} which are not"
-                f" available when the step gets to be executed in the pipeline."
+                f"Step '{step.name}' requires inputs {step_inputs}, but only the inputs"
+                f"={inputs_available_for_step} are available, which means that the inputs"
+                f"={list(set(step_inputs) - set(inputs_available_for_step))} are missing or not"
+                " available when the step gets to be executed in the pipeline."
                 f" Please make sure previous steps to '{step.name}' are generating"
-                f" the required inputs. Available inputs are: {inputs_available_for_step}"
+                " the required inputs."
             )
 
     def _validate_step_process_arguments(self, step: "_Step") -> None:


### PR DESCRIPTION
## Description

This PR only updates the `ValueError` exception that is raised whenever a `Step` does not have the required inputs as not existing in the steps above, so that the exception also shows what inputs are missing so as to let the developer know, as of #605

Additionally, a typo in `suported` -> `supported` has been fixed.

Closes #605