### PR TITLE
Do not take into account `disable_cuda_device_placement` for pipeline signature

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -254,7 +254,11 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
                 if isinstance(value, dict):
                     # input_mappings/output_mappings
                     step_info += "-".join(
-                        [f"{str(k)}-{str(v)}" for k, v in value.items()]
+                        [
+                            f"{str(k)}={str(v)}"
+                            for k, v in value.items()
+                            if k not in ("disable_cuda_device_placement",)
+                        ]
                     )
                 elif isinstance(value, (list, tuple)):
                     # runtime_parameters_info

--- a/tests/unit/pipeline/test_base.py
+++ b/tests/unit/pipeline/test_base.py
@@ -1290,7 +1290,7 @@ class TestPipelineSerialization:
             )
 
         signature = pipeline._create_signature()
-        assert signature == "f291da215cd42085c538e4897e4355f614932547"
+        assert signature == "d3c7c572fe31233aa1198174c6c793b67ef3744b"
 
     def test_binary_rshift_operator(self) -> None:
         # Tests the steps can be connected using the >> operator.


### PR DESCRIPTION
## Description

In PR #814, a new attribute `disable_cuda_device_placement` was added to the `CudaDevicePlacementMixin`. This attribute is set to `False` after loading the `Step` in the `_StepWrapper` class if executed in a `RayPipeline`. It was being used to compute the pipeline signature, so when executing a `RayPipeline` with an `LLM` using the `CudaDevicePlacementMixin` the signature was different after loading the `Step`.