### PR TITLE
Fix problem with sorting method in `list_files_in_dir` function

### DIFF
--- a/src/distilabel/utils/files.py
+++ b/src/distilabel/utils/files.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List
+from typing import Callable, List, Optional
 
 
-def list_files_in_dir(dir_path: Path) -> List[Path]:
+def list_files_in_dir(
+    dir_path: Path, key: Optional[Callable] = lambda x: int(x.stem)
+) -> List[Path]:
     """List all files in a directory.
 
     Args:
         dir_path: Path to the directory.
+        key: A function to sort the files. Defaults to sorting by the integer value of the file name.
+            This is useful when loading files from the cache, as the name will be numbered.
 
     Returns:
         A list of file names in the directory.
     """
-    return [f for f in sorted(dir_path.iterdir()) if f.is_file()]
+    return [f for f in sorted(dir_path.iterdir(), key=key) if f.is_file()]

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -23,7 +23,7 @@ def test_list_files_in_dir() -> None:
         temp_dir = Path(temp_dir)
 
         created_files = []
-        for i in range(10):
+        for i in range(20):
             file_path = temp_dir / f"{i}.txt"
             created_files.append(file_path)
             with open(file_path, "w") as f:


### PR DESCRIPTION
## Description

This PR fixes a issue with the sorting method of the files in `list_files_in_dir` function, it was using alphabetical sorting instead of numerical, causing issues (as the files from the batches are created in numerical order).
