### PR TITLE
Add context to guide the generate sentence pair task if informed

### DIFF
--- a/src/distilabel/steps/tasks/sentence_transformers.py
+++ b/src/distilabel/steps/tasks/sentence_transformers.py
@@ -43,17 +43,19 @@ GENERATION_ACTION_SENTENCES: Final[Dict[GenerationAction, str]] = {
 }
 
 POSITIVE_SYSTEM_PROMPT: str = (
-    "Your task is to generate a positive sentence given an anchor sentence. The positive"
+    "Your task is to generate a positive sentence given an anchor sentence.{context} The positive"
     " sentence has to {action_sentence} the anchor sentence. You must output only one new"
     " section: `## Positive`."
 )
 
 POSITIVE_NEGATIVE_SYSTEM_PROMPT: str = (
-    "Your task is to generate a positive and a negative sentence given an anchor sentence."
+    "Your task is to generate a positive and a negative sentence given an anchor sentence.{context}"
     " The positive sentence has to {action_sentence} the anchor sentence, while the negative"
     " sentence can use similar words but must not be related to the anchor sentence. You"
     " must output only two new sections: `## Positive` and `## Negative`."
 )
+
+CONTEXT_INTRO: Final[str] = " Take into account the context given."
 
 
 class GenerateSentencePair(Task):
@@ -68,6 +70,8 @@ class GenerateSentencePair(Task):
         triplet: a flag to indicate if the task should generate a triplet of sentences
             (anchor, positive, negative). Defaults to `False`.
         action: the action to perform to generate the positive sentence.
+        context: the context to use for the generation. Can be helpful to guide the LLM
+            towards more specific context. Defaults to `None`.
 
     Input columns:
         - anchor (`str`): The anchor sentence to generate the positive and negative sentences.
@@ -169,6 +173,7 @@ class GenerateSentencePair(Task):
 
     triplet: bool = False
     action: GenerationAction
+    context: str = ""
 
     def load(self) -> None:
         """Loads the Jinja2 template."""
@@ -203,11 +208,20 @@ class GenerateSentencePair(Task):
         action_sentence = GENERATION_ACTION_SENTENCES[self.action]
         system_prompt = (
             POSITIVE_NEGATIVE_SYSTEM_PROMPT if self.triplet else POSITIVE_SYSTEM_PROMPT
-        ).format(action_sentence=action_sentence)
+        ).format(
+            action_sentence=action_sentence,
+            context=CONTEXT_INTRO if self.context else "",
+        )
 
         return [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": self._template.render(anchor=input["anchor"])},
+            {
+                "role": "user",
+                "content": self._template.render(
+                    anchor=input["anchor"],
+                    context=self.context if self.context else None,
+                ),
+            },
         ]
 
     @property

--- a/src/distilabel/steps/tasks/sentence_transformers.py
+++ b/src/distilabel/steps/tasks/sentence_transformers.py
@@ -63,7 +63,8 @@ class GenerateSentencePair(Task):
 
     `GenerateSentencePair` is a pre-defined task that given an anchor sentence generates
     a positive sentence related to the anchor and optionally a negative sentence unrelated
-    to the anchor. This task is useful to generate training datasets for training embeddings
+    to the anchor. Optionally, you can give a context to guide the LLM towards more specific
+    behavior. This task is useful to generate training datasets for training embeddings
     models.
 
     Attributes:
@@ -71,7 +72,7 @@ class GenerateSentencePair(Task):
             (anchor, positive, negative). Defaults to `False`.
         action: the action to perform to generate the positive sentence.
         context: the context to use for the generation. Can be helpful to guide the LLM
-            towards more specific context. Defaults to `None`.
+            towards more specific context. Not used by default.
 
     Input columns:
         - anchor (`str`): The anchor sentence to generate the positive and negative sentences.
@@ -168,6 +169,28 @@ class GenerateSentencePair(Task):
         generate_sentence_pair.load()
 
         result = generate_sentence_pair.process([{"anchor": "What Game of Thrones villain would be the most likely to give you mercy?"}])
+        ```
+
+        Generating queries with context (**applies to every action**):
+
+        ```python
+        from distilabel.steps.tasks import GenerateSentencePair
+        from distilabel.llms import InferenceEndpointsLLM
+
+        generate_sentence_pair = GenerateSentencePair(
+            triplet=True, # `False` to generate only positive
+            action="query",
+            context="Argilla is an open-source data curation platform for LLMs.",
+            llm=InferenceEndpointsLLM(
+                model_id="meta-llama/Meta-Llama-3-70B-Instruct",
+                tokenizer_id="meta-llama/Meta-Llama-3-70B-Instruct",
+            ),
+            input_batch_size=10,
+        )
+
+        generate_sentence_pair.load()
+
+        result = generate_sentence_pair.process([{"anchor": "I want to generate queries for my LLM."}])
         ```
     """
 

--- a/src/distilabel/steps/tasks/templates/generate-sentence-pair.jinja2
+++ b/src/distilabel/steps/tasks/templates/generate-sentence-pair.jinja2
@@ -1,8 +1,11 @@
-## Anchor
-
-{{ anchor }}
 {% if context is not none -%}
 ## Context
 
 {{ context }}
-{%- endif %}
+
+{% endif -%}
+
+## Anchor
+
+{{ anchor }}
+

--- a/src/distilabel/steps/tasks/templates/generate-sentence-pair.jinja2
+++ b/src/distilabel/steps/tasks/templates/generate-sentence-pair.jinja2
@@ -1,4 +1,8 @@
 ## Anchor
 
 {{ anchor }}
+{% if context is not none -%}
+## Context
 
+{{ context }}
+{%- endif %}

--- a/tests/unit/steps/tasks/test_sentence_transformers.py
+++ b/tests/unit/steps/tasks/test_sentence_transformers.py
@@ -91,9 +91,10 @@ class TestGenerateSentencePair:
     ) -> None:
         task = GenerateSentencePair(llm=DummyLLM(), action=action, triplet=triplet)
         task.load()
+        content = "## Anchor\n\nThis is a unit test\n"
         assert task.format_input({"anchor": "This is a unit test"}) == [
             {"role": "system", "content": system_prompt},
-            {"role": "user", "content": "## Anchor\n\nThis is a unit test\n"},
+            {"role": "user", "content": content},
         ]
 
     @pytest.mark.parametrize(
@@ -168,7 +169,8 @@ class TestGenerateSentencePair:
             context=context,
         )
         task.load()
-        content = f"## Anchor\n\nThis is a unit test\n## Context\n\n{context}"
+        content = f"## Context\n\n{context}\n\n## Anchor\n\nThis is a unit test\n"
+        # content = f"## Anchor\n\nThis is a unit test\n## Context\n\n{context}"
         assert task.format_input({"anchor": "This is a unit test"}) == [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": content},


### PR DESCRIPTION
## Description

This PR adds a new optional `context` to the `GenerateSentencePair` task to help guiding the prompts:

```python
from distilabel.steps import GenerateSentencePair

task = GenerateSentencePair(
    llm=llm,
    action="query",
    triplet=True,
    context="The generated sentence has to be related with Argilla, a data annotation tool for AI engineers and domain experts.",
)
```

## Context

The original prompt, given a "hard" instruction (or possibly quite meaningless without context) could generate unexpected queries, for reference:
<img width="650" alt="image" src="https://github.com/argilla-io/distilabel/assets/56895847/3475a6f1-722b-41c0-a131-869510d9bd3b">

With context, it can generate more meaningful queries:

![image](https://github.com/argilla-io/distilabel/assets/56895847/b41f95b2-14d5-4758-9a32-fe79827ceea4)
