### PR TITLE
Add `dry_run` method to the pipelines to run with a single example.

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -252,8 +252,8 @@ class BasePipeline(_Serializable):
         """Do a dry run to test the pipeline runs as expected.
 
         Running a `Pipeline` in dry run mode will set all the `batch_size` of generator steps
-        to one, and run just with a single batch, effectively running the whole pipeline with
-        a single example. The cache will be set to False.
+        to the specified batch_size, and run just with a single batch, effectively
+        running the whole pipeline with a single example. The cache will be set to False.
 
         Args:
             parameters: The same parameters variable from `BasePipeline.run`. Defaults to None.
@@ -269,14 +269,15 @@ class BasePipeline(_Serializable):
         for step_name in self.dag:
             step = self.dag.get_step(step_name)[STEP_ATTR_NAME]
             if step.is_generator:
-                self.dag.set_step_attr(step_name, "batch_size", batch_size)
-                # Just in case update the parameters argument
                 if parameters.get(step_name) and parameters[step_name].get(
                     "batch_size"
                 ):
                     parameters[step_name]["batch_size"] = batch_size
 
-        return self.run(parameters, use_cache=False)
+        distiset = self.run(parameters, use_cache=False)
+
+        self._dry_run = False
+        return distiset
 
     def get_runtime_parameters_info(self) -> Dict[str, List[Dict[str, Any]]]:
         """Get the runtime parameters for the steps in the pipeline.

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -100,7 +100,7 @@ class Pipeline(BasePipeline):
 
         if self._dry_run:
             # This message is placed here to ensure we are using the already setup logger.
-            self._logger.info("⚙️  Dry run mode")
+            self._logger.info("🌵 Dry run mode")
 
         if self._batch_manager is None:
             self._batch_manager = _BatchManager.from_dag(self.dag)
@@ -490,8 +490,6 @@ class Pipeline(BasePipeline):
 
         for step in self._batch_manager._steps.values():
             if batch := step.get_batch():
-                if self._dry_run:
-                    batch.last_batch = True
                 self._logger.debug(
                     f"Sending initial batch to '{step.step_name}' step: {batch}"
                 )

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -1,0 +1,40 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from distilabel.pipeline import Pipeline
+from distilabel.steps import LoadDataFromDicts, StepInput, StepOutput, step
+
+
+@step(inputs=["instruction"], outputs=["response"])
+def SucceedAlways(inputs: StepInput) -> "StepOutput":
+    for input in inputs:
+        input["response"] = "This step always succeeds"
+    yield inputs
+
+
+def test_dry_run():
+    with Pipeline(name="other-pipe") as pipeline:
+        load_dataset = LoadDataFromDicts(
+            data=[
+                {"instruction": "Tell me a joke."},
+            ]
+            * 50,
+            batch_size=20,
+        )
+        text_generation = SucceedAlways()
+
+        load_dataset >> text_generation
+
+    distiset = pipeline.dry_run(parameters={load_dataset.name: {"batch_size": 5}})
+    assert len(distiset["default"]["train"]) == 1

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -36,5 +36,23 @@ def test_dry_run():
 
         load_dataset >> text_generation
 
-    distiset = pipeline.dry_run(parameters={load_dataset.name: {"batch_size": 5}})
+    distiset = pipeline.dry_run(parameters={load_dataset.name: {"batch_size": 8}})
     assert len(distiset["default"]["train"]) == 1
+    assert pipeline._dry_run is False
+
+    with Pipeline(name="other-pipe") as pipeline:
+        load_dataset = LoadDataFromDicts(
+            data=[
+                {"instruction": "Tell me a joke."},
+            ]
+            * 50,
+            batch_size=20,
+        )
+        text_generation = SucceedAlways()
+
+        load_dataset >> text_generation
+
+    distiset = pipeline.run(
+        parameters={load_dataset.name: {"batch_size": 10}}, use_cache=False
+    )
+    assert len(distiset["default"]["train"]) == 50

--- a/tests/unit/pipeline/test_local.py
+++ b/tests/unit/pipeline/test_local.py
@@ -88,18 +88,21 @@ class TestLocalPipeline:
                     input_queue=mock.ANY,
                     output_queue=queue,
                     shared_info=shared_info,
+                    dry_run=False,
                 ),
                 mock.call(
                     step=dummy_step_1,
                     input_queue=mock.ANY,
                     output_queue=queue,
                     shared_info=shared_info,
+                    dry_run=False,
                 ),
                 mock.call(
                     step=dummy_step_2,
                     input_queue=mock.ANY,
                     output_queue=queue,
                     shared_info=shared_info,
+                    dry_run=False,
                 ),
             ],
         )


### PR DESCRIPTION
## Description

This PR adds a `dry_run` method to `BasePipeline` to check everything works as expected with a single example.

The following message will be shown at the beginning:

```bash
[05/13/24 16:22:30] INFO     ['distilabel.pipeline.local'] 🌵  Dry run mode                                                                                                                                                                local.py:103
                    INFO     ['distilabel.pipeline.local'] 📝 Pipeline data will be ...                                    local.py:125

```

### How does it work

```python
with Pipeline(...) as pipeline:
    ...
    distiset = pipeline.dry_run(
        parameters=...,  # The same argument as `Pipeline.run`
        batch_size=1  # Optional, will be set to 1 by default.
    )
```

Closes #627 
