### PR TITLE
Fix error on `Pipeline.dry_run` without `parameters`

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.2.0"
+__version__ = "1.1.1"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -268,13 +268,13 @@ class BasePipeline(_Serializable):
 
         for step_name in self.dag:
             step = self.dag.get_step(step_name)[STEP_ATTR_NAME]
-            if step.is_generator:
-                if parameters.get(step_name) and parameters[step_name].get(
-                    "batch_size"
-                ):
-                    parameters[step_name]["batch_size"] = batch_size
 
-        distiset = self.run(parameters, use_cache=False)
+            if step.is_generator:
+                if not parameters:
+                    parameters = {}
+                parameters[step_name] = {"batch_size": batch_size}
+
+        distiset = self.run(parameters=parameters, use_cache=False)
 
         self._dry_run = False
         return distiset

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -36,6 +36,11 @@ def test_dry_run():
 
         load_dataset >> text_generation
 
+    # Test with and without parameters
+    distiset = pipeline.dry_run(batch_size=2)
+    assert len(distiset["default"]["train"]) == 2
+    assert pipeline._dry_run is False
+
     distiset = pipeline.dry_run(parameters={load_dataset.name: {"batch_size": 8}})
     assert len(distiset["default"]["train"]) == 1
     assert pipeline._dry_run is False

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -24,40 +24,36 @@ def SucceedAlways(inputs: StepInput) -> "StepOutput":
 
 
 def test_dry_run():
-    with Pipeline(name="other-pipe") as pipeline:
-        load_dataset = LoadDataFromDicts(
-            data=[
-                {"instruction": "Tell me a joke."},
-            ]
-            * 50,
-            batch_size=20,
-        )
-        text_generation = SucceedAlways()
+    load_dataset_name = "load_dataset"
 
-        load_dataset >> text_generation
+    def get_pipeline():
+        with Pipeline(name="other-pipe") as pipeline:
+            load_dataset = LoadDataFromDicts(
+                name=load_dataset_name,
+                data=[
+                    {"instruction": "Tell me a joke."},
+                ]
+                * 50,
+                batch_size=20,
+            )
+            text_generation = SucceedAlways()
+
+            load_dataset >> text_generation
+        return pipeline
 
     # Test with and without parameters
+    pipeline = get_pipeline()
     distiset = pipeline.dry_run(batch_size=2)
     assert len(distiset["default"]["train"]) == 2
     assert pipeline._dry_run is False
 
-    distiset = pipeline.dry_run(parameters={load_dataset.name: {"batch_size": 8}})
+    pipeline = get_pipeline()
+    distiset = pipeline.dry_run(parameters={load_dataset_name: {"batch_size": 8}})
     assert len(distiset["default"]["train"]) == 1
     assert pipeline._dry_run is False
 
-    with Pipeline(name="other-pipe") as pipeline:
-        load_dataset = LoadDataFromDicts(
-            data=[
-                {"instruction": "Tell me a joke."},
-            ]
-            * 50,
-            batch_size=20,
-        )
-        text_generation = SucceedAlways()
-
-        load_dataset >> text_generation
-
+    pipeline = get_pipeline()
     distiset = pipeline.run(
-        parameters={load_dataset.name: {"batch_size": 10}}, use_cache=False
+        parameters={load_dataset_name: {"batch_size": 10}}, use_cache=False
     )
     assert len(distiset["default"]["train"]) == 50


### PR DESCRIPTION
## Description

This PR fixes a bug (thanks @sdiazlor) that prevented calling `dry_run` method without `parameters` argument informed.