### PR TITLE
Fix AzureOpenAILLM load method setting the correct path to mock the internal class

### DIFF
--- a/src/distilabel/llms/azure.py
+++ b/src/distilabel/llms/azure.py
@@ -134,7 +134,9 @@ class AzureOpenAILLM(OpenAILLM):
         """Loads the `AsyncAzureOpenAI` client to benefit from async requests."""
         # This is a workaround to avoid the `OpenAILLM` calling the _prepare_structured_output
         # in the load method before we have the proper client.
-        with patch("OpenAILLM._prepare_structured_output", lambda x: x):
+        with patch(
+            "distilabel.llms.openai.OpenAILLM._prepare_structured_output", lambda x: x
+        ):
             super().load()
 
         try:


### PR DESCRIPTION
## Description

This PR fixes a bug created while mocking a method in `AzureOpenAILLM`.

Closes https://github.com/argilla-io/distilabel/issues/716