### PR TITLE
Add `_desired_num_gpus` attribute to `CudaDevicePlacementMixin`

### DIFF
--- a/src/distilabel/pipeline/step_wrapper.py
+++ b/src/distilabel/pipeline/step_wrapper.py
@@ -68,6 +68,7 @@ class _StepWrapper:
             and isinstance(self.step.llm, CudaDevicePlacementMixin)
         ):
             self.step.llm._llm_identifier = self.step.name
+            self.step.llm._desired_num_gpus = self.step.resources.gpus
 
     def run(self) -> str:
         """The target function executed by the process. This function will also handle

--- a/tests/unit/llms/mixins/test_cuda_device_placement.py
+++ b/tests/unit/llms/mixins/test_cuda_device_placement.py
@@ -95,6 +95,28 @@ class TestCudaDevicePlacementMixin:
         llm1.unload()
         llm2.unload()
 
+    def test_set_cuda_visible_devices_auto_with_desired_num_gpus(self, caplog) -> None:
+        llm1 = DummyCudaLLM()
+        llm1._llm_identifier = "unit-test-1"
+        llm1._desired_num_gpus = 3
+        llm1.load()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0,1,2"
+
+        llm2 = DummyCudaLLM()
+        llm2._llm_identifier = "unit-test-2"
+        llm2._desired_num_gpus = 2
+        llm2.load()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "3"
+        assert (
+            "Could not assign the desired number of GPUs 2 for LLM with identifier 'unit-test-2'"
+            in caplog.text
+        )
+
+        llm1.unload()
+        llm2.unload()
+
     def test_set_cuda_visible_devices_auto_not_enough_devices(self) -> None:
         llms = []
         for i in range(5):
@@ -102,12 +124,13 @@ class TestCudaDevicePlacementMixin:
             llm._llm_identifier = f"unit-test-{i}"
             llms.append(llm)
 
-        with pytest.raises(
-            RuntimeError, match="Couldn't find an available CUDA device"
-        ):
-            # 4 devices are available, but 5 LLMs are going to be loaded
-            for llm in llms:
-                llm.load()
+        # 4 devices are available, but 5 LLMs are going to be loaded
+        for i, llm in enumerate(llms):
+            llm.load()
+            if i == len(llms) - 1:
+                assert llm.cuda_devices == []
+            else:
+                assert llm.cuda_devices == [i]
 
         for llm in llms:
             llm.unload()


### PR DESCRIPTION
## Description

This PR adds a new attribute `_desired_num_gpus` to the `CudaDevicePlacementMixin` that will be set as value the `Step.resources.gpus`. This attribute will be used by the mixin when `cuda_devices == "auto"` to assign the desired num of GPUs to the LLM if available.