### PR TITLE
Fix docs for distiset.save_to_disk kwargs

### DIFF
--- a/src/distilabel/distiset.py
+++ b/src/distilabel/distiset.py
@@ -270,7 +270,7 @@ class Distiset(dict):
         Examples:
             ```python
             # Save your distiset in a local folder:
-            >>> distiset.save_to_disk(dataset_path="my-distiset")
+            >>> distiset.save_to_disk(distiset_path="my-distiset")
             # Save your distiset in a remote storage:
             >>> storage_options = {
             ...     "key": os.environ["S3_ACCESS_KEY"],
@@ -280,7 +280,7 @@ class Distiset(dict):
             ...         "region_name": os.environ["S3_REGION"],
             ...     },
             ... }
-            >>> distiset.save_to_disk(dataset_path="my-distiset", storage_options=storage_options)
+            >>> distiset.save_to_disk(distiset_path="my-distiset", storage_options=storage_options)
             ```
         """
         distiset_path = str(distiset_path)


### PR DESCRIPTION
The keyword argument for the path in Distiset.save_to_disk should be documented as `distiset_path` instead of `dataset_path`.