### PR TITLE
Add default structured output for `GenerateSentencePair` task

### DIFF
--- a/src/distilabel/steps/tasks/base.py
+++ b/src/distilabel/steps/tasks/base.py
@@ -155,14 +155,25 @@ class _Task(_Step, ABC):
         return output
 
     def _set_default_structured_output(self) -> None:
-        """Prepares the structured output to be set in the selected `LLM`."""
+        """Prepares the structured output to be set in the selected `LLM`.
+
+        If the method `get_structured_output` returns None (the default), there's no need
+        to set anything, as it doesn't apply.
+        If the `use_default_structured_output` and there's no previous structured output
+        set by hand, then decide the type of structured output to select depending on the
+        `LLM` provider.
+        """
+        schema = self.get_structured_output()
+        if not schema:
+            return
+
         if self.use_default_structured_output and not self.llm.structured_output:
             # In case the default structured output is required, we have to set it before
             # the LLM is loaded
             from distilabel.llms import InferenceEndpointsLLM
             from distilabel.llms.base import AsyncLLM
 
-            structured_output = {"schema": self.get_structured_output()}
+            structured_output = {"schema": schema}
             # To determine instructor or outlines format
             if not (
                 isinstance(self.llm, AsyncLLM)

--- a/src/distilabel/steps/tasks/sentence_transformers.py
+++ b/src/distilabel/steps/tasks/sentence_transformers.py
@@ -373,11 +373,8 @@ class GenerateSentencePair(Task):
         Returns:
             JSON Schema of the response to enforce.
         """
-        from distilabel.llms import InferenceEndpointsLLM
-        from distilabel.llms.base import AsyncLLM
-
         if self.triplet:
-            schema = {
+            return {
                 "properties": {
                     "positive": {"title": "Positive", "type": "string"},
                     "negative": {"title": "Negative", "type": "string"},
@@ -386,21 +383,12 @@ class GenerateSentencePair(Task):
                 "title": "Schema",
                 "type": "object",
             }
-        else:
-            schema = {
-                "properties": {"positive": {"title": "Positive", "type": "string"}},
-                "required": ["positive"],
-                "title": "Schema",
-                "type": "object",
-            }
-
-        # To determine instructor or outlines format
-        if isinstance(self.llm, AsyncLLM) and not isinstance(
-            self.llm, InferenceEndpointsLLM
-        ):
-            return {"schema": schema}
-
-        return {"format": "json", "schema": schema}
+        return {
+            "properties": {"positive": {"title": "Positive", "type": "string"}},
+            "required": ["positive"],
+            "title": "Schema",
+            "type": "object",
+        }
 
     def _format_structured_output(self, output: str) -> Dict[str, str]:
         """Parses the structured response, which should correspond to a dictionary

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 # Defined here too, so that the serde still works
 class DummyLLM(AsyncLLM):
+    structured_output: Any = None
+
     def load(self) -> None:
         pass
 
@@ -33,6 +35,22 @@ class DummyLLM(AsyncLLM):
         return "test"
 
     async def agenerate(
+        self, input: "FormattedInput", num_generations: int = 1
+    ) -> "GenerateOutput":
+        return ["output" for _ in range(num_generations)]
+
+
+class DummySyncLLM(AsyncLLM):
+    structured_output: Any = None
+
+    def load(self) -> None:
+        pass
+
+    @property
+    def model_name(self) -> str:
+        return "test"
+
+    def generate(
         self, input: "FormattedInput", num_generations: int = 1
     ) -> "GenerateOutput":
         return ["output" for _ in range(num_generations)]

--- a/tests/unit/steps/tasks/test_sentence_transformers.py
+++ b/tests/unit/steps/tasks/test_sentence_transformers.py
@@ -26,6 +26,27 @@ from distilabel.steps.tasks.sentence_transformers import (
 
 from tests.unit.conftest import DummyLLM
 
+# from distilabel.llms.base import LLM, AsyncLLM
+
+# if TYPE_CHECKING:
+#     from distilabel.llms.typing import GenerateOutput
+#     from distilabel.steps.tasks.typing import FormattedInput
+
+# # Defined here too, so that the serde still works
+# class DummyStructuredLLM(LLM):
+#     structured_output: Any = None
+#     def load(self) -> None:
+#         pass
+
+#     @property
+#     def model_name(self) -> str:
+#         return "test"
+
+#     def generate(
+#         self, input: "FormattedInput", num_generations: int = 1
+#     ) -> "GenerateOutput":
+#         return ['{ \n  "negative": "negative",\n  "positive": "positive"\n}' for _ in range(num_generations)]
+
 
 class TestGenerateSentencePair:
     @pytest.mark.parametrize(
@@ -300,11 +321,12 @@ class TestGenerateSentencePair:
         ]
 
     @pytest.mark.parametrize(
-        "output,triplet,expected",
+        "output,triplet,use_default_structured_output,expected",
         [
             (
                 "## Positive\n\nThis is a paraphrase\n## Negative\n\nThis is not a paraphrase",
                 True,
+                False,
                 {
                     "positive": "This is a paraphrase",
                     "negative": "This is not a paraphrase",
@@ -313,25 +335,66 @@ class TestGenerateSentencePair:
             (
                 "## Positive\n\nThis is a paraphrase",
                 True,
+                False,
                 {"positive": "This is a paraphrase", "negative": None},
             ),
             (
                 "## Positive\n\nThis is a paraphrase",
+                False,
                 False,
                 {"positive": "This is a paraphrase"},
             ),
             (
                 "random",
                 False,
+                False,
                 {"positive": None},
+            ),
+            (
+                '{ \n  "negative": "This is not a paraphrase",\n  "positive": "This is a paraphrase"\n}',
+                True,
+                True,
+                {
+                    "positive": "This is a paraphrase",
+                    "negative": "This is not a paraphrase",
+                },
+            ),
+            (
+                '{ \n   "positive": "This is a paraphrase"\n}',
+                True,
+                True,
+                {
+                    "positive": "This is a paraphrase",
+                },
+            ),
+            (
+                "{ \n   random\n}",
+                False,
+                True,
+                {
+                    "positive": None,
+                },
+            ),
+            (
+                "{ \n   random\n}",
+                True,
+                True,
+                {"positive": None, "negative": None},
             ),
         ],
     )
     def test_format_output(
-        self, output: str, triplet: bool, expected: Dict[str, Any]
+        self,
+        output: str,
+        triplet: bool,
+        use_default_structured_output: bool,
+        expected: Dict[str, Any],
     ) -> None:
         task = GenerateSentencePair(
-            llm=DummyLLM(), action="paraphrase", triplet=triplet
+            llm=DummyLLM(),
+            action="paraphrase",
+            triplet=triplet,
+            use_default_structured_output=use_default_structured_output,
         )
         task.load()
 


### PR DESCRIPTION
## Description

Adds a default structured output for `GenerateSentencePair`, it can be set from the `Task` and will prepare the LLM for it internally.

```python
from distilabel.steps.tasks import GenerateSentencePair
from distilabel.llms import InferenceEndpointsLLM

generate_sentence_pair = GenerateSentencePair(
    triplet=True, # `False` to generate only positive
    action="query",
    llm=...,
#    llm=InferenceEndpointsLLM(
#        model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
#    ),
    use_default_structured_output=True,
    input_batch_size=10,
)
```

Depending of the `LLM` will use a provider for the structured outputs. For example with `InferenceEndpointsLLM` it will use `outlines` to generate a dict of the form: `{"positive": ...}` or `{"positive": ..., "negative": ...}` that will be easier to parse.

It also puts in place a mechanism to define a default structured output for every `Task` that may require it.

Closes #867