### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,13 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: "Bartolome"
-  given-names: "Alvaro"
-- family-names: "Martín Blázquez"
+- family-names: "Bartolomé"
+  given-names: "Álvaro"
+- family-names: "Martín-Blázquez"
   given-names: "Gabriel"
-- family-names: "Piqueres"
-  given-names: "Agustin"
-- family-names: "Vila"
+- family-names: "Piqueres-Lajarín"
+  given-names: "Agustín"
+- family-names: "Vila-Suero"
   given-names: "Daniel"
 title: "Distilabel: An AI Feedback (AIF) framework for building datasets with and for LLMs."
 version: 1.1.1


### PR DESCRIPTION
## Description

This PR adds the `CITATION.cff` file so that anyone willing to cite `distilabel` can do so without having to create their own custom citation forms.

The authors have been sorted alphabetically due to equal contribution, and the title/description is matching the GitHub description as in the `pyproject.toml` file; but can be modified too.

Reference about the GitHub citation system at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files, and kudos to @davidberenstein1957 for the suggestion!