### PR TITLE
Fix `install_dependencies.sh`

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 python_version=$(python -c "import sys; print(sys.version_info[:2])")
 
 python -m pip install uv


### PR DESCRIPTION
## Description

This PR fixes the script used to install the dependencies within the CI i.e. `scripts/instal_dependencies.sh` so as to include the `set -e` option will exit on every non-zero status code, otherwise, the CI continues even if the `uv pip install` command fails.