### PR TITLE
Fix 404 model not found for private Serverless IE

### DIFF
--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -212,8 +212,7 @@ class InferenceEndpointsLLM(AsyncLLM):
 
         if self.model_id is not None:
             client = InferenceClient(
-                model=self.model_id,
-                token=self.api_key.get_secret_value()
+                model=self.model_id, token=self.api_key.get_secret_value()
             )
             status = client.get_model_status()
 

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -212,7 +212,7 @@ class InferenceEndpointsLLM(AsyncLLM):
 
         if self.model_id is not None:
             client = InferenceClient(
-                model=self.model_id, 
+                model=self.model_id,
                 token=self.api_key.get_secret_value()
             )
             status = client.get_model_status()

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -211,7 +211,10 @@ class InferenceEndpointsLLM(AsyncLLM):
             self.api_key = SecretStr(get_hf_token(self.__class__.__name__, "api_key"))
 
         if self.model_id is not None:
-            client = InferenceClient(model=self.model_id, token=self.api_key.get_secret_value())
+            client = InferenceClient(
+                model=self.model_id, 
+                token=self.api_key.get_secret_value()
+            )
             status = client.get_model_status()
 
             if (

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -211,8 +211,8 @@ class InferenceEndpointsLLM(AsyncLLM):
             self.api_key = SecretStr(get_hf_token(self.__class__.__name__, "api_key"))
 
         if self.model_id is not None:
-            client = InferenceClient()
-            status = client.get_model_status(self.model_id)
+            client = InferenceClient(model=self.model_id, token=self.api_key.get_secret_value())
+            status = client.get_model_status()
 
             if (
                 status.state not in {"Loadable", "Loaded"}


### PR DESCRIPTION
Get models status without token fails for serverless endpoints with `"private":true`.