### PR TITLE
Fix file name to render docs

### DIFF
--- a/docs/sections/examples/index.md
+++ b/docs/sections/examples/index.md
@@ -10,9 +10,9 @@ It makes use of a local model which can be downlaoded using curl (explained in t
 !!! Run
 
     ```python
-    python examples/rpg_characters_llamacpp.py
+    python examples/structured_generation_with_outlines.py
     ```
 
-```python title="rpg_characters_llamacpp.py"
---8<-- "examples/rpg_characters_llamacpp.py"
+```python title="structured_generation_with_outlines.py"
+--8<-- "examples/structured_generation_with_outlines.py"
 ```


### PR DESCRIPTION
## Description

A file was misnamed in the documentations and we couldn't build the docs, it's fixed here.