### PR TITLE
Add `routing_batch_function` serialization

### DIFF
--- a/src/distilabel/cli/pipeline/utils.py
+++ b/src/distilabel/cli/pipeline/utils.py
@@ -21,7 +21,10 @@ import yaml
 from pydantic import HttpUrl, ValidationError
 from pydantic.type_adapter import TypeAdapter
 
-from distilabel.pipeline.constants import STEP_ATTR_NAME
+from distilabel.pipeline.constants import (
+    ROUTING_BATCH_FUNCTION_ATTR_NAME,
+    STEP_ATTR_NAME,
+)
 from distilabel.pipeline.local import Pipeline
 
 if TYPE_CHECKING:
@@ -164,6 +167,17 @@ def _build_pipeline_panel(pipeline: "BasePipeline") -> "Panel":
         ]
     )
 
+    if any(
+        pipeline.dag.get_step(step).get(ROUTING_BATCH_FUNCTION_ATTR_NAME) is not None
+        for step in pipeline.dag.G.nodes
+    ):
+        information.extend(
+            [
+                "\n",
+                _build_routing_batch_function_panel(pipeline),
+            ]
+        )
+
     return Panel(
         Group(*information),
         title="[magenta]Pipeline Information[/magenta]",
@@ -272,6 +286,43 @@ def _build_steps_connection_panel(pipeline: "BasePipeline") -> "Panel":
     return Panel(
         table,
         title="[magenta]Steps connections[/magenta]",
+        style="light_cyan3",
+        expand=True,
+    )
+
+
+def _build_routing_batch_function_panel(pipeline: "BasePipeline") -> "Panel":
+    """Builds a panel to display the routing batch function of the pipeline.
+
+    Args:
+        pipeline: The pipeline
+
+    Returns:
+        A `rich.panel.Panel` containing the routing batch function of the pipeline.
+    """
+    from rich.panel import Panel
+    from rich.table import Table
+
+    table = Table(show_header=True, header_style="bold magenta", expand=True)
+    table.add_column("Step", style="dim", width=18)
+    table.add_column("Function", style="dim")
+    table.add_column("Description", width=90)
+
+    G = pipeline.dag.G
+
+    for step_name in G.nodes:
+        node = pipeline.dag.get_step(step_name)
+        if routing_batch_function := node.get(ROUTING_BATCH_FUNCTION_ATTR_NAME):
+            table.add_row(
+                step_name,
+                routing_batch_function.routing_function.__name__,
+                routing_batch_function.description,
+            )
+            continue
+
+    return Panel(
+        table,
+        title="[magenta]Routing Batch Function[/magenta]",
         style="light_cyan3",
         expand=True,
     )

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -33,8 +33,13 @@ from distilabel.pipeline.constants import (
     ROUTING_BATCH_FUNCTION_ATTR_NAME,
     STEP_ATTR_NAME,
 )
+from distilabel.pipeline.routing_batch_function import RoutingBatchFunction
 from distilabel.steps.base import GeneratorStep
-from distilabel.utils.serialization import TYPE_INFO_KEY, _get_class, _Serializable
+from distilabel.utils.serialization import (
+    TYPE_INFO_KEY,
+    _get_module_attr,
+    _Serializable,
+)
 
 if TYPE_CHECKING:
     from distilabel.mixins.runtime_parameters import RuntimeParametersNames
@@ -599,7 +604,7 @@ class DAG(_Serializable):
 
         adjacency_data = json_graph.adjacency_data(self.G, **kwargs)
 
-        data = {"steps": [], "connections": []}
+        data = {"steps": [], "connections": [], "routing_batch_functions": []}
         for i, node in enumerate(adjacency_data["nodes"]):
             name = node["id"]
             data["steps"].append({"step": node[STEP_ATTR_NAME].dump(), "name": name})
@@ -609,6 +614,8 @@ class DAG(_Serializable):
                     "to": [node["id"] for node in adjacency_data["adjacency"][i]],
                 }
             )
+            if routing_batch_function := node.get(ROUTING_BATCH_FUNCTION_ATTR_NAME):
+                data["routing_batch_functions"].append(routing_batch_function.dump())
 
         return data
 
@@ -626,12 +633,25 @@ class DAG(_Serializable):
         dag = cls()
 
         for step in data["steps"]:
-            cls_step: Type["_Step"] = _get_class(**step[STEP_ATTR_NAME][TYPE_INFO_KEY])
+            cls_step: Type["_Step"] = _get_module_attr(
+                **step[STEP_ATTR_NAME][TYPE_INFO_KEY]
+            )
             dag.add_step(cls_step.from_dict(step[STEP_ATTR_NAME]))
 
         for connection in data["connections"]:
             from_step = connection["from"]
             for to_step in connection["to"]:
                 dag.add_edge(from_step, to_step)
+
+        for routing_batch_function in data["routing_batch_functions"]:
+            step_name = routing_batch_function["step"]
+            routing_batch_function = RoutingBatchFunction.from_dict(
+                routing_batch_function
+            )
+            dag.set_step_attr(
+                name=step_name,
+                attr=ROUTING_BATCH_FUNCTION_ATTR_NAME,
+                value=routing_batch_function,
+            )
 
         return dag

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -643,7 +643,7 @@ class DAG(_Serializable):
             for to_step in connection["to"]:
                 dag.add_edge(from_step, to_step)
 
-        for routing_batch_function in data["routing_batch_functions"]:
+        for routing_batch_function in data.get("routing_batch_functions", []):
             step_name = routing_batch_function["step"]
             routing_batch_function = RoutingBatchFunction.from_dict(
                 routing_batch_function

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -1159,10 +1159,10 @@ class _BatchManager(_Serializable):
         Returns:
             A `_BatchManager` instance.
         """
-        # Remove the type info, we already know its a _BatchManager, and there aren't subclasses of it
+        # Remove the type info, we already know its a `_BatchManager`, and there aren't subclasses of it
         data.pop(TYPE_INFO_KEY)
-        # Also there is only one type of _BatchManagerStep, so we can call it directly instead of generically
-        # via _get_class
+        # Also there is only one type of `_BatchManagerStep`, so we can call it directly instead of generically
+        # via `_get_module_attr`
         return cls(
             {
                 name: _BatchManagerStep.from_file(step_path)

--- a/src/distilabel/pipeline/routing_batch_function.py
+++ b/src/distilabel/pipeline/routing_batch_function.py
@@ -165,18 +165,31 @@ class RoutingBatchFunction(BaseModel, _Serializable):
         """
         dump_info: Dict[str, Any] = {"step": self._step.name}  # type: ignore
 
-        if (
-            self._factory_function_module
-            and self._factory_function_name
-            and self._factory_function_kwargs
-        ):
-            dump_info[TYPE_INFO_KEY] = {
-                "module": self._factory_function_module,
-                "name": self._factory_function_name,
-                "kwargs": self._factory_function_kwargs,
-            }
+        if type_info := self._get_type_info():
+            dump_info[TYPE_INFO_KEY] = type_info
 
         return dump_info
+
+    def _get_type_info(self) -> Dict[str, Any]:
+        """Returns the information of the factory function used to create the routing batch
+        function.
+
+        Returns:
+            A dictionary with the factory function information.
+        """
+
+        type_info = {}
+
+        if self._factory_function_module:
+            type_info["module"] = self._factory_function_module
+
+        if self._factory_function_name:
+            type_info["name"] = self._factory_function_name
+
+        if self._factory_function_kwargs:
+            type_info["kwargs"] = self._factory_function_kwargs
+
+        return type_info
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> Self:

--- a/src/distilabel/pipeline/routing_batch_function.py
+++ b/src/distilabel/pipeline/routing_batch_function.py
@@ -290,13 +290,14 @@ def routing_batch_function(
             factory_function_frame_info = stack[1]
 
             # Function factory path
-            factory_function_name = factory_function_frame_info.function
-            factory_function_module = inspect.getmodule(
-                factory_function_frame_info.frame
-            ).__name__  # type: ignore
+            if factory_function_frame_info.function != "<module>":
+                factory_function_name = factory_function_frame_info.function
+                factory_function_module = inspect.getmodule(
+                    factory_function_frame_info.frame
+                ).__name__  # type: ignore
 
-            # Function factory kwargs
-            factory_function_kwargs = factory_function_frame_info.frame.f_locals
+                # Function factory kwargs
+                factory_function_kwargs = factory_function_frame_info.frame.f_locals
 
         routing_batch_function = RoutingBatchFunction(
             routing_function=func,

--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -475,9 +475,9 @@ class _Step(RuntimeParametersMixin, BaseModel, _Serializable, ABC):
         # some of the internal objects. For the moment we only take into account the LLM,
         # we should take care if we update any of the objects.
         if llm := _data.get("llm"):
-            from distilabel.utils.serialization import _get_class
+            from distilabel.utils.serialization import _get_module_attr
 
-            nested_cls = _get_class(**llm.pop(TYPE_INFO_KEY))
+            nested_cls = _get_module_attr(**llm.pop(TYPE_INFO_KEY))
             # Load the LLM and update the _data inplace
             nested_cls = nested_cls(**llm)
             _data.update({"llm": nested_cls})

--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -40,7 +40,7 @@ StrOrPath = Union[str, os.PathLike]
 SaveFormats = Literal["json", "yaml"]
 
 
-def _get_class(module: str, name: str) -> Type:
+def _get_module_attr(module: str, name: str) -> Type:
     """Gets a class given the module and the name of the class.
 
     Returns:
@@ -65,7 +65,7 @@ def load_from_dict(class_: Dict[str, Any]) -> Any:
         # There is a nested type_info, load the class recursively
         type_info = load_from_dict(type_info)
 
-    cls = _get_class(type_info["module"], type_info["name"])
+    cls = _get_module_attr(type_info["module"], type_info["name"])
 
     for k, v in class_.items():
         if isinstance(v, dict) and "_type" in v and v["_type"] == "enum":

--- a/tests/integration/test_routing_batch_function.py
+++ b/tests/integration/test_routing_batch_function.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 random.seed(42)
 
 
-@routing_batch_function
+@routing_batch_function()
 def random_routing_batch(steps: List[str]) -> List[str]:
     return random.sample(steps, 2)
 

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1841,37 +1841,55 @@ class TestPipelineSerialization:
 
         # Maybe not the best place for this test, but does the work for now
         from distilabel.pipeline.local import Pipeline
+        from distilabel.pipeline.routing_batch_function import sample_n_steps
 
         from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
 
-        with Pipeline(name="unit-test-pipeline") as pipeline:
-            dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
-            dummy_step_1 = DummyStep1(name="dummy_step_1")
-            dummy_step_2 = DummyStep2(name="dummy_step_2")
+        sample_two_steps = sample_n_steps(2)
 
-            dummy_generator.connect(dummy_step_1)
-            dummy_step_1.connect(dummy_step_2)
+        with Pipeline(name="unit-test-pipeline") as pipeline:
+            dummy_generator = DummyGeneratorStep()
+            dummy_step_1_0 = DummyStep1()
+            dummy_step_1_1 = DummyStep1()
+            dummy_step_1_2 = DummyStep1()
+            dummy_step_2 = DummyStep2()
+
+            (
+                dummy_generator
+                >> sample_two_steps
+                >> [dummy_step_1_0, dummy_step_1_1, dummy_step_1_2]
+                >> dummy_step_2
+            )
 
         signature = pipeline._create_signature()
-        assert signature == "81ed33f28947896a2601a0eea1b3637712f33e36"
+        assert signature == "a11ac46253598e6fe126420b23b9ad31c6422c92"
 
     @pytest.mark.parametrize("use_cache", [True, False])
     def test_run_pipe_and_load_from_cache(self, use_cache: bool):
         # Maybe not the best place for this test, but does the work for now
         from distilabel.pipeline.base import BasePipeline
+        from distilabel.pipeline.routing_batch_function import sample_n_steps
 
         from tests.unit.pipeline.utils import DummyGeneratorStep, DummyStep1, DummyStep2
+
+        sample_two_steps = sample_n_steps(2)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             with BasePipeline(
                 name="unit-test-pipeline", cache_dir=tmpdirname
             ) as pipeline:
-                dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
-                dummy_step_1 = DummyStep1(name="dummy_step_1")
-                dummy_step_2 = DummyStep2(name="dummy_step_2")
+                dummy_generator = DummyGeneratorStep()
+                dummy_step_1_0 = DummyStep1()
+                dummy_step_1_1 = DummyStep1()
+                dummy_step_1_2 = DummyStep1()
+                dummy_step_2 = DummyStep2()
 
-                dummy_generator.connect(dummy_step_1)
-                dummy_step_1.connect(dummy_step_2)
+                (
+                    dummy_generator
+                    >> sample_two_steps
+                    >> [dummy_step_1_0, dummy_step_1_1, dummy_step_1_2]
+                    >> dummy_step_2
+                )
 
                 pipeline.run({}, use_cache=use_cache)
 
@@ -1883,12 +1901,18 @@ class TestPipelineSerialization:
                 assert pipeline._cache_location["pipeline"].exists()
 
             with BasePipeline(name="unit-test-pipeline", cache_dir=tmpdirname) as pipe:
-                dummy_generator = DummyGeneratorStep(name="dummy_generator_step")
-                dummy_step_1 = DummyStep1(name="dummy_step_1")
-                dummy_step_2 = DummyStep2(name="dummy_step_2")
+                dummy_generator = DummyGeneratorStep()
+                dummy_step_1_0 = DummyStep1()
+                dummy_step_1_1 = DummyStep1()
+                dummy_step_1_2 = DummyStep1()
+                dummy_step_2 = DummyStep2()
 
-                dummy_generator.connect(dummy_step_1)
-                dummy_step_1.connect(dummy_step_2)
+                (
+                    dummy_generator
+                    >> sample_two_steps
+                    >> [dummy_step_1_0, dummy_step_1_1, dummy_step_1_2]
+                    >> dummy_step_2
+                )
 
                 pipe.run({}, use_cache=use_cache)
                 if use_cache:

--- a/tests/unit/pipeline/test_dag.py
+++ b/tests/unit/pipeline/test_dag.py
@@ -487,11 +487,11 @@ class TestDAG:
 
         convergence_step = DummyStep2(name="convergence_step", pipeline=pipeline)
 
-        @routing_batch_function
+        @routing_batch_function()
         def routing_batch_function_1(steps: List[str]) -> List[str]:
             return steps
 
-        @routing_batch_function
+        @routing_batch_function()
         def routing_batch_function_2(steps: List[str]) -> List[str]:
             return steps
 
@@ -520,7 +520,7 @@ class TestDAG:
             input_batch_size=666,
         )
 
-        @routing_batch_function
+        @routing_batch_function()
         def routing_batch_function_1(steps: List[str]) -> List[str]:
             return steps
 
@@ -549,7 +549,7 @@ class TestDAG:
         dummy_step_3 = DummyStep2(name="doomed", pipeline=pipeline)
         dummy_step_4 = DummyStep2(pipeline=pipeline)
 
-        @routing_batch_function
+        @routing_batch_function()
         def routing_batch_function_1(steps: List[str]) -> List[str]:
             return steps
 
@@ -576,7 +576,7 @@ class TestDAG:
         dummy_step_1 = DummyStep1(pipeline=pipeline)
         dummy_step_2 = DummyStep1(name="demon", pipeline=pipeline, input_batch_size=666)
 
-        @routing_batch_function
+        @routing_batch_function()
         def routing_batch_function_1(steps: List[str]) -> List[str]:
             return steps
 

--- a/tests/unit/pipeline/test_routing_batch_function.py
+++ b/tests/unit/pipeline/test_routing_batch_function.py
@@ -97,6 +97,7 @@ class TestRoutingBatchFunction:
 
         assert routing_batch_function.dump() == {
             "step": upstream_step.name,
+            "description": routing_batch_function.description,
             TYPE_INFO_KEY: {
                 "module": "distilabel.pipeline.routing_batch_function",
                 "name": "sample_n_steps",
@@ -107,6 +108,7 @@ class TestRoutingBatchFunction:
     def test_from_dict(self) -> None:
         routing_batch_function_dict = {
             "step": "upstream_step",
+            "description": "Sample 2 steps from the list of downstream steps.",
             TYPE_INFO_KEY: {
                 "module": "distilabel.pipeline.routing_batch_function",
                 "name": "sample_n_steps",
@@ -128,7 +130,7 @@ class TestRoutingBatchFunction:
 
 class TestRoutingBatchFunctionDecorator:
     def test_decorator(self) -> None:
-        @routing_batch_function
+        @routing_batch_function()
         def random_routing_batch(steps: List[str]) -> List[str]:
             return steps[:2]
 


### PR DESCRIPTION
## Description

This PR adds the serialization/deserialization for the routing batch functions. A `routing_batch_function` will be able to be loaded back if it was built using a factory function that can be imported from a module:

```python
def my_factory_func() -> RoutingBatchFunction:
    @routing_batch_function(description="Description")
    def my_routing_batch_function(steps: List[str]) -> List[str]: ...

    return my_routing_batch_function
```

In addition, this PR updates the `BasePipeline._create_signature` function to use the routing batch functions of the steps (if any) to compute the signature, and updates the `distilabel pipeline info` command.