### PR TITLE
docs: 728 docs api reference tasktyping cannot be imported during doc build

### DIFF
--- a/docs/api/task/typing.md
+++ b/docs/api/task/typing.md
@@ -1,11 +1,3 @@
 # Task Typing
 
-This section contains typing classes implemented in distilabel.
-
-::: distilabel.steps.tasks.typing.ChatType
-    options:
-        members:
-            - _ChatType
-            - ChatType
-::: distilabel.steps.tasks.structured_outputs.outlines.StructuredOutputType
-::: distilabel.steps.tasks.structured_outputs.instructor.InstructorStructuredOutputType
+::: distilabel.steps.tasks.typing


### PR DESCRIPTION
- only include `distilabel.steps.tasks.typing`
- remove `distilabel.steps.task.structured_generation.*` from API ref