### PR TITLE
docs: 846 docs include google analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ extra:
       link: https://www.youtube.com/channel/UCAIz8TmvQQrLqbD7sd-5S2A
     - icon: fontawesome/brands/discord
       link: http://hf.co/join/discord
-  extra:
   analytics:
     provider: google
     property: G-PPKL7LMWCE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,24 @@ extra:
       link: https://www.youtube.com/channel/UCAIz8TmvQQrLqbD7sd-5S2A
     - icon: fontawesome/brands/discord
       link: http://hf.co/join/discord
+  extra:
+  analytics:
+    provider: google
+    property: G-PPKL7LMWCE
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/thumb-up-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/thumb-down-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve this page by
+            <a href="https://github.com/argilla-io/distilabel/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">opening a GitHub issue</a>.
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
Closes #846 

I added GA for MkDocs https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#configuration