### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/sections/pipeline_samples/papers/ultrafeedback.md
+++ b/docs/sections/pipeline_samples/papers/ultrafeedback.md
@@ -210,7 +210,7 @@ distiset = pipeline.run(
                 }
             },
         },
-        ultrafeedback_openai.name: {
+        ultrafeedback.name: {
             "llm": {
                 "generation_kwargs": {
                     "max_new_tokens": 2048,


### PR DESCRIPTION
## Description

Fix typo with variable name. Closes #798 