### PR TITLE
Fix `EvolQuality._apply_random_mutation` not properly injecting `response` in template

### DIFF
--- a/src/distilabel/steps/tasks/evol_quality/base.py
+++ b/src/distilabel/steps/tasks/evol_quality/base.py
@@ -149,7 +149,7 @@ class EvolQuality(Task):
         return (
             self.mutation_templates[mutation]
             .replace("<PROMPT>", instruction)
-            .replace("<RESPONSE>", response[-1])
+            .replace("<RESPONSE>", response)
         )
 
     def _evolve_reponses(self, inputs: "StepInput") -> List[List[str]]:

--- a/tests/unit/steps/tasks/evol_quality/test_base.py
+++ b/tests/unit/steps/tasks/evol_quality/test_base.py
@@ -34,6 +34,18 @@ class TestEvolQuality:
         EvolQuality(name="task", llm=dummy_llm, num_evolutions=2)
         assert "Step 'task' hasn't received a pipeline" in caplog.text
 
+    def test_apply_random_mutation(self, dummy_llm: LLM) -> None:
+        pipeline = Pipeline(name="unit-test-pipeline")
+        task = EvolQuality(
+            name="task", llm=dummy_llm, num_evolutions=2, pipeline=pipeline
+        )
+        task.load()
+
+        mutated = task._apply_random_mutation("I'm an instruction", "I'm a response")
+
+        assert "I'm an instruction" in mutated
+        assert "I'm a response" in mutated
+
     def test_process(self, dummy_llm: LLM) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         task = EvolQuality(


### PR DESCRIPTION
## Description

This PR fix the `_apply_random_mutation` method that was just using the last character of the provided `response`.