### PR TITLE
Add serving LLM section in the docs

### DIFF
--- a/docs/sections/getting_started/faq.md
+++ b/docs/sections/getting_started/faq.md
@@ -39,3 +39,6 @@ hide:
     For more information on the caching mechanism in `distilabel`, you can check the [Learn - Advanced - Caching](../how_to_guides/advanced/caching.md) section.
 
     Also note that when running a [`Step`][distilabel.steps.base.Step] or a [`Task`][distilabel.steps.tasks.Task] standalone, the cache mechanism won't be used, so if you want to use that, you should use the `Pipeline` context manager.
+
+??? faq "How can I use the same `LLM` across several tasks without having to load it several times?"
+    You can serve the LLM using a solution like TGI or vLLM, and then connect to it using an `AsyncLLM` client like `InferenceEndpointsLLM` or `OpenAILLM`. Please refer to [Serving LLMs guide](../how_to_guides/advanced/serving_an_llm_for_reuse.md) for more information.

--- a/docs/sections/how_to_guides/advanced/argilla.md
+++ b/docs/sections/how_to_guides/advanced/argilla.md
@@ -106,7 +106,8 @@ with Pipeline(name="my-pipeline") as pipeline:
 
     load_dataset >> text_generation >> to_argilla
 
-pipeline.run()
+if __name__ == "__main__":
+    pipeline.run()
 ```
 
 ![Preference to Argilla](../../../assets/images/sections/how_to_guides/steps/argilla/preference.png)

--- a/docs/sections/how_to_guides/advanced/serving_an_llm_for_reuse.md
+++ b/docs/sections/how_to_guides/advanced/serving_an_llm_for_reuse.md
@@ -1,0 +1,92 @@
+# Serving an `LLM` for sharing it between several `Task`s
+
+It's very common to want to use the same `LLM` for several `Task`s in a pipeline. To avoid loading the `LLM` as many times as the number of `Task`s and avoid wasting resources, it's recommended to serve the model using solutions like [`text-generation-inference`](https://huggingface.co/docs/text-generation-inference/quicktour#launching-tgi) or [`vLLM`](https://docs.vllm.ai/en/stable/serving/deploying_with_docker.html), and then use an `AsyncLLM` compatible client like `InferenceEndpointsLLM` or `OpenAILLM` to communicate with the server respectively.
+
+## Serving `meta-llama/Meta-Llama-3-8B-Instruct` using `text-generation-inference`
+
+```bash
+model=meta-llama/Meta-Llama-3-8B-Instruct
+volume=$PWD/data # share a volume with the Docker container to avoid downloading weights every run
+
+docker run --gpus all --shm-size 1g -p 8080:80 -v $volume:/data \
+    -e HUGGING_FACE_HUB_TOKEN=<secret> \
+    ghcr.io/huggingface/text-generation-inference:2.0.4 \
+    --model-id $model
+```
+
+!!! NOTE
+
+    The bash command above has been copy-pasted from the official docs [text-generation-inference](https://huggingface.co/docs/text-generation-inference/quicktour#launching-tgi). Please refer to the official docs for more information.
+
+And then we can use `InferenceEndpointsLLM` with `base_url=http://localhost:8080` (pointing to our `TGI` local deployment):
+
+```python
+from distilabel.llms import InferenceEndpointsLLM
+from distilabel.pipeline import Pipeline
+from distilabel.steps import LoadDataFromDicts
+from distilabel.steps.tasks import TextGeneration, UltraFeedback
+
+with Pipeline(name="serving-llm") as pipeline:
+    load_data = LoadDataFromDicts(
+        data=[{"instruction": "Write a poem about the sun and moon."}]
+    )
+
+    # `base_url` points to the address of the `TGI` serving the LLM
+    llm = InferenceEndpointsLLM(base_url="http://192.168.1.138:8080")
+
+    text_generation = TextGeneration(
+        llm=llm,
+        num_generations=3,
+        group_generations=True,
+        output_mappings={"generation": "generations"},
+    )
+
+    ultrafeedback = UltraFeedback(aspect="overall-rating", llm=llm)
+
+    load_data >> text_generation >> ultrafeedback
+```
+
+
+## Serving `meta-llama/Meta-Llama-3-8B-Instruct` using `vLLM`
+
+```bash
+docker run --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
+    -p 8000:8000 \
+    --ipc=host \
+    vllm/vllm-openai:latest \
+    --model meta-llama/Meta-Llama-3-8B-Instruct
+```
+
+!!! NOTE
+
+    The bash command above has been copy-pasted from the official docs [vLLM](https://docs.vllm.ai/en/stable/serving/deploying_with_docker.html). Please refer to the official docs for more information.
+
+And then we can use `OpenAILLM` with `base_url=http://localhost:8000` (pointing to our `vLLM` local deployment):
+
+```python
+from distilabel.llms import OpenAILLM
+from distilabel.pipeline import Pipeline
+from distilabel.steps import LoadDataFromDicts
+from distilabel.steps.tasks import TextGeneration, UltraFeedback
+
+with Pipeline(name="serving-llm") as pipeline:
+    load_data = LoadDataFromDicts(
+        data=[{"instruction": "Write a poem about the sun and moon."}]
+    )
+
+    # `base_url` points to the address of the `vLLM` serving the LLM
+    llm = OpenAILLM(base_url="http://192.168.1.138:8000", model="")
+
+    text_generation = TextGeneration(
+        llm=llm,
+        num_generations=3,
+        group_generations=True,
+        output_mappings={"generation": "generations"},
+    )
+
+    ultrafeedback = UltraFeedback(aspect="overall-rating", llm=llm)
+
+    load_data >> text_generation >> ultrafeedback
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
           - Using CLI to explore and re-run existing Pipelines: "sections/how_to_guides/advanced/cli/index.md"
           - Cache and recover pipeline executions: "sections/how_to_guides/advanced/caching.md"
           - Structured data generation: "sections/how_to_guides/advanced/structured_generation.md"
+          - Serving an LLM for sharing it between several tasks: "sections/how_to_guides/advanced/serving_an_llm_for_reuse.md"
   - Pipeline Samples:
       - Examples: "sections/pipeline_samples/examples/index.md"
       - Papers:


### PR DESCRIPTION
## Description

This PR adds a new section in the docs describing how to leverage a solution like TGI or vLLM to serve an LLM that can be reused across several tasks in the same pipeline using an `AsyncLLM` client.