### PR TITLE
Add new step `CombineKeys`

### DIFF
--- a/src/distilabel/pipeline/utils.py
+++ b/src/distilabel/pipeline/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from distilabel.steps.base import StepInput
 
@@ -58,4 +58,26 @@ def combine_dicts(
                 else:
                     combined_dict[key] = value
         result.append(combined_dict)
+    return result
+
+
+def combine_keys(row: Dict[str, Any], keys: List[str], new_key: str = "combined_key"):
+    """Combines keys in a dictionary into a single key on the specified `new_key`.
+
+    Args:
+        row: Dictionary corresponding to a row in a dataset.
+        keys: List of keys to combine.
+        new_key: Name of the new key created.
+
+    Returns:
+        Dictionary with the new combined key.
+    """
+    result = row.copy()  # preserve the original dictionary
+    combined = []
+    for key in keys:
+        to_combine = result.pop(key)
+        if not isinstance(to_combine, list):
+            to_combine = [to_combine]
+        combined += to_combine
+    result[new_key] = combined
     return result

--- a/src/distilabel/steps/__init__.py
+++ b/src/distilabel/steps/__init__.py
@@ -15,7 +15,7 @@
 from distilabel.steps.argilla.preference import PreferenceToArgilla
 from distilabel.steps.argilla.text_generation import TextGenerationToArgilla
 from distilabel.steps.base import GeneratorStep, GlobalStep, Step, StepInput
-from distilabel.steps.combine import CombineColumns
+from distilabel.steps.combine import CombineColumns, CombineKeys
 from distilabel.steps.decorator import step
 from distilabel.steps.deita import DeitaFiltering
 from distilabel.steps.expand import ExpandColumns
@@ -43,6 +43,7 @@ __all__ = [
     "PreferenceToArgilla",
     "TextGenerationToArgilla",
     "CombineColumns",
+    "CombineKeys",
     "ConversationTemplate",
     "DeitaFiltering",
     "ExpandColumns",

--- a/src/distilabel/steps/combine.py
+++ b/src/distilabel/steps/combine.py
@@ -124,7 +124,7 @@ class CombineColumns(Step):
 
 
 class CombineKeys(Step):
-    """Combines keys from a `StepInput`.
+    """Combines keys from a row.
 
     `CombineKeys` is a `Step` that implements the `process` method that calls the `combine_keys`
     function to handle and combine keys in a `StepInput`. `CombineKeys` provides two attributes

--- a/src/distilabel/steps/combine.py
+++ b/src/distilabel/steps/combine.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from typing_extensions import override
 
-from distilabel.pipeline.utils import combine_dicts
+from distilabel.pipeline.utils import combine_dicts, combine_keys
 from distilabel.steps.base import Step, StepInput
 
 if TYPE_CHECKING:
@@ -121,3 +121,80 @@ class CombineColumns(Step):
             merge_keys=self.inputs,
             output_merge_keys=self.outputs,
         )
+
+
+class CombineKeys(Step):
+    """Combines keys from a `StepInput`.
+
+    `CombineKeys` is a `Step` that implements the `process` method that calls the `combine_keys`
+    function to handle and combine keys in a `StepInput`. `CombineKeys` provides two attributes
+    `keys` and `output_keys` to specify the keys to merge and the resulting output key.
+
+    This step can be useful if you have a `Task` that generates instructions for example, and you
+    want to have more examples of those. In such a case, you could for example use another `Task`
+    to multiply your instructions synthetically, what would yield two different keys splitted.
+    Using `CombineKeys` you can merge them and use them as a single column in your dataset for
+    further processing.
+
+    Attributes:
+        columns: List of strings with the names of the columns to merge.
+        output_columns: Optional list of strings with the names of the output columns.
+
+    Input columns:
+        - dynamic (determined by `keys` attribute): The keys to merge.
+
+    Output columns:
+        - dynamic (determined by `keys` and `output_key` attributes): The columns
+            that were merged.
+
+    Examples:
+
+        Combine keys in rows of a dataset:
+
+        ```python
+        from distilabel.steps import CombineKeys
+
+        combiner = CombineKeys(
+            keys=["queries", "multiple_queries"],
+            output_key="queries",
+        )
+        combiner.load()
+
+        result = next(
+            combiner.process(
+                [
+                    {
+                        "queries": "How are you?",
+                        "multiple_queries": ["What's up?", "Everything ok?"]
+                    }
+                ],
+            )
+        )
+        # >>> result
+        # [{'queries': ['How are you?', "What's up?", 'Everything ok?']}]
+        ```
+    """
+
+    keys: List[str]
+    output_key: Optional[str] = None
+
+    @property
+    def inputs(self) -> List[str]:
+        return self.keys
+
+    @property
+    def outputs(self) -> List[str]:
+        return [self.output_key] if self.output_key else ["combined_key"]
+
+    @override
+    def process(self, inputs: StepInput) -> "StepOutput":
+        combined = []
+        for input in inputs:
+            combined.append(
+                combine_keys(
+                    input,
+                    keys=self.keys,
+                    new_key=self.outputs[0],
+                )
+            )
+        yield combined

--- a/tests/unit/steps/test_combine.py
+++ b/tests/unit/steps/test_combine.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Dict, List, Optional
+
+import pytest
 from distilabel.pipeline.local import Pipeline
-from distilabel.steps.combine import CombineColumns
+from distilabel.steps.combine import CombineColumns, CombineKeys
 
 
 class TestCombineColumns:
@@ -43,3 +46,33 @@ class TestCombineColumns:
         )
         output = next(combine.process([{"a": 1, "b": 2}], [{"a": 3, "b": 4}]))
         assert output == [{"merged_a": [1, 3], "merged_b": [2, 4]}]
+
+
+class TestCombineKeys:
+    @pytest.mark.parametrize(
+        "output_key, expected",
+        [
+            (None, "combined_key"),
+            ("queries", "queries"),
+        ],
+    )
+    def test_init(self, output_key: Optional[str], expected: str) -> None:
+        task = CombineKeys(keys=["query", "queries"], output_key=output_key)
+
+        assert task.inputs == ["query", "queries"]
+        assert task.outputs == [expected]
+
+    @pytest.mark.parametrize(
+        "keys",
+        [
+            [{"query": 1, "queries": 2}],
+            [{"query": 1, "queries": [2]}],
+            [{"query": [1], "queries": [2]}],
+        ],
+    )
+    def test_process(self, keys: List[Dict[str, Any]]) -> None:
+        combiner = CombineKeys(
+            keys=["query", "queries"],
+        )
+        output = next(combiner.process(keys))
+        assert output == [{"combined_key": [1, 2]}]

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -39,6 +39,7 @@ def test_imports() -> None:
 
     from distilabel.steps import (
         CombineColumns,
+        CombineKeys,
         ConversationTemplate,
         DeitaFiltering,
         ExpandColumns,


### PR DESCRIPTION
## Description

This PR adds a new step to combine keys in a dict. The main use case I found was the following:

In a `Pipeline` I have a `Task` that generates instructions (say `GenerateSentencePair`), and I want more examples of the `positives` generated for diversity. With a new task, I generate more of those, so afterwards I want to combine the `positive` keys with the new extra instructions (say a list of instructions called `positives` or whatever). With this `CombineKeys` we can combine those keys:

```python
from distilabel.steps import CombineKeys

combiner = CombineKeys(
    keys=["queries", "multiple_queries"],
    output_key="queries",
)
combiner.load()

result = next(
    combiner.process(
        [
            {
                "queries": "How are you?",
                "multiple_queries": ["What's up?", "Everything ok?"]
            }
        ],
    )
)
# >>> result
# [{'queries': ['How are you?', "What's up?", 'Everything ok?']}]
```