### PR TITLE
Add workflow concurrency group for publishing docs

### DIFF
--- a/.github/workflows/docs-pr-close.yml
+++ b/.github/workflows/docs-pr-close.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
 
+concurrency: distilabel-docs
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - synchronize
 
+concurrency: distilabel-docs
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - "**"
 
+concurrency: distilabel-docs
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds a concurrency group to the workflows that publish docs, as there can be a race condition between them.