### PR TITLE
Fix `response_format` for `TogetherLLM` and `AnyScaleLLM`

### DIFF
--- a/src/distilabel/llms/openai.py
+++ b/src/distilabel/llms/openai.py
@@ -194,7 +194,7 @@ class OpenAILLM(AsyncLLM):
         temperature: float = 1.0,
         top_p: float = 1.0,
         stop: Optional[Union[str, List[str]]] = None,
-        response_format: str = "text",
+        response_format: Optional[str] = None,
     ) -> GenerateOutput:
         """Generates `num_generations` responses for the given input using the OpenAI async
         client.
@@ -223,12 +223,6 @@ class OpenAILLM(AsyncLLM):
         Returns:
             A list of lists of strings containing the generated responses for each input.
         """
-        if response_format == "json":
-            response_format = "json_object"
-        elif response_format != "text":
-            raise ValueError(
-                f"Invalid response format '{response_format}'. Must be either 'text' or 'json'."
-            )
 
         structured_output = None
         if isinstance(input, tuple):
@@ -254,8 +248,20 @@ class OpenAILLM(AsyncLLM):
             "top_p": top_p,
             "stop": stop,
             "timeout": 50,
-            "response_format": {"type": response_format},
         }
+
+        if response_format is not None:
+            if response_format not in ["text", "json", "json_object"]:
+                raise ValueError(
+                    f"Invalid response format '{response_format}'. Must be either 'text'"
+                    " or 'json'."
+                )
+
+            if response_format == "json":
+                response_format = "json_object"
+
+            kwargs["response_format"] = response_format
+
         if structured_output:
             kwargs = self._prepare_kwargs(kwargs, structured_output)
 


### PR DESCRIPTION
## Description

`Together` and `AnyScale` APIs only accepts `response_format == "json_object"`. This PR makes the `response_format` argument `Optional`, and removes the logic that set `"text"` as default for the `response_format` as this is not supported by the aforementioned APIs.