### PR TITLE
Correct variable name in dataset push example (in ultrafeedback.md file) (Issue #787)

### DIFF
--- a/docs/sections/pipeline_samples/papers/ultrafeedback.md
+++ b/docs/sections/pipeline_samples/papers/ultrafeedback.md
@@ -225,7 +225,7 @@ distiset = pipeline.run(
 Finally, we can optionally push the generated dataset, named [`Distiset`][distilabel.distiset.Distiset], to the Hugging Face Hub via the `push_to_hub` method, so that each subset generated in the leaf steps is pushed to the Hub.
 
 ```python
-dataset.push_to_hub(
+distiset.push_to_hub(
     "ultrafeedback-instruction-dataset",
     private=True,
 )


### PR DESCRIPTION
This PR addresses issue #787,
This pull request fixes the incorrect variable name used in the example for pushing the dataset to the hub in the Ultrafeedback documentation.
In the current documentation, the variable distiset is defined when running the pipeline, but dataset is used when pushing to the hub. This inconsistency can lead to confusion and errors for users following the documentation.
Replaced the incorrect dataset variable with distiset in the example code for pushing the dataset to the hub.