### PR TITLE
Some more `Magpie` improvements

### DIFF
--- a/src/distilabel/steps/tasks/magpie/base.py
+++ b/src/distilabel/steps/tasks/magpie/base.py
@@ -301,7 +301,8 @@ class Magpie(Task, MagpieBase):
     Output columns:
         - conversation (`ChatType`): the generated conversation which is a list of chat
             items with a role and a message. Only if `only_instruction=False`.
-        - instruction (`str`): the generated instructions if `only_instruction=True`.
+        - instruction (`str`): the generated instructions if `only_instruction=True` or `n_turns==1`.
+        - response (`str`): the generated response if `n_turns==1`.
         - model_name (`str`): The model name used to generate the `conversation` or `instruction`.
 
     Categories:

--- a/src/distilabel/steps/tasks/magpie/base.py
+++ b/src/distilabel/steps/tasks/magpie/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import Field, PositiveInt
@@ -63,10 +64,10 @@ class MagpieBase(RuntimeParametersMixin):
         description="Whether to generate only the instruction. If this argument"
         " is `True`, then `n_turns` will be ignored.",
     )
-    system_prompt: Optional[RuntimeParameter[str]] = Field(
+    system_prompt: Optional[RuntimeParameter[Union[List[str], str]]] = Field(
         default=None,
-        description="An optional system prompt that can be used to steer the LLM to generate"
-        " content of certain topic, guide the style, etc.",
+        description="An optional system prompt or list of system prompts that can be used"
+        " to steer the LLM to generate content of certain topic, guide the style, etc.",
     )
 
     def _prepare_inputs_for_instruction_generation(
@@ -90,7 +91,11 @@ class MagpieBase(RuntimeParametersMixin):
                     {"role": "system", "content": input["system_prompt"]}
                 )
             elif self.system_prompt is not None:
-                conversation.append({"role": "system", "content": self.system_prompt})
+                if isinstance(self.system_prompt, list):
+                    system_prompt = random.choice(self.system_prompt)
+                else:
+                    system_prompt = self.system_prompt
+                conversation.append({"role": "system", "content": system_prompt})
             elif self.n_turns > 1:  # type: ignore
                 conversation.append(
                     {"role": "system", "content": MAGPIE_MULTI_TURN_SYSTEM_PROMPT}
@@ -265,10 +270,12 @@ class Magpie(Task, MagpieBase):
             conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        system_prompt: an optional system prompt that can be used to steer the LLM to generate
-            content of certain topic, guide the style, etc. If the provided inputs contains
-            a `system_prompt` column, then this runtime parameter will be ignored and the
-            one from the column will be used. Defaults to `None`.
+        system_prompt: an optional system prompt or list of system prompts that can
+            be used to steer the LLM to generate content of certain topic, guide the style,
+            etc. If it's a list of system prompts, then a random system prompt will be chosen
+            per input/output batch. If the provided inputs contains a `system_prompt` column,
+            then this runtime parameter will be ignored and the one from the column will
+            be used. Defaults to `None`.
 
     Runtime parameters:
         - `n_turns`: the number of turns that the generated conversation will have. Defaults
@@ -279,10 +286,12 @@ class Magpie(Task, MagpieBase):
             conversation. Defaults to `False`.
         - `only_instruction`: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        - `system_prompt`: an optional system prompt that can be used to steer the LLM to
-            generate content of certain topic, guide the style, etc. If the provided inputs
-            contains a `system_prompt` column, then this runtime parameter will be ignored
-            and the one from the column will be used. Defaults to `None`.
+        - `system_prompt`: an optional system prompt or list of system prompts that can
+            be used to steer the LLM to generate content of certain topic, guide the style,
+            etc. If it's a list of system prompts, then a random system prompt will be chosen
+            per input/output batch. If the provided inputs contains a `system_prompt` column,
+            then this runtime parameter will be ignored and the one from the column will
+            be used. Defaults to `None`.
 
     Input columns:
         - system_prompt (`str`, optional): an optional system prompt that can be provided

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -49,10 +49,12 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        system_prompt: an optional system prompt that can be used to steer the LLM to generate
-            content of certain topic, guide the style, etc. If the provided inputs contains
-            a `system_prompt` column, then this runtime parameter will be ignored and the
-            one from the column will be used. Defaults to `None`.
+        system_prompt: an optional system prompt or list of system prompts that can
+            be used to steer the LLM to generate content of certain topic, guide the style,
+            etc. If it's a list of system prompts, then a random system prompt will be chosen
+            per input/output batch. If the provided inputs contains a `system_prompt` column,
+            then this runtime parameter will be ignored and the one from the column will
+            be used. Defaults to `None`.
         num_rows: the number of rows to be generated.
 
     Runtime parameters:
@@ -64,10 +66,12 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             conversation. Defaults to `False`.
         - `only_instruction`: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        - `system_prompt`: an optional system prompt that can be used to steer the LLM to
-            generate content of certain topic, guide the style, etc. If the provided inputs
-            contains a `system_prompt` column, then this runtime parameter will be ignored
-            and the one from the column will be used. Defaults to `None`.
+        - `system_prompt`: an optional system prompt or list of system prompts that can
+            be used to steer the LLM to generate content of certain topic, guide the style,
+            etc. If it's a list of system prompts, then a random system prompt will be chosen
+            per input/output batch. If the provided inputs contains a `system_prompt` column,
+            then this runtime parameter will be ignored and the one from the column will
+            be used. Defaults to `None`.
         - `num_rows`: the number of rows to be generated.
 
     Output columns:

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -229,6 +229,8 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
         """Either a multi-turn conversation or the instruction generated."""
         if self.only_instruction:
             return ["instruction", "model_name"]
+        if self.n_turns == 1:
+            return ["instruction", "response", "model_name"]
         return ["conversation", "model_name"]
 
     def process(self, offset: int = 0) -> "GeneratorStepOutput":

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -78,6 +78,7 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
         - conversation (`ChatType`): the generated conversation which is a list of chat
             items with a role and a message.
         - instruction (`str`): the generated instructions if `only_instruction=True`.
+        - response (`str`): the generated response if `n_turns==1`.
         - model_name (`str`): The model name used to generate the `conversation` or `instruction`.
 
     Categories:

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -28,7 +28,15 @@ class TestMagpieGenerator:
             MagpieGenerator(llm=OpenAILLM(model="gpt-4", api_key="fake"))  # type: ignore
 
     def test_outputs(self) -> None:
-        task = MagpieGenerator(llm=DummyMagpieLLM(magpie_pre_query_template="llama3"))
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=1
+        )
+
+        assert task.outputs == ["instruction", "response", "model_name"]
+
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=2
+        )
 
         assert task.outputs == ["conversation", "model_name"]
 
@@ -106,7 +114,7 @@ class TestMagpieGenerator:
                 {
                     "name": "system_prompt",
                     "optional": True,
-                    "description": "An optional system prompt that can be used to steer the LLM to generate content of certain topic, guide the style, etc.",
+                    "description": "An optional system prompt or list of system prompts that can be used to steer the LLM to generate content of certain topic, guide the style, etc.",
                 },
                 {
                     "name": "resources",


### PR DESCRIPTION
## Description

This PR adds some improvements to the `Magpie` tasks:

1. If `n_turns==1` then the tasks will output "instruction" and "response" columns instead of "conversation"
2. `system_prompt` attribute and runtime parameter has been updated so a list of system prompts can be passed. One of these system prompts will be chosen randomly per input/output batch. This is useful to steer the model to generate instructions of several topics.