### PR TITLE
Add `end_with_user` and `include_system_prompt` flags to `Magpie` tasks and handle `None`s.

### DIFF
--- a/src/distilabel/steps/tasks/magpie/base.py
+++ b/src/distilabel/steps/tasks/magpie/base.py
@@ -50,6 +50,10 @@ class MagpieBase(RuntimeParametersMixin):
         default=1,
         description="The number of turns to generate for the conversation.",
     )
+    end_with_user: RuntimeParameter[bool] = Field(
+        default=False,
+        description="Whether the conversation should end with a user message.",
+    )
     only_instruction: RuntimeParameter[bool] = Field(
         default=False,
         description="Whether to generate only the instruction. If this argument"
@@ -125,7 +129,7 @@ class MagpieBase(RuntimeParametersMixin):
     ) -> List[Dict[str, Any]]:
         conversations = self._prepare_inputs_for_instruction_generation(inputs)
 
-        for _ in range(self.n_turns):  # type: ignore
+        for i in range(self.n_turns):  # type: ignore
             # Generate instruction or user message
             outputs = self.llm.generate(
                 inputs=conversations,
@@ -138,6 +142,9 @@ class MagpieBase(RuntimeParametersMixin):
                 messages=[output[0] for output in outputs],
                 conversations=conversations,  # type: ignore
             )
+
+            if i == self.n_turns - 1 and self.end_with_user:  # type: ignore
+                break
 
             # TODO: handle potential previous `None`s
 

--- a/src/distilabel/steps/tasks/magpie/base.py
+++ b/src/distilabel/steps/tasks/magpie/base.py
@@ -227,6 +227,11 @@ class Magpie(Task, MagpieBase):
 
     Attributes:
         n_turns: the number of turns that the generated conversation will have.
+            Defaults to `1`.
+        end_with_user: whether the conversation should end with a user message.
+            Defaults to `False`.
+        include_system_prompt: whether to include the system prompt used in the generated
+            conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
         system_prompt: an optional system prompt that can be used to steer the LLM to generate
@@ -235,7 +240,12 @@ class Magpie(Task, MagpieBase):
             one from the column will be used. Defaults to `None`.
 
     Runtime parameters:
-        - `n_turns`: the number of turns that the generated conversation will have.
+        - `n_turns`: the number of turns that the generated conversation will have. Defaults
+            to `1`.
+        - `end_with_user`: whether the conversation should end with a user message.
+            Defaults to `False`.
+        - `include_system_prompt`: whether to include the system prompt used in the generated
+            conversation. Defaults to `False`.
         - `only_instruction`: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
         - `system_prompt`: an optional system prompt that can be used to steer the LLM to

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -42,6 +42,11 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
 
     Attributes:
         n_turns: the number of turns that the generated conversation will have.
+            Defaults to `1`.
+        end_with_user: whether the conversation should end with a user message.
+            Defaults to `False`.
+        include_system_prompt: whether to include the system prompt used in the generated
+            conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
         system_prompt: an optional system prompt that can be used to steer the LLM to generate
@@ -51,11 +56,18 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
         num_rows: the number of rows to be generated.
 
     Runtime parameters:
-        - `n_turns`: the number of turns that the generated conversation will have.
-        - `only_instruction`: whether to generate only the instruction. If this argument
-            is `True`, then `n_turns` will be ignored. Defaults to `False`.
+        - `n_turns`: the number of turns that the generated conversation will have. Defaults
+            to `1`.
+        - `end_with_user`: whether the conversation should end with a user message.
+            Defaults to `False`.
+        - `include_system_prompt`: whether to include the system prompt used in the generated
+            conversation. Defaults to `False`.
+        - `only_instruction`: whether to generate only the instruction. If this argument is
+            `True`, then `n_turns` will be ignored. Defaults to `False`.
         - `system_prompt`: an optional system prompt that can be used to steer the LLM to
-            generate content of certain topic, guide the style, etc. Defaults to `None`.
+            generate content of certain topic, guide the style, etc. If the provided inputs
+            contains a `system_prompt` column, then this runtime parameter will be ignored
+            and the one from the column will be used. Defaults to `None`.
         - `num_rows`: the number of rows to be generated.
 
     Output columns:

--- a/tests/unit/llms/huggingface/test_inference_endpoints.py
+++ b/tests/unit/llms/huggingface/test_inference_endpoints.py
@@ -171,7 +171,6 @@ class TestInferenceEndpointsLLM:
                 created=1721045246,
                 id="",
                 model="meta-llama/Meta-Llama-3-70B-Instruct",
-                object="chat.completion",
                 system_fingerprint="2.1.1-dev0-sha-4327210",
                 usage=ChatCompletionOutputUsage(
                     completion_tokens=66, prompt_tokens=18, total_tokens=84
@@ -212,7 +211,6 @@ class TestInferenceEndpointsLLM:
                 created=1721045246,
                 id="",
                 model="meta-llama/Meta-Llama-3-70B-Instruct",
-                object="chat.completion",
                 system_fingerprint="2.1.1-dev0-sha-4327210",
                 usage=ChatCompletionOutputUsage(
                     completion_tokens=66, prompt_tokens=18, total_tokens=84

--- a/tests/unit/steps/tasks/magpie/test_base.py
+++ b/tests/unit/steps/tasks/magpie/test_base.py
@@ -106,6 +106,45 @@ class TestMagpie:
             },
         ]
 
+    def test_process_with_end_with_user(self) -> None:
+        task = Magpie(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
+            n_turns=2,
+            end_with_user=True,
+        )
+
+        task.load()
+
+        assert next(task.process(inputs=[{}, {}, {}])) == [
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+        ]
+
     def test_process_with_system_prompt_per_row(self) -> None:
         task = Magpie(llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=2)
 
@@ -195,6 +234,7 @@ class TestMagpie:
                 },
             },
             "n_turns": 1,
+            "end_with_user": False,
             "only_instruction": True,
             "system_prompt": None,
             "name": "magpie_0",
@@ -226,6 +266,11 @@ class TestMagpie:
                     "name": "n_turns",
                     "optional": True,
                     "description": "The number of turns to generate for the conversation.",
+                },
+                {
+                    "name": "end_with_user",
+                    "optional": True,
+                    "description": "Whether the conversation should end with a user message.",
                 },
                 {
                     "name": "only_instruction",

--- a/tests/unit/steps/tasks/magpie/test_base.py
+++ b/tests/unit/steps/tasks/magpie/test_base.py
@@ -76,7 +76,6 @@ class TestMagpie:
         assert next(task.process(inputs=[{}, {}, {}])) == [
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -86,7 +85,6 @@ class TestMagpie:
             },
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -96,7 +94,6 @@ class TestMagpie:
             },
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -118,7 +115,6 @@ class TestMagpie:
         assert next(task.process(inputs=[{}, {}, {}])) == [
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -127,7 +123,6 @@ class TestMagpie:
             },
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -136,7 +131,6 @@ class TestMagpie:
             },
             {
                 "conversation": [
-                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
                     {"role": "user", "content": "Hello Magpie"},
                     {"role": "assistant", "content": "Hello Magpie"},
                     {"role": "user", "content": "Hello Magpie"},
@@ -145,8 +139,54 @@ class TestMagpie:
             },
         ]
 
+    def test_process_with_include_system_prompt(self) -> None:
+        task = Magpie(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
+            n_turns=2,
+            include_system_prompt=True,
+        )
+
+        task.load()
+
+        assert next(task.process(inputs=[{}, {}, {}])) == [
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+            {
+                "conversation": [
+                    {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                    {"role": "user", "content": "Hello Magpie"},
+                    {"role": "assistant", "content": "Hello Magpie"},
+                ],
+                "model_name": "test",
+            },
+        ]
+
     def test_process_with_system_prompt_per_row(self) -> None:
-        task = Magpie(llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=2)
+        task = Magpie(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
+            n_turns=2,
+            include_system_prompt=True,
+        )
 
         task.load()
 
@@ -235,6 +275,7 @@ class TestMagpie:
             },
             "n_turns": 1,
             "end_with_user": False,
+            "include_system_prompt": False,
             "only_instruction": True,
             "system_prompt": None,
             "name": "magpie_0",
@@ -271,6 +312,11 @@ class TestMagpie:
                     "name": "end_with_user",
                     "optional": True,
                     "description": "Whether the conversation should end with a user message.",
+                },
+                {
+                    "name": "include_system_prompt",
+                    "optional": True,
+                    "description": "Whether to include the system prompt used in the generated conversation.",
                 },
                 {
                     "name": "only_instruction",

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -54,6 +54,7 @@ class TestMagpieGenerator:
             },
             "n_turns": 1,
             "end_with_user": False,
+            "include_system_prompt": False,
             "only_instruction": False,
             "system_prompt": None,
             "name": "magpie_generator_0",
@@ -91,6 +92,11 @@ class TestMagpieGenerator:
                     "name": "end_with_user",
                     "optional": True,
                     "description": "Whether the conversation should end with a user message.",
+                },
+                {
+                    "name": "include_system_prompt",
+                    "optional": True,
+                    "description": "Whether to include the system prompt used in the generated conversation.",
                 },
                 {
                     "name": "only_instruction",

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -53,6 +53,7 @@ class TestMagpieGenerator:
                 },
             },
             "n_turns": 1,
+            "end_with_user": False,
             "only_instruction": False,
             "system_prompt": None,
             "name": "magpie_generator_0",
@@ -85,6 +86,11 @@ class TestMagpieGenerator:
                     "name": "n_turns",
                     "optional": True,
                     "description": "The number of turns to generate for the conversation.",
+                },
+                {
+                    "name": "end_with_user",
+                    "optional": True,
+                    "description": "Whether the conversation should end with a user message.",
                 },
                 {
                     "name": "only_instruction",


### PR DESCRIPTION
## Description

This PR updates `MagpieBase` class to:
 - add a new attribute `end_with_user` that allows ending the conversation generated by `Magpie` tasks with a user message.
 - add a new attribute `include_system_prompt` which can be used to include or not the used system prompt in the generated conversation
 - updates the code to handle `None` from the `LLM.generate` method when generating a multi-turn conversation