### PR TITLE
Add custom `rubrics` attribute to `PrometheusEval`

### DIFF
--- a/src/distilabel/steps/tasks/prometheus_eval.py
+++ b/src/distilabel/steps/tasks/prometheus_eval.py
@@ -82,8 +82,9 @@ class PrometheusEval(Task):
 
     Both evaluations provide the possibility whether to use a reference answer to compare with or not
     via the `reference` attribute, and both are based on a score rubric that critiques the generation/s
-    based on the following aspects: `helpfulness`, `harmlessness`, `honesty`, `factual-validity`, and
-    `reasoning`, set via the attribute `rubric`.
+    based on the following default aspects: `helpfulness`, `harmlessness`, `honesty`, `factual-validity`,
+    and `reasoning`, that can be overriden via `rubrics`, and the selected rubric is set via the attribute
+    `rubric`.
 
     Note:
         The `PrometheusEval` task is better suited and intended to be used with any of the Prometheus 2.0
@@ -95,8 +96,13 @@ class PrometheusEval(Task):
     Attributes:
         mode: the evaluation mode to use, either `absolute` or `relative`. It defines whether the task
             will evaluate one or two generations.
-        rubric: the score rubric to use within the prompt to run the critique based on differnt aspects. Can be:
-            `helpfulness`, `harmlessness`, `honesty`, `factual-validity`, or `reasoning`.
+        rubric: the score rubric to use within the prompt to run the critique based on differnt aspects.
+            Can be any existing key in the `rubrics` attribute, which by default means that it can be:
+            `helpfulness`, `harmlessness`, `honesty`, `factual-validity`, or `reasoning`. Those will only
+            work if using the default `rubrics`, otherwise, the provided `rubrics` should be used.
+        rubrics: a dictionary containing the different rubrics to use for the critique, where the keys are
+            the rubric names and the values are the rubric descriptions. The default rubrics are the following:
+            `helpfulness`, `harmlessness`, `honesty`, `factual-validity`, and `reasoning`.
         reference: a boolean flag to indicate whether a reference answer / completion will be provided, so
             that the model critique is based on the comparison with it. It implies that the column `reference`
             needs to be provided within the input data in addition to the rest of the inputs.

--- a/src/distilabel/steps/tasks/prometheus_eval.py
+++ b/src/distilabel/steps/tasks/prometheus_eval.py
@@ -140,14 +140,7 @@ class PrometheusEval(Task):
 
     @model_validator(mode="after")
     def validate_rubric_and_rubrics(self) -> Self:
-        if (
-            not isinstance(self.rubrics, dict)
-            or len(self.rubrics) < 1
-            or not all(
-                isinstance(key, str) and isinstance(value, str)
-                for key, value in self.rubrics.items()
-            )
-        ):
+        if not isinstance(self.rubrics, dict) or len(self.rubrics) < 1:
             raise ValueError(
                 "Provided `rubrics` must be a Python dictionary with string keys and string values."
             )

--- a/src/distilabel/steps/tasks/prometheus_eval.py
+++ b/src/distilabel/steps/tasks/prometheus_eval.py
@@ -20,10 +20,11 @@ if sys.version_info < (3, 9):
 else:
     import importlib.resources as importlib_resources
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Self, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from jinja2 import Template
 from pydantic import Field, PrivateAttr, model_validator
+from typing_extensions import Self
 
 from distilabel.steps.tasks.base import Task
 

--- a/tests/unit/steps/tasks/test_prometheus_eval.py
+++ b/tests/unit/steps/tasks/test_prometheus_eval.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, Union
 
 import pytest
 from distilabel.pipeline.local import Pipeline
-from distilabel.steps.tasks.prometheus_eval import _RUBRICS, PrometheusEval
+from distilabel.steps.tasks.prometheus_eval import _DEFAULT_RUBRICS, PrometheusEval
 from jinja2 import Template
 
 from tests.unit.steps.tasks.utils import DummyLLM
@@ -136,7 +136,7 @@ class TestPrometheusAbsEval:
         task.load()
 
         template_kwargs = input
-        template_kwargs["rubric"] = _RUBRICS[rubric]
+        template_kwargs["rubric"] = _DEFAULT_RUBRICS[rubric]
 
         assert task.format_input(input=input)[-1]["content"] == load_template(
             template=template

--- a/tests/unit/steps/tasks/test_prometheus_eval.py
+++ b/tests/unit/steps/tasks/test_prometheus_eval.py
@@ -297,6 +297,19 @@ class TestPrometheusAbsEval:
                 llm=DummyLLM(),
                 pipeline=Pipeline(name="unit-test-pipeline"),
             )
+        with pytest.raises(
+            ValidationError,
+            match=r"rubrics.custom\n  Input should be a valid string",
+        ):
+            PrometheusEval(
+                name="task",
+                mode="absolute",
+                rubric="custom",
+                rubrics={"custom": 1},
+                reference=False,
+                llm=DummyLLM(),
+                pipeline=Pipeline(name="unit-test-pipeline"),
+            )
         # 2. `rubrics` is not compliant with the pre-defined schema
         with pytest.raises(
             ValidationError,


### PR DESCRIPTION
## Description

This PR adds the attribute `rubrics` to the `PrometheusEval` task so as to allow the possibility of providing a Python dictionary with custom rubrics.

The custom rubrics to be provided would need to be compliant with the following schema, and the `rubric` still needs to be provided, but is no longer constrained to the default rubrics, but to the ones available within the `rubrics` attribute keys.

```
[{criteria}]
Score 1: {score1_description}
Score 2: {score2_description}
Score 3: {score3_description}
Score 4: {score4_description}
Score 5: {score5_description}
```

Reference at https://github.com/prometheus-eval/prometheus-eval/blob/26a9e29f99024014ef83fd15f97617121376a36b/libs/prometheus-eval/prometheus_eval/prompts.py#L94-L101

Closes #619

## Example

```python
import time

from distilabel.llms import vLLM
from distilabel.pipeline import Pipeline
from distilabel.steps import LoadDataFromDicts
from distilabel.steps.tasks.prometheus_eval import PrometheusEval

if __name__ == "__main__":
    start_time = time.time()

    with Pipeline(name="prometheus") as pipeline:
        load_dataset = LoadDataFromDicts(
            name="load_dataset",
            data=[
                {
                    "instruction": "What's 2+2?",
                    "generation": "The answer is 4",
                },
            ],
        )

        task = PrometheusEval(
            name="task",
            llm=vLLM(
                model="prometheus-eval/prometheus-7b-v2.0",
                chat_template="[INST] {{ messages[0]['content'] }}\n{{ messages[1]['content'] }}[/INST]",
            ),
            mode="absolute",
            rubric="factual-validity",
            rubrics={
                "factual-validity": """[Are the model’s responses factually correct and well-supported by evidence?]
Score 1: The model’s responses are mostly incorrect or based on unfounded information.
Score 2: The model sometimes provides factually correct responses, but inaccuracies are common.
Score 3: The model generally provides factually correct information, though some errors occur.
Score 4: The model often provides factually accurate information with only occasional minor errors.
Score 5: The model consistently provides responses that are factually correct and well-supported by evidence.
""".strip(),
            },
            reference=False,
            num_generations=1,
            group_generations=False,
        )

        load_dataset >> task  # type: ignore

    pipeline.run(
        parameters={
            "task": {
                "llm": {
                    "generation_kwargs": {
                        "max_new_tokens": 1024,
                        "temperature": 0.7,
                    },
                },
            },
        },
    )
    print("--- %s seconds ---" % (time.time() - start_time))
```

cc @davanstrien 