### PR TITLE
Fix crash when using vLLM without structured generation

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/llms/vllm.py
+++ b/src/distilabel/llms/vllm.py
@@ -211,7 +211,9 @@ class vLLM(LLM, CudaDevicePlacementMixin):
             top_p=top_p,
             top_k=top_k,
             max_tokens=max_new_tokens,
-            logits_processors=[self._logits_processor],
+            logits_processors=(
+                [self._logits_processor] if self._logits_processor else None
+            ),
             **extra_sampling_params,
         )
 


### PR DESCRIPTION
When using the vLLM backend, currently structured generation must be set or the task will crash with the following error:

```
 "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/layers/logits_processor.py", line 106, in _apply_logits_processors
    logits_row = logits_processor(token_ids, logits_row)
TypeError: 'NoneType' object is not callable
```

This is because `[self._logits_processor]` is passed to vLLM as the list of logit processors, even when `self._logits_processor` is `None`. vLLM isn't picky and happily calls that `None`.

Just a one-line tweak to make things work again.