### PR TITLE
Fix routing batch function deadlocks and unordered batches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,4 @@ jobs:
 
       - name: Integration Tests
         run: make integration-tests
+        timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
----
-description: Distilabel is an AI Feedback (AIF) framework for building datasets with and for LLMs.
-hide: 
-  - toc
----
-
-<style>.md-typeset h1, .md-content__button { display: none;}</style>
-
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://github.com/argilla-io/distilabel/blob/main/docs/assets/distilabel-white.png?raw=true">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
     "CairoSVG >= 2.7.1",
     "mknotebooks >= 0.8.0",
 ]
-tests = ["pytest >= 7.4.0", "pytest-asyncio", "nest-asyncio"]
+tests = ["pytest >= 7.4.0", "pytest-asyncio", "nest-asyncio", "pytest-timeout"]
 
 # Optional LLMs, integrations, etc
 anthropic = ["anthropic >= 0.20.0"]

--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -234,22 +234,22 @@ def create_distiset(  # noqa: C901
             continue
 
         files = [str(file) for file in list_files_in_dir(file)]
-        try:
-            if files:
+        if files:
+            try:
                 ds = load_dataset(
                     "parquet", name=file.stem, data_files={"train": files}
                 )
                 if not enable_metadata and DISTILABEL_METADATA_KEY in ds.column_names:
                     ds = ds.remove_columns(DISTILABEL_METADATA_KEY)
                 distiset[file.stem] = ds
-            else:
-                logger.warning(
-                    f"No output files for step '{file.stem}', can't create a dataset."
-                    " Did the step produce any data?"
-                )
-        except ArrowInvalid:
-            logger.warning(f"❌ Failed to load the subset from '{file}' directory.")
-            continue
+            except ArrowInvalid:
+                logger.warning(f"❌ Failed to load the subset from '{file}' directory.")
+                continue
+        else:
+            logger.warning(
+                f"No output files for step '{file.stem}', can't create a dataset."
+                " Did the step produce any data?"
+            )
 
     # If there's only one dataset i.e. one config, then set the config name to `default`
     if len(distiset.keys()) == 1:

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -431,7 +431,7 @@ class DAG(_Serializable):
                 f" from step '{predecessor_step.name}' to step '{step.name}'."
             )
 
-        if step.input_batch_size % batch_size != 0:  # type: ignore
+        if batch_size % step.input_batch_size != 0:  # type: ignore
             raise ValueError(
                 f"Step '{step.name}' should have an `input_batch_size` that is a multiple"
                 f" of the `input_batch_size` or `batch_size` of the previous step."

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -30,6 +30,7 @@ from typing import (
 import networkx as nx
 
 from distilabel.pipeline.constants import (
+    CONVERGENCE_STEP_ATTR_NAME,
     ROUTING_BATCH_FUNCTION_ATTR_NAME,
     STEP_ATTR_NAME,
 )
@@ -352,6 +353,9 @@ class DAG(_Serializable):
             for predecessor in predecessors
         ):
             return
+
+        # Mark the step as a convergence step
+        self.set_step_attr(step.name, CONVERGENCE_STEP_ATTR_NAME, True)  # type: ignore
 
         # Check if all the predecessors of the step are receiving routed batches from the
         # same step

--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -431,6 +431,14 @@ class DAG(_Serializable):
                 f" from step '{predecessor_step.name}' to step '{step.name}'."
             )
 
+        if step.input_batch_size % batch_size != 0:  # type: ignore
+            raise ValueError(
+                f"Step '{step.name}' should have an `input_batch_size` that is a multiple"
+                f" of the `input_batch_size` or `batch_size` of the previous step."
+                f" This is because the batches are being routed with a `routing_batch_function`"
+                f" from step '{predecessor_step.name}' to step '{step.name}'."
+            )
+
         return True
 
     def _validate_process_step_input_parameter(

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -545,6 +545,16 @@ class _BatchManagerStep(_Serializable):
         convergence_step: A flag to indicate if the step is a convergence step. An
             `Step` is a convergence step if all its predecessors are receiving routed
             batches. Defaults to `False`.
+        convergence_step_batches_consumed: A dictionary in which the key is the `seq_no`
+            of the batch created by step A, that was used by step B and C and obtained from
+            the `created_from` of the batches created by them. It's used to know if all
+            the batches from B and C steps created from batches of A have been consumed
+            by D, in order to not mess up the order of the batches. Only used if `convergence_step=True`.
+            Defaults to an empty dictionary.
+        next_expected_created_from_batch_seq_no: The next expected sequence number of the
+            batch from step A used by steps B and C and obtained from the `created_from`
+            of the batches created by them. It's used to avoid messing up the order of the
+            batches. Only used if `convergence_step=True`. Defaults to `0`.
     """
 
     step_name: str

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -413,12 +413,12 @@ class BasePipeline(_Serializable):
         """Saves the `BasePipeline` using the `_cache_filename`."""
         self.save(
             path=self._cache_location["pipeline"],
-            format=self._cache_location["pipeline"].suffix.replace(".", ""),
+            format=self._cache_location["pipeline"].suffix.replace(".", ""),  # type: ignore
         )
         if self._batch_manager is not None:
             self._batch_manager.save(
                 self._cache_location["batch_manager"],
-                format=self._cache_location["batch_manager"].suffix.replace(".", ""),
+                format=self._cache_location["batch_manager"].suffix.replace(".", ""),  # type: ignore
             )
         self._logger.debug("Pipeline and batch manager saved to cache.")
 
@@ -428,12 +428,6 @@ class BasePipeline(_Serializable):
         """
         cache_loc = self._cache_location
         if cache_loc["pipeline"].exists():
-            # Refresh the DAG to avoid errors when it's created within a context manager
-            # (it will check the steps aren't already defined for the DAG).
-            self.dag = DAG()
-            new_class = self.from_yaml(cache_loc["pipeline"])
-            # Update the internal dag and batch_manager
-            self.dag.G = new_class.dag.G
             if cache_loc["batch_manager"].exists():
                 self._batch_manager = _BatchManager.from_json(
                     cache_loc["batch_manager"]
@@ -1000,11 +994,11 @@ class _BatchManagerStep(_Serializable):
         """Dumps the content of the `_BatchManagerStep` to a dictionary, using the `dataclass` helper function.
 
         Args:
-            obj (Any): Unused, just kept to match the signature of the parent method.
-            kwargs (Any): Additional arguments that are kept to match the signature of the parent method.
+            obj: Unused, just kept to match the signature of the parent method.
+            kwargs: Additional arguments that are kept to match the signature of the parent method.
 
         Returns:
-            Dict[str, Any]: Internal representation of the `_BatchManagerStep`.
+            Internal representation of the `_BatchManagerStep`.
         """
         return asdict(self)
 

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -1053,10 +1053,16 @@ class _BatchManager(_Serializable):
         """
 
         for step_name, batch in self._last_batch_received.items():
-            if not batch:
+            # It can happen that an step hasn't received any batch because of a `routing_batch_function`,
+            # but the `LAST_BATCH_SENT_FLAG` was sent to it.
+            if not batch and step_name not in self._last_batch_flag_sent_to:
                 return True
 
-            if not batch.last_batch and step_name not in self._last_batch_flag_sent_to:
+            if (
+                batch
+                and not batch.last_batch
+                and step_name not in self._last_batch_flag_sent_to
+            ):
                 return True
 
             if not self.get_last_batch_sent(step_name):

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -1169,12 +1169,10 @@ class _BatchManager(_Serializable):
         steps = {}
         last_batch_received = {}
         last_batch_sent = {}
-        step_seq_nos_received = {}
         for step_name in dag:
             step: "_Step" = dag.get_step(step_name)[STEP_ATTR_NAME]
             last_batch_received[step.name] = None
             last_batch_sent[step.name] = None
-            step_seq_nos_received[step.name] = []
             if step.is_generator:
                 continue
             predecessors = list(dag.get_step_predecessors(step_name))

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -781,15 +781,8 @@ class _BatchManagerStep(_Serializable):
             count == 0
             for count in self.convergence_step_batches_consumed[seq_no].values()
         )
-
         if no_remaining_rows:
-            grouped_batches = self._group_batches_by_created_from()
-            if grouped_batches:
-                next_seq_no, _ = grouped_batches[0]
-                if next_seq_no != seq_no:
-                    self.next_expected_created_from_batch_seq_no = next_seq_no
-            else:
-                self.next_expected_created_from_batch_seq_no += 1
+            self.next_expected_created_from_batch_seq_no += 1
 
         return list(data.values()), dict(batches_used)
 

--- a/src/distilabel/pipeline/constants.py
+++ b/src/distilabel/pipeline/constants.py
@@ -15,6 +15,7 @@
 from typing import Final
 
 STEP_ATTR_NAME: Final[str] = "step"
+INPUT_QUEUE_ATTR_NAME: Final[str] = "input_queue"
 RECEIVES_ROUTED_BATCHES_ATTR_NAME: Final[str] = "receives_routed_batches"
 ROUTING_BATCH_FUNCTION_ATTR_NAME: Final[str] = "routing_batch_function"
 CONVERGENCE_STEP_ATTR_NAME: Final[str] = "convergence_step"

--- a/src/distilabel/pipeline/constants.py
+++ b/src/distilabel/pipeline/constants.py
@@ -17,3 +17,4 @@ from typing import Final
 STEP_ATTR_NAME: Final[str] = "step"
 RECEIVES_ROUTED_BATCHES_ATTR_NAME: Final[str] = "receives_routed_batches"
 ROUTING_BATCH_FUNCTION_ATTR_NAME: Final[str] = "routing_batch_function"
+CONVERGENCE_STEP_ATTR_NAME: Final[str] = "convergence_step"

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -914,7 +914,7 @@ class _ProcessWrapper:
             )
 
             for data, last_batch in step.process_applying_mappings(offset=offset):
-                batch.data = [data]
+                batch.set_data([data])
                 batch.last_batch = self._dry_run or last_batch
                 self._send_batch(batch)
 
@@ -987,7 +987,7 @@ class _ProcessWrapper:
                     f"Subprocess traceback:\n\n{traceback.format_exc()}"
                 )
             finally:
-                batch.data = [result]
+                batch.set_data([result])
                 self._send_batch(batch)
 
             if batch.last_batch:

--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -277,6 +277,14 @@ class _Serializable:
 
     @classmethod
     def from_file(cls, path: StrOrPath) -> Self:
+        """Loads a class from a file.
+
+        Args:
+            path: the path to the file containing the serialized class.
+
+        Returns:
+            An instance of the class.
+        """
         path = Path(path)
         if path.suffix == ".json":
             return cls.from_json(path)

--- a/tests/integration/test_pipe_simple.py
+++ b/tests/integration/test_pipe_simple.py
@@ -157,10 +157,6 @@ def run_pipeline():
 
     return pipeline.run(
         parameters={
-            "load_dataset": {
-                "repo_id": "plaguss/test",
-                "split": "train",
-            },
             "rename_columns": {
                 "rename_mappings": {
                     "prompt": "instruction",

--- a/tests/integration/test_routing_batch_function.py
+++ b/tests/integration/test_routing_batch_function.py
@@ -16,6 +16,7 @@ import random
 import time
 from typing import TYPE_CHECKING, List
 
+import pytest
 from distilabel.pipeline import Pipeline, routing_batch_function
 from distilabel.steps import LoadDataFromDicts, StepInput, step
 
@@ -73,6 +74,7 @@ def CombineGenerations(*inputs: StepInput) -> "StepOutput":
     yield combined_list
 
 
+@pytest.mark.timeout(45)
 def test_routing_batch_function() -> None:
     with Pipeline(name="test") as pipeline:
         load_dataset = LoadDataFromDicts(
@@ -93,6 +95,7 @@ def test_routing_batch_function() -> None:
         assert len(row["generations"]) == 2
 
 
+@pytest.mark.timeout(60)
 def test_routing_batch_function_irregular_batch_sizes() -> None:
     with Pipeline(name="test") as pipeline:
         load_dataset = LoadDataFromDicts(
@@ -117,6 +120,7 @@ def test_routing_batch_function_irregular_batch_sizes() -> None:
         assert len(row["generations"]) == 2
 
 
+@pytest.mark.timeout(120)
 def test_multiple_routing_batch_function() -> None:
     batch_size = 200
 

--- a/tests/integration/test_routing_batch_function.py
+++ b/tests/integration/test_routing_batch_function.py
@@ -74,7 +74,7 @@ def CombineGenerations(*inputs: StepInput) -> "StepOutput":
     yield combined_list
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(120)
 def test_routing_batch_function() -> None:
     with Pipeline(name="test") as pipeline:
         load_dataset = LoadDataFromDicts(
@@ -95,7 +95,7 @@ def test_routing_batch_function() -> None:
         assert len(row["generations"]) == 2
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 def test_routing_batch_function_irregular_batch_sizes() -> None:
     with Pipeline(name="test") as pipeline:
         load_dataset = LoadDataFromDicts(

--- a/tests/integration/test_routing_batch_function.py
+++ b/tests/integration/test_routing_batch_function.py
@@ -80,3 +80,24 @@ def test_routing_batch_function() -> None:
 
     for i, row in enumerate(distiset["default"]["train"]):
         assert row["index"] == i
+
+
+def test_routing_batch_function_irregular_batch_sizes() -> None:
+    with Pipeline(name="test") as pipeline:
+        load_dataset = LoadDataFromDicts(
+            data=[{"index": i, "instruction": f"Instruction {i}"} for i in range(1000)],
+            batch_size=200,
+        )
+
+        generates = [
+            Generate(input_batch_size=batch_size) for batch_size in [25, 50, 100, 200]
+        ]
+
+        combine_generations = CombineGenerations(input_batch_size=25)
+
+        load_dataset >> random_routing_batch >> generates >> combine_generations
+
+    distiset = pipeline.run(use_cache=False)
+
+    for i, row in enumerate(distiset["default"]["train"]):
+        assert row["index"] == i

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1041,6 +1041,100 @@ class TestBatchManagerStep:
         [
             (
                 {
+                    "step1": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=False,
+                            data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                    "step2": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=False,
+                            data=[[{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                },
+                [],
+                False,
+            ),
+            (
+                {
+                    "step1": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=True,
+                            data=[[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                    "step2": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=True,
+                            data=[[{"b": 1}, {"b": 2}, {"b": 3}, {"b": 4}, {"b": 5}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                },
+                [],
+                False,
+            ),
+            (
+                {
+                    "step1": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=True,
+                            data=[[{"a": 1}, {"a": 2}, {"a": 3}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                    "step2": [
+                        _Batch(
+                            seq_no=0,
+                            step_name="step1",
+                            last_batch=True,
+                            data=[[{"b": 1}, {"b": 2}, {"b": 3}]],
+                            created_from={"step0": [0]},
+                        )
+                    ],
+                },
+                [],
+                True,
+            ),
+        ],
+    )
+    def test_last_batch_convergence_step(
+        self,
+        data: Dict[str, List[_Batch]],
+        last_batch_received: List[str],
+        expected: bool,
+    ) -> None:
+        batch_manager_step = _BatchManagerStep(
+            step_name="step3",
+            accumulate=False,
+            data=data,
+            last_batch_received=last_batch_received,
+            input_batch_size=3,
+            convergence_step=True,
+        )
+
+        assert batch_manager_step._last_batch() is expected
+
+    @pytest.mark.parametrize(
+        "data, last_batch_received, expected",
+        [
+            (
+                {
                     "step1": [],
                     "step2": [
                         _Batch(
@@ -1506,6 +1600,7 @@ class TestBatchManager:
             },
             last_batch_received={"step3": None},
             last_batch_sent={"step3": None},
+            last_batch_flag_sent_to=[],
         )
 
         batch_from_step_1 = _Batch(
@@ -1542,6 +1637,7 @@ class TestBatchManager:
             },
             last_batch_received={"step3": None},
             last_batch_sent={"step3": None},
+            last_batch_flag_sent_to=[],
         )
         batch_0 = _Batch(
             seq_no=0,
@@ -1603,6 +1699,7 @@ class TestBatchManager:
                 "step_3": _Batch(seq_no=0, step_name="step_3", last_batch=False),
             },
             last_batch_sent={"step_1": None, "step_2": None, "step_3": None},
+            last_batch_flag_sent_to=[],
         )
 
         assert batch_manager.can_generate()
@@ -1619,6 +1716,7 @@ class TestBatchManager:
                 "step_3": batch_3,
             },
             last_batch_sent={"step_1": batch_1, "step_2": batch_2, "step_3": batch_3},
+            last_batch_flag_sent_to=[],
         )
 
         assert not batch_manager.can_generate()

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1787,6 +1787,7 @@ class TestBatchManager:
                     "step_name": "step3",
                     "accumulate": False,
                     "convergence_step": False,
+                    "convergence_step_batches_consumed": {},
                     "input_batch_size": 5,
                     "data": {"step1": [], "step2": []},
                     "seq_no": 1,
@@ -1806,6 +1807,7 @@ class TestBatchManager:
                     "created_from": {},
                     "last_batch": False,
                     "data": [],
+                    "size": 0,
                     "accumulated": False,
                     "type_info": {
                         "module": "distilabel.pipeline.base",
@@ -1821,6 +1823,7 @@ class TestBatchManager:
                     "created_from": {},
                     "last_batch": False,
                     "data": [],
+                    "size": 0,
                     "accumulated": False,
                     "type_info": {
                         "module": "distilabel.pipeline.base",


### PR DESCRIPTION
## Description

This PR fixes several issues that caused deadlocks and having a final dataset with unordered batches caused when a routing batch function was used in a pipeline. Several tests have been added to check that everything is working correctly.