### PR TITLE
Update default names in `GroupColumns`

### DIFF
--- a/src/distilabel/steps/columns/group.py
+++ b/src/distilabel/steps/columns/group.py
@@ -50,14 +50,14 @@ class GroupColumns(Step):
         ```python
         from distilabel.steps import GroupColumns
 
-        combine_columns = GroupColumns(
-            name="combine_columns",
+        group_columns = GroupColumns(
+            name="group_columns",
             columns=["generation", "model_name"],
         )
-        combine_columns.load()
+        group_columns.load()
 
         result = next(
-            combine_columns.process(
+            group_columns.process(
                 [{"generation": "AI generated text"}, {"model_name": "my_model"}],
                 [{"generation": "Other generated text", "model_name": "my_model"}]
             )
@@ -71,15 +71,15 @@ class GroupColumns(Step):
         ```python
         from distilabel.steps import GroupColumns
 
-        combine_columns = GroupColumns(
-            name="combine_columns",
+        group_columns = GroupColumns(
+            name="group_columns",
             columns=["generation", "model_name"],
             output_columns=["generations", "generation_models"]
         )
-        combine_columns.load()
+        group_columns.load()
 
         result = next(
-            combine_columns.process(
+            group_columns.process(
                 [{"generation": "AI generated text"}, {"model_name": "my_model"}],
                 [{"generation": "Other generated text", "model_name": "my_model"}]
             )
@@ -100,11 +100,11 @@ class GroupColumns(Step):
     @property
     def outputs(self) -> List[str]:
         """The outputs for the task are the column names in `output_columns` or
-        `merged_{column}` for each column in `columns`."""
+        `grouped_{column}` for each column in `columns`."""
         return (
             self.output_columns
             if self.output_columns is not None
-            else [f"merged_{column}" for column in self.columns]
+            else [f"grouped_{column}" for column in self.columns]
         )
 
     @override

--- a/tests/integration/test_branching_missaligmnent.py
+++ b/tests/integration/test_branching_missaligmnent.py
@@ -46,6 +46,6 @@ def test_branching_missalignment_because_step_fails_processing_batch() -> None:
     distiset = pipeline.run(use_cache=False)
 
     assert (
-        distiset["default"]["train"]["merged_response"]
+        distiset["default"]["train"]["grouped_response"]
         == [[None, "This step always succeeds"]] * 20
     )

--- a/tests/unit/steps/columns/test_group.py
+++ b/tests/unit/steps/columns/test_group.py
@@ -21,15 +21,15 @@ from distilabel.steps.columns.group import CombineColumns, GroupColumns
 class TestGroupColumns:
     def test_init(self) -> None:
         task = GroupColumns(
-            name="combine-columns",
+            name="group-columns",
             columns=["a", "b"],
             pipeline=Pipeline(name="unit-test-pipeline"),
         )
         assert task.inputs == ["a", "b"]
-        assert task.outputs == ["merged_a", "merged_b"]
+        assert task.outputs == ["grouped_a", "grouped_b"]
 
         task = GroupColumns(
-            name="combine-columns",
+            name="group-columns",
             columns=["a", "b"],
             output_columns=["c", "d"],
             pipeline=Pipeline(name="unit-test-pipeline"),
@@ -38,13 +38,13 @@ class TestGroupColumns:
         assert task.outputs == ["c", "d"]
 
     def test_process(self) -> None:
-        combine = GroupColumns(
-            name="combine-columns",
+        group = GroupColumns(
+            name="group-columns",
             columns=["a", "b"],
             pipeline=Pipeline(name="unit-test-pipeline"),
         )
-        output = next(combine.process([{"a": 1, "b": 2}], [{"a": 3, "b": 4}]))
-        assert output == [{"merged_a": [1, 3], "merged_b": [2, 4]}]
+        output = next(group.process([{"a": 1, "b": 2}], [{"a": 3, "b": 4}]))
+        assert output == [{"grouped_a": [1, 3], "grouped_b": [2, 4]}]
 
 
 def test_CombineColumns_deprecation_warning():


### PR DESCRIPTION
## Description

This PR updates the default name of the columns for `GroupColumns`.

As part of https://github.com/argilla-io/distilabel/pull/758 we renamed some steps, but the default names were not updated. The `GroupColumns` will generate default column names as `group_...`. The old `CombineColumns` (deprecated, to be removed in 1.5.0), as for the moment we just keep it as a copy of `GroupColumns` won't see any update, it should throw a warning like the following:

```python
>>> combine = CombineColumns(columns=["test_column"])
<stdin>:1: DeprecationWarning: `CombineColumns` is deprecated and will be removed in version 1.5.0, use `GroupColumns` instead.
```

Closes #800 