### PR TITLE
Fix only getting last string item for `EvolQuality._apply_random_mutation`

### DIFF
--- a/src/distilabel/steps/tasks/evol_quality/base.py
+++ b/src/distilabel/steps/tasks/evol_quality/base.py
@@ -149,7 +149,7 @@ class EvolQuality(Task):
         return (
             self.mutation_templates[mutation]
             .replace("<PROMPT>", instruction)
-            .replace("<RESPONSE>", response[-1])
+            .replace("<RESPONSE>", response)
         )
 
     def _evolve_reponses(self, inputs: "StepInput") -> List[List[str]]:


### PR DESCRIPTION
`EvolQuality._apply_random_mutation` was only taking the last item in the string, which caused the prompt template to be applied incorrectly.