### PR TITLE
Gather HF_TOKEN internally when calling `Distiset.push_to_hub` if token is None.

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -90,8 +90,7 @@ class Distiset(dict):
         if token is None:
             from huggingface_hub import constants
 
-            if token := os.getenv(_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME):
-                pass
+            token = os.getenv(_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME):
             if token is None:
                 if not Path(constants.HF_TOKEN_PATH).exists():
                     raise ValueError(

--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 import os.path as posixpath
 import re
 from os import PathLike
@@ -29,12 +28,12 @@ from huggingface_hub.file_download import hf_hub_download
 from pyarrow.lib import ArrowInvalid
 from typing_extensions import Self
 
-from distilabel.utils import _INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME
 from distilabel.utils.card.dataset_card import (
     DistilabelDatasetCard,
     size_categories_parser,
 )
 from distilabel.utils.files import list_files_in_dir
+from distilabel.utils.huggingface import get_hf_token
 
 DISTISET_CONFIG_FOLDER: Final[str] = "distiset_configs"
 PIPELINE_CONFIG_FILENAME: Final[str] = "pipeline.yaml"
@@ -88,19 +87,7 @@ class Distiset(dict):
             ValueError: If no token is provided and couldn't be retrieved automatically.
         """
         if token is None:
-            from huggingface_hub import constants
-
-            token = os.getenv(_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME):
-            if token is None:
-                if not Path(constants.HF_TOKEN_PATH).exists():
-                    raise ValueError(
-                        f"To use `{self.__class__.__name__}` an API key must be provided via"
-                        " `token`, set the environment variable"
-                        f" `{_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME}` or use the `huggingface-hub` CLI to login"
-                        " with `huggingface-cli login`."
-                    )
-                with open(constants.HF_TOKEN_PATH) as f:
-                    token = f.read().strip()
+            token = get_hf_token(self.__class__.__name__, "token")
 
         for name, dataset in self.items():
             dataset.push_to_hub(

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -33,15 +33,13 @@ from distilabel.llms.base import AsyncLLM
 from distilabel.llms.typing import GenerateOutput
 from distilabel.mixins.runtime_parameters import RuntimeParameter
 from distilabel.steps.tasks.typing import FormattedInput, Grammar, StandardInput
+from distilabel.utils import _INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME
 from distilabel.utils.itertools import grouper
 
 if TYPE_CHECKING:
     from huggingface_hub import AsyncInferenceClient
     from openai import AsyncOpenAI
     from transformers import PreTrainedTokenizer
-
-
-_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME = "HF_TOKEN"
 
 
 class InferenceEndpointsLLM(AsyncLLM):

--- a/src/distilabel/utils/__init__.py
+++ b/src/distilabel/utils/__init__.py
@@ -11,7 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Final
-
-_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME: Final[str] = "HF_TOKEN"

--- a/src/distilabel/utils/__init__.py
+++ b/src/distilabel/utils/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import Final
+
+_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME: Final[str] = "HF_TOKEN"

--- a/src/distilabel/utils/huggingface.py
+++ b/src/distilabel/utils/huggingface.py
@@ -1,0 +1,53 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Final
+
+from huggingface_hub import constants
+
+_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME: Final[str] = "HF_TOKEN"
+
+
+def get_hf_token(cls_name: str, token_arg: str) -> str:
+    """Get the token for the hugging face API.
+
+    Tries to extract it from the environment variable, if it is not found
+    it tries to read it from the file using 'huggingface_hub',
+    and if not possible raises a ValueError.
+
+    Args:
+        cls_name: Name of the class/function that requires the token.
+        token_arg: Argument name to use in the error message, normally
+            is "token" or "api_key".
+
+    Raises:
+        ValueError: If the token is not found in the file.
+
+    Returns:
+        The token for the hugging face API.
+    """
+    token = os.getenv(_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME)
+    if token is None:
+        if not Path(constants.HF_TOKEN_PATH).exists():
+            raise ValueError(
+                f"To use `{cls_name}` an API key must be provided via"
+                f" `{token_arg}`, set the environment variable"
+                f" `{_INFERENCE_ENDPOINTS_API_KEY_ENV_VAR_NAME}` or use the `huggingface-hub` CLI to login"
+                " with `huggingface-cli login`."
+            )
+        with open(constants.HF_TOKEN_PATH) as f:
+            token = f.read().strip()
+    return token


### PR DESCRIPTION
## Description

We will try to load the HF_TOKEN internally if possible, or raise a `ValueError` if not possible, to avoid propagating the error.

Closes #693 