### PR TITLE
Create file per hostname in `CudaDevicePlacementMixin`

### DIFF
--- a/src/distilabel/llms/mixins/cuda_device_placement.py
+++ b/src/distilabel/llms/mixins/cuda_device_placement.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import socket
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -26,7 +27,11 @@ from pydantic import BaseModel, Field, PositiveInt, PrivateAttr
 from distilabel.mixins.runtime_parameters import RuntimeParameter
 
 _CUDA_DEVICE_PLACEMENT_MIXIN_FILE = (
-    Path(tempfile.gettempdir()) / "distilabel_cuda_device_placement_mixin.json"
+    Path(tempfile.gettempdir())
+    / "distilabel"
+    / "cuda_device_placement"
+    / socket.gethostname()
+    / "distilabel_cuda_device_placement_mixin.json"
 )
 
 
@@ -105,6 +110,7 @@ class CudaDevicePlacementMixin(BaseModel):
         Yields:
             The content of the device placement file.
         """
+        _CUDA_DEVICE_PLACEMENT_MIXIN_FILE.parent.mkdir(parents=True, exist_ok=True)
         _CUDA_DEVICE_PLACEMENT_MIXIN_FILE.touch()
         with portalocker.Lock(
             _CUDA_DEVICE_PLACEMENT_MIXIN_FILE,

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -233,6 +233,7 @@ class Pipeline(BasePipeline):
             output_queue=self._output_queue,
             load_queue=self._load_queue,
             dry_run=self._dry_run,
+            ray_pipeline=False,
         )
 
         self._pool.apply_async(step_wrapper.run, error_callback=self._error_callback)

--- a/src/distilabel/pipeline/ray.py
+++ b/src/distilabel/pipeline/ray.py
@@ -235,6 +235,7 @@ class RayPipeline(BasePipeline):
                 output_queue=self._output_queue,
                 load_queue=self._load_queue,
                 dry_run=self._dry_run,
+                ray_pipeline=True,
             ),
             log_queue=self._log_queue,
         )

--- a/src/distilabel/pipeline/step_wrapper.py
+++ b/src/distilabel/pipeline/step_wrapper.py
@@ -21,7 +21,7 @@ from distilabel.pipeline.batch import _Batch
 from distilabel.pipeline.constants import LAST_BATCH_SENT_FLAG
 from distilabel.pipeline.typing import StepLoadStatus
 from distilabel.steps.base import GeneratorStep, Step, _Step
-from distilabel.steps.tasks.base import Task
+from distilabel.steps.tasks.base import _Task
 
 
 class _StepWrapper:
@@ -63,7 +63,7 @@ class _StepWrapper:
         self._dry_run = dry_run
 
         if (
-            isinstance(self.step, Task)
+            isinstance(self.step, _Task)
             and hasattr(self.step, "llm")
             and isinstance(self.step.llm, CudaDevicePlacementMixin)
         ):

--- a/src/distilabel/pipeline/step_wrapper.py
+++ b/src/distilabel/pipeline/step_wrapper.py
@@ -68,7 +68,7 @@ class _StepWrapper:
             and isinstance(self.step.llm, CudaDevicePlacementMixin)
         ):
             self.step.llm._llm_identifier = self.step.name
-            self.step.llm._desired_num_gpus = self.step.resources.gpus
+            self.step.llm._desired_num_gpus = self.step.resources.gpus or 1
 
     def run(self) -> str:
         """The target function executed by the process. This function will also handle

--- a/src/distilabel/pipeline/step_wrapper.py
+++ b/src/distilabel/pipeline/step_wrapper.py
@@ -73,11 +73,6 @@ class _StepWrapper:
             and isinstance(self.step.llm, CudaDevicePlacementMixin)
         ):
             desired_num_gpus = self.step.resources.gpus or 1
-            self.step._logger.info(
-                f"Step '{self.step.name}' is a `Task` using an `LLM` with CUDA capabilities."
-                f" Setting identifier to '{self.step.name}' and number of desired GPUs to"
-                f" {desired_num_gpus}."
-            )
             self.step.llm._llm_identifier = self.step.name
             self.step.llm._desired_num_gpus = desired_num_gpus
 

--- a/tests/unit/pipeline/test_local.py
+++ b/tests/unit/pipeline/test_local.py
@@ -55,6 +55,7 @@ class TestPipeline:
                     output_queue=pipeline._output_queue,
                     load_queue=pipeline._load_queue,
                     dry_run=False,
+                    ray_pipeline=False,
                 ),
                 mock.call(
                     step=dummy_step_1,
@@ -63,6 +64,7 @@ class TestPipeline:
                     output_queue=pipeline._output_queue,
                     load_queue=pipeline._load_queue,
                     dry_run=False,
+                    ray_pipeline=False,
                 ),
                 mock.call(
                     step=dummy_step_1,
@@ -71,6 +73,7 @@ class TestPipeline:
                     output_queue=pipeline._output_queue,
                     load_queue=pipeline._load_queue,
                     dry_run=False,
+                    ray_pipeline=False,
                 ),
                 mock.call(
                     step=dummy_step_2,
@@ -79,6 +82,7 @@ class TestPipeline:
                     output_queue=pipeline._output_queue,
                     load_queue=pipeline._load_queue,
                     dry_run=False,
+                    ray_pipeline=False,
                 ),
             ],
         )

--- a/tests/unit/steps/tasks/structured_outputs/test_outlines.py
+++ b/tests/unit/steps/tasks/structured_outputs/test_outlines.py
@@ -59,6 +59,7 @@ DUMP_JSON = {
     "device_map": None,
     "token": None,
     "use_magpie_template": False,
+    "disable_cuda_device_placement": False,
     "type_info": {
         "module": "distilabel.llms.huggingface.transformers",
         "name": "TransformersLLM",
@@ -85,6 +86,7 @@ DUMP_REGEX = {
     "device_map": None,
     "token": None,
     "use_magpie_template": False,
+    "disable_cuda_device_placement": False,
     "type_info": {
         "module": "distilabel.llms.huggingface.transformers",
         "name": "TransformersLLM",


### PR DESCRIPTION
## Description

In some environments, all the nodes of the cluster shares the same file system, so they were using the same file to check which GPUs were being used. This is incorrect, as the GPUs IDs has to be checked per node, so now a new file is created per hostname.