### PR TITLE
Add name of the pipeline to group the hashed folders by it

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -353,7 +353,7 @@ class BasePipeline(_Serializable):
         Returns:
             Path: Filenames where the pipeline content will be serialized.
         """
-        folder = self._cache_dir / self._create_signature()
+        folder = self._cache_dir / self.name / self._create_signature()
         return {
             "pipeline": folder / "pipeline.yaml",
             "batch_manager": folder / "batch_manager.json",


### PR DESCRIPTION
## Description

This PR adds the name of the pipeline to the cached folder so we can group the cached folders and find them easily. Instead of having the raw hashes with the content, they will now be under the following structure.

```bash
> tree ~/.cache/distilabel/pipelines/
├── other-pipe
│   ├── f23b95d7ad4e9301a70b2a54c953f8375ebfcd5c
│   │   ├── batch_manager.json
│   │   ├── batch_manager_steps
│   │   │   └── text_generation_0.json
│   │   ├── data
│   │   │   └── text_generation_0
│   │   │       └── 00001.parquet
│   │   ├── pipeline.log
│   │   └── pipeline.yaml
│   └── f9fdc2e82b992050fcf3c8c54748d213087e3290
...
└── test-pipe
    └── f23b95d7ad4e9301a70b2a54c953f8375ebfcd5c
```

Closes #618.