### PR TITLE
Add `prometheus.md`

### DIFF
--- a/docs/sections/learn/advanced/argilla.md
+++ b/docs/sections/learn/advanced/argilla.md
@@ -115,4 +115,4 @@ pipeline.run()
 ![Preference to Argilla](../../../assets/images/sections/learn/steps/argilla/preference.png)
 
 !!! NOTE
-    If you are willing to also add the suggestions, feel free to check ["UltraFeedback: Boosting Language Models with High-quality Feedback"](../../examples/papers/ultrafeedback.md) where the [`UltraFeedback`][distilabel.steps.tasks.UltraFeedback] task is used to generate both ratings and rationales for each of the generations of a given instruction.
+    If you are willing to also add the suggestions, feel free to check ["UltraFeedback: Boosting Language Models with High-quality Feedback"](../../pipeline_samples/papers/ultrafeedback.md) where the [`UltraFeedback`][distilabel.steps.tasks.UltraFeedback] task is used to generate both ratings and rationales for each of the generations of a given instruction.

--- a/docs/sections/learn/advanced/structured_generation.md
+++ b/docs/sections/learn/advanced/structured_generation.md
@@ -103,7 +103,7 @@ These were some simple examples, but one can see the options this opens.
 
 !!! NOTE
     A full pipeline example can be seen in the following script:
-    [`examples/structured_generation_with_outlines.py`](../../examples/index.md/#structured_generation_with_outlines)
+    [`examples/structured_generation_with_outlines.py`](../../pipeline_samples/examples/index.md#llama-cpp-with-outlines)
 
 [^1]:
     You can check the variable type by importing it from:

--- a/docs/sections/pipeline_samples/examples/index.md
+++ b/docs/sections/pipeline_samples/examples/index.md
@@ -2,7 +2,7 @@
 
 This section contains different example pipelines that showcase different tasks, maybe you can take inspiration from them.
 
-### llama.cpp with outlines
+### [llama.cpp with outlines](#llama-cpp-with-outlines)
 
 Generate RPG characters following a `pydantic.BaseModel` with `outlines` in `distilabel`.
 

--- a/docs/sections/pipeline_samples/papers/prometheus.md
+++ b/docs/sections/pipeline_samples/papers/prometheus.md
@@ -1,0 +1,121 @@
+# Prometheus 2
+
+["Prometheus 2: An Open Source Language Model Specialized in Evaluating Other Language Models"](https://arxiv.org/pdf/2405.01535) presents Prometheus 2, a new and more powerful evaluator LLM compared to Prometheus (its predecessor) presented in ["Prometheus: Inducing Fine-grained Evaluation Capability in Language Models"](https://arxiv.org/abs/2310.08491); since GPT-4, as well as other proprietary LLMs, are commonly used to asses the quality of the responses for various LLMs, but there are concerns about transparency, controllability, and affordability, that motivate the need of open-source LLMs specialized in evaluations.
+
+Existing open evaluator LMs exhibit critical shortcomings:
+
+1. They issue scores that significantly diverge from those assigned by humans
+2. They lack the flexibility to perform both direct assessment and pairwise ranking, the two most prevalent forms of assessment.
+
+Additionally, they do not possess the ability to evaluate based on custom evaluation criteria, focusing instead on general attributes like helpfulness and harmlessness. Prometheus 2 is capable of processing both direct assessment and pair-wise ranking formats grouped with a user-defined evaluation criteria.
+
+Prometheus 2 released two variants:
+
+- [`prometheus-eval/prometheus-7b-v2.0`](https://hf.co/prometheus-eval/prometheus-7b-v2.0): fine-tuned on top of [`mistralai/Mistral-7B-Instruct-v0.2`](https://hf.co/mistralai/Mistral-7B-Instruct-v0.2)
+- [`prometheus-eval/prometheus-8x7b-v2.0`](https://hf.co/prometheus-eval/prometheus-8x7b-v2.0): fine-tuned on top of [`mistralai/Mixtral-8x7B-Instruct-v0.1`](https://hf.co/mistralai/Mixtral-8x7B-Instruct-v0.1)
+
+Both models have been fine-tuned for both direct assessment and pairwise ranking tasks i.e. assessing the quality of a single isolated response for a given instruction with or without a reference answer, and assessing the quality of one response against another one for a given instruction with or without a reference answer, respectively.
+
+On four direct assessment benchmarks and four pairwise ranking benchmarks, Prometheus 2 scores the highest correlation and agreement with humans and proprietary LM judges among all tested open evaluator LMs. Their models, code, and data are all publicly available at [`prometheus-eval/prometheus-eval`](https://github.com/prometheus-eval/prometheus-eval).
+
+### Replication
+
+!!! NOTE
+    The section is named `Replication` but in this case we're not replicating the Prometheus 2 paper per se, but rather showing how to use the [`PrometheusEval`][distilabel.steps.tasks.PrometheusEval] task implemented within `distilabel` to evaluate the quality of the responses from a given instruction using the Prometheus 2 model.
+
+To showcase Prometheus 2 we will be using the [`PrometheusEval`][distilabel.steps.tasks.PrometheusEval] task implemented in `distilabel` and a smaller dataset created by the Hugging Face H4 team named [`HuggingFaceH4/instruction-dataset`](https://hf.co/datasets/HuggingFaceH4/instruction-dataset) for testing purposes.
+
+#### Installation
+
+To reproduce the code below, one will need to install `distilabel` as it follows:
+
+```bash
+pip install "distilabel[vllm]>=1.1.0"
+```
+
+Alternatively, it's recommended to install [`Dao-AILab/flash-attention`](https://github.com/Dao-AILab/flash-attention) to benefit from Flash Attention 2 speed ups during inference via `vllm`.
+
+```bash
+pip install flash-attn --no-build-isolation
+```
+
+!!! NOTE
+    The installation notes above assume that you are using a VM with one GPU accelerator with at least the required VRAM to fit [`prometheus-eval/prometheus-7b-v2.0`](https://hf.co/prometheus-eval/prometheus-7b-v2.0) in bfloat16 (28GB); but if you have enough VRAM to fit their 8x7B model in bfloat16 (~90GB) you can use [`prometheus-eval/prometheus-8x7b-v2.0`](https://hf.co/prometheus-eval/prometheus-8x7b-v2.0) instead.
+
+#### Building blocks
+
+- [`LoadHubDataset`][distilabel.steps.LoadHubDataset]: [`GeneratorStep`][distilabel.steps.GeneratorStep] to load a dataset from the Hugging Face Hub.
+
+- [`PrometheusEval`][distilabel.steps.tasks.PrometheusEval]: [`Task`][distilabel.steps.tasks.Task] that assesses the quality of a response for a given instruction using any of the Prometheus 2 models.
+    - [`vLLM`][distilabel.llms.vLLM]: [`LLM`][distilabel.llms.LLM] that loads a model from the Hugging Face Hub via [vllm-project/vllm](https://github.com/vllm-project/vllm).
+
+    !!! NOTE
+        Since the Prometheus 2 models use a slightly different chat template than [`mistralai/Mistral-7B-Instruct-v0.2`](https://hf.co/mistralai/Mistral-7B-Instruct-v0.2), we need to set the `chat_template` parameter to `[INST] {{ messages[0]['content'] }}\n{{ messages[1]['content'] }}[/INST]` so as to properly format the input for Prometheus 2.
+
+- (Optional) [`KeepColumns`][distilabel.steps.KeepColumns]: [`Task`][distilabel.steps.tasks.Task] that keeps only the specified columns in the dataset, used to remove the undesired columns.
+
+#### Code
+
+As mentioned before, we will put the previously mentioned building blocks together to see how Prometheus 2 can be used via `distilabel`.
+
+```python
+from distilabel.llms import vLLM
+from distilabel.pipeline import Pipeline
+from distilabel.steps import KeepColumns, LoadHubDataset
+from distilabel.steps.tasks import PrometheusEval
+
+if __name__ == "__main__":
+    with Pipeline(name="prometheus") as pipeline:
+        load_dataset = LoadHubDataset(
+            name="load_dataset",
+            repo_id="HuggingFaceH4/instruction-dataset",
+            split="test",
+            output_mappings={"prompt": "instruction", "completion": "generation"},
+        )
+
+        task = PrometheusEval(
+            name="task",
+            llm=vLLM(
+                model="prometheus-eval/prometheus-7b-v2.0",
+                chat_template="[INST] {{ messages[0]['content'] }}\n{{ messages[1]['content'] }}[/INST]",
+            ),
+            mode="absolute",
+            rubric="factual-validity",
+            reference=False,
+            num_generations=1,
+            group_generations=False,
+        )
+
+        keep_columns = KeepColumns(
+            name="keep_columns",
+            columns=["instruction", "generation", "feedback", "result", "model_name"],
+        )
+
+        load_dataset >> task >> keep_columns
+```
+
+Then we need to call `pipeline.run` with the runtime parameters so that the pipeline can be launched.
+
+```python
+distiset = pipeline.run(
+    parameters={
+        task.name: {
+            "llm": {
+                "generation_kwargs": {
+                    "max_new_tokens": 1024,
+                    "temperature": 0.7,
+                },
+            },
+        },
+    },
+)
+```
+
+Finally, we can optionally push the generated dataset, named [`Distiset`][distilabel.distiset.Distiset], to the Hugging Face Hub via the `push_to_hub` method, so that each subset generated in the leaf steps is pushed to the Hub.
+
+```python
+distiset.push_to_hub(
+    "instruction-dataset-prometheus",
+    private=True,
+)
+```

--- a/docs/sections/pipeline_samples/papers/prometheus.md
+++ b/docs/sections/pipeline_samples/papers/prometheus.md
@@ -4,7 +4,7 @@
 
 Existing open evaluator LMs exhibit critical shortcomings:
 
-1. They issue scores that significantly diverge from those assigned by humans
+1. They issue scores that significantly diverge from those assigned by humans.
 2. They lack the flexibility to perform both direct assessment and pairwise ranking, the two most prevalent forms of assessment.
 
 Additionally, they do not possess the ability to evaluate based on custom evaluation criteria, focusing instead on general attributes like helpfulness and harmlessness. Prometheus 2 is capable of processing both direct assessment and pair-wise ranking formats grouped with a user-defined evaluation criteria.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,7 @@ nav:
           - "sections/pipeline_samples/papers/index.md"
           - DEITA: "sections/pipeline_samples/papers/deita.md"
           - Instruction Backtranslation: "sections/pipeline_samples/papers/instruction_backtranslation.md"
-          # - Prometheus: "sections/examples/papers/prometheus.md"
+          - Prometheus 2: "sections/pipeline_samples/papers/prometheus.md"
           - UltraFeedback: "sections/pipeline_samples/papers/ultrafeedback.md"
   - FAQ: "sections/faq.md"
   - API Reference:


### PR DESCRIPTION
## Description

This PR adds the `prometheus.md` file to the `sections/pipeline_samples/papers/*.md` directory with a brief introduction to the Prometheus 2 paper and the `PrometheusEval` task implemented within `distilabel` as of the v1.1.0 release.

Announcement post at https://x.com/alvarobartt/status/1788152893461123105

Closes #645 