### PR TITLE
Fix Import Error for KeepColumns in instruction_backtranslation.md (Issue #785)

### DIFF
--- a/docs/sections/pipeline_samples/papers/instruction_backtranslation.md
+++ b/docs/sections/pipeline_samples/papers/instruction_backtranslation.md
@@ -43,7 +43,7 @@ As mentioned before, we will put the previously mentioned building blocks togeth
 ```python
 from distilabel.llms import InferenceEndpointsLLM, OpenAILLM
 from distilabel.pipeline import Pipeline
-from distilabel.steps import LoadDataFromHub
+from distilabel.steps import LoadDataFromHub, KeepColumns
 from distilabel.steps.tasks import InstructionBacktranslation, TextGeneration
 
 


### PR DESCRIPTION
This PR addresses issue #785, which involved a missing import (KeepColumns) in the pipeline definition. The KeepColumns class was referenced but not imported, causing a NameError during execution.

