### PR TITLE
Fix circular import due to DISTILABEL_METADATA_KEY

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -21,7 +21,6 @@ from datasets import load_dataset
 from huggingface_hub import DatasetCardData, HfApi
 from pyarrow.lib import ArrowInvalid
 
-from distilabel.steps.tasks.base import DISTILABEL_METADATA_KEY
 from distilabel.utils.card.dataset_card import (
     DistilabelDatasetCard,
     size_categories_parser,
@@ -225,6 +224,7 @@ def create_distiset(  # noqa: C901
         correspond to different configurations of the dataset.
     """
     logger = logging.getLogger("distilabel.distiset")
+    from distilabel.steps.constants import DISTILABEL_METADATA_KEY
 
     data_dir = Path(data_dir)
 

--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -223,8 +223,9 @@ def create_distiset(  # noqa: C901
         The dataset created from the buffer folder, where the different leaf steps will
         correspond to different configurations of the dataset.
     """
-    logger = logging.getLogger("distilabel.distiset")
     from distilabel.steps.constants import DISTILABEL_METADATA_KEY
+    
+    logger = logging.getLogger("distilabel.distiset")
 
     data_dir = Path(data_dir)
 

--- a/src/distilabel/steps/constants.py
+++ b/src/distilabel/steps/constants.py
@@ -1,0 +1,15 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DISTILABEL_METADATA_KEY = "distilabel_metadata"


### PR DESCRIPTION
## Description

This PR fixes a bug due to a circular import in `distiset.py`, to check:
```python
from distilabel.distiset import create_distiset
```
