### PR TITLE
Deprecate conversation support in `TextGeneration` in favour of `ChatGeneration`

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -224,7 +224,7 @@ def create_distiset(  # noqa: C901
         correspond to different configurations of the dataset.
     """
     from distilabel.steps.constants import DISTILABEL_METADATA_KEY
-    
+
     logger = logging.getLogger("distilabel.distiset")
 
     data_dir = Path(data_dir)

--- a/src/distilabel/steps/tasks/text_generation.py
+++ b/src/distilabel/steps/tasks/text_generation.py
@@ -62,14 +62,10 @@ class TextGeneration(Task):
         is the first interaction from the user within a conversation."""
 
         if is_openai_format(input["instruction"]):
-            warnings.warn(
+            raise ValueError(
                 "Providing `instruction` formatted as an OpenAI chat / conversation is"
-                " about to be deprecated in `distilabel v1.2.0`, please make sure to use"
-                " `ChatTextGeneration` with `messages` as input instead.",
-                DeprecationWarning,
-                stacklevel=2,
+                " deprecated, you should use `ChatGeneration` with `messages` as input instead.",
             )
-            return input["instruction"]
 
         if not isinstance(input["instruction"], str):
             raise ValueError(

--- a/tests/unit/steps/tasks/test_text_generation.py
+++ b/tests/unit/steps/tasks/test_text_generation.py
@@ -54,6 +54,12 @@ class TestTextGeneration:
         )
 
         with pytest.raises(
+            ValueError,
+            match=r"Providing \`instruction\` formatted as an OpenAI chat / conversation is deprecated",
+        ):
+            task.format_input({"instruction": [{"role": "user", "content": "test"}]})
+
+        with pytest.raises(
             ValueError, match=r"Input \`instruction\` must be a string. Got: 1."
         ):
             task.format_input({"instruction": 1})
@@ -78,23 +84,6 @@ class TestTextGeneration:
                 "model_name": "test",
             }
         ]
-
-    def test_deprecation_warning(self) -> None:
-        pipeline = Pipeline(name="unit-test-pipeline")
-        llm = DummyLLM()
-        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
-
-        with pytest.warns(
-            DeprecationWarning,
-            match=r"Providing \`instruction\` formatted as an OpenAI chat \/ conversation is about to be deprecated in \`distilabel v1.2.0\`",
-        ):
-            task.format_input(
-                {
-                    "instruction": [
-                        {"role": "user", "content": "Tell me a joke."},
-                    ]
-                }
-            )
 
 
 class TestChatGeneration:


### PR DESCRIPTION
## Description

This PR drops the support for conversation-like messages in `TextGeneration` in favour of the recently included `ChatGeneration` task, as anticipated within the v1.1.0 release.

Closes #644