### PR TITLE
Complexity scorer default structured output

### DIFF
--- a/src/distilabel/__init__.py
+++ b/src/distilabel/__init__.py
@@ -14,6 +14,6 @@
 
 from rich import traceback as rich_traceback
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 rich_traceback.install(show_locals=True)

--- a/src/distilabel/steps/tasks/complexity_scorer.py
+++ b/src/distilabel/steps/tasks/complexity_scorer.py
@@ -22,8 +22,10 @@ else:
 
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
+import orjson
 from jinja2 import Template
 from pydantic import PrivateAttr
+from typing_extensions import override
 
 from distilabel.steps.tasks.base import Task
 
@@ -84,6 +86,31 @@ class ComplexityScorer(Task):
         )
         # result
         # [{'instructions': ['plain instruction', 'highly complex instruction'], 'model_name': 'test', 'scores': [1, 5], 'distilabel_metadata': {'raw_output_complexity_scorer_0': 'output'}}]
+        ```
+
+        Generate structured output with default schema:
+
+        ```python
+        from distilabel.steps.tasks import ComplexityScorer
+        from distilabel.llms.huggingface import InferenceEndpointsLLM
+
+        # Consider this as a placeholder for your actual LLM.
+        scorer = ComplexityScorer(
+            llm=InferenceEndpointsLLM(
+                model_id="mistralai/Mistral-7B-Instruct-v0.2",
+            ),
+            use_default_structured_output=use_default_structured_output
+        )
+
+        scorer.load()
+
+        result = next(
+            scorer.process(
+                [{"instructions": ["plain instruction", "highly complex instruction"]}]
+            )
+        )
+        # result
+        # [{'instructions': ['plain instruction', 'highly complex instruction'], 'model_name': 'test', 'scores': [1, 2], 'distilabel_metadata': {'raw_output_complexity_scorer_0': '{ \n  "scores": [\n    1, \n    2\n  ]\n}'}}]
         ```
 
     Citations:
@@ -153,6 +180,9 @@ class ComplexityScorer(Task):
         if output is None:
             return {"scores": [None] * len(input["instructions"])}
 
+        if self.use_default_structured_output:
+            return self._format_structured_output(output, input)
+
         scores = []
         score_lines = output.split("\n")
         for i, line in enumerate(score_lines):
@@ -162,3 +192,52 @@ class ComplexityScorer(Task):
             if i == len(input["instructions"]) - 1:
                 break
         return {"scores": scores}
+
+    @override
+    def get_structured_output(self) -> Dict[str, Any]:
+        """Creates the json schema to be passed to the LLM, to enforce generating
+        a dictionary with the output which can be directly parsed as a python dictionary.
+
+        Returns:
+            JSON Schema of the response to enforce.
+        """
+        from distilabel.llms import InferenceEndpointsLLM
+        from distilabel.llms.base import AsyncLLM
+
+        schema = {
+            "properties": {
+                "scores": {
+                    "items": {"type": "integer"},
+                    "title": "Scores",
+                    "type": "array",
+                }
+            },
+            "required": ["scores"],
+            "title": "SchemaComplexityScorer",
+            "type": "object",
+        }
+
+        # To determine instructor or outlines format
+        if isinstance(self.llm, AsyncLLM) and not isinstance(
+            self.llm, InferenceEndpointsLLM
+        ):
+            return {"schema": schema}
+
+        return {"format": "json", "schema": schema}
+
+    def _format_structured_output(
+        self, output: str, input: Dict[str, Any]
+    ) -> Dict[str, str]:
+        """Parses the structured response, which should correspond to a dictionary
+        with either `positive`, or `positive` and `negative` keys.
+
+        Args:
+            output: The output from the `LLM`.
+
+        Returns:
+            Formatted output.
+        """
+        try:
+            return orjson.loads(output)
+        except orjson.JSONDecodeError:
+            return {"scores": [None] * len(input["instructions"])}

--- a/src/distilabel/steps/tasks/complexity_scorer.py
+++ b/src/distilabel/steps/tasks/complexity_scorer.py
@@ -201,10 +201,7 @@ class ComplexityScorer(Task):
         Returns:
             JSON Schema of the response to enforce.
         """
-        from distilabel.llms import InferenceEndpointsLLM
-        from distilabel.llms.base import AsyncLLM
-
-        schema = {
+        return {
             "properties": {
                 "scores": {
                     "items": {"type": "integer"},
@@ -216,14 +213,6 @@ class ComplexityScorer(Task):
             "title": "SchemaComplexityScorer",
             "type": "object",
         }
-
-        # To determine instructor or outlines format
-        if isinstance(self.llm, AsyncLLM) and not isinstance(
-            self.llm, InferenceEndpointsLLM
-        ):
-            return {"schema": schema}
-
-        return {"format": "json", "schema": schema}
 
     def _format_structured_output(
         self, output: str, input: Dict[str, Any]

--- a/src/distilabel/steps/tasks/complexity_scorer.py
+++ b/src/distilabel/steps/tasks/complexity_scorer.py
@@ -198,6 +198,16 @@ class ComplexityScorer(Task):
         """Creates the json schema to be passed to the LLM, to enforce generating
         a dictionary with the output which can be directly parsed as a python dictionary.
 
+        The schema corresponds to the following:
+
+        ```python
+        from pydantic import BaseModel
+        from typing import List
+
+        class SchemaComplexityScorer(BaseModel):
+            scores: List[int]
+        ```
+
         Returns:
             JSON Schema of the response to enforce.
         """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 # Defined here too, so that the serde still works
 class DummyLLM(AsyncLLM):
+    structured_output: Any = None
+
     def load(self) -> None:
         pass
 
@@ -33,6 +35,22 @@ class DummyLLM(AsyncLLM):
         return "test"
 
     async def agenerate(
+        self, input: "FormattedInput", num_generations: int = 1
+    ) -> "GenerateOutput":
+        return ["output" for _ in range(num_generations)]
+
+
+class DummySyncLLM(AsyncLLM):
+    structured_output: Any = None
+
+    def load(self) -> None:
+        pass
+
+    @property
+    def model_name(self) -> str:
+        return "test"
+
+    def generate(
         self, input: "FormattedInput", num_generations: int = 1
     ) -> "GenerateOutput":
         return ["output" for _ in range(num_generations)]

--- a/tests/unit/steps/tasks/test_complexity_scorer.py
+++ b/tests/unit/steps/tasks/test_complexity_scorer.py
@@ -42,29 +42,43 @@ class TestComplexityScorer:
         ]
 
     @pytest.mark.parametrize(
-        "output, expected",
+        "output, use_default_structured_output, expected",
         [
             (
                 "[1] Score: 1\n[2] Score: 2\n[3] Score: 3\n",
+                False,
                 {"scores": [1.0, 2.0, 3.0]},
             ),
             (
                 "[1] Score: 1\n[2] Score: 2\n[3] Score: 3\njfjfjfjjfjfjf this is noise from the llm\nlallalalala more noise\nand more noise",
+                False,
                 {"scores": [1.0, 2.0, 3.0]},
             ),
             (
                 None,
+                False,
+                {"scores": [None, None, None]},
+            ),
+            (
+                '{"scores":[1,2,3]}',
+                True,
+                {"scores": [1.0, 2.0, 3.0]},
+            ),
+            (
+                "wrong",
+                True,
                 {"scores": [None, None, None]},
             ),
         ],
     )
     def test_format_output(
-        self, output: Union[str, None], expected: Dict[str, Any]
+        self,
+        output: Union[str, None],
+        use_default_structured_output: bool,
+        expected: Dict[str, Any],
     ) -> None:
         task = ComplexityScorer(
-            name="complexity_scorer",
-            llm=DummyLLM(),
-            pipeline=Pipeline(name="unit-test-pipeline"),
+            llm=DummyLLM(), use_default_structured_output=use_default_structured_output
         )
         task.load()
 

--- a/tests/unit/steps/tasks/test_sentence_transformers.py
+++ b/tests/unit/steps/tasks/test_sentence_transformers.py
@@ -26,6 +26,27 @@ from distilabel.steps.tasks.sentence_transformers import (
 
 from tests.unit.conftest import DummyLLM
 
+# from distilabel.llms.base import LLM, AsyncLLM
+
+# if TYPE_CHECKING:
+#     from distilabel.llms.typing import GenerateOutput
+#     from distilabel.steps.tasks.typing import FormattedInput
+
+# # Defined here too, so that the serde still works
+# class DummyStructuredLLM(LLM):
+#     structured_output: Any = None
+#     def load(self) -> None:
+#         pass
+
+#     @property
+#     def model_name(self) -> str:
+#         return "test"
+
+#     def generate(
+#         self, input: "FormattedInput", num_generations: int = 1
+#     ) -> "GenerateOutput":
+#         return ['{ \n  "negative": "negative",\n  "positive": "positive"\n}' for _ in range(num_generations)]
+
 
 class TestGenerateSentencePair:
     @pytest.mark.parametrize(
@@ -300,11 +321,12 @@ class TestGenerateSentencePair:
         ]
 
     @pytest.mark.parametrize(
-        "output,triplet,expected",
+        "output,triplet,use_default_structured_output,expected",
         [
             (
                 "## Positive\n\nThis is a paraphrase\n## Negative\n\nThis is not a paraphrase",
                 True,
+                False,
                 {
                     "positive": "This is a paraphrase",
                     "negative": "This is not a paraphrase",
@@ -313,25 +335,66 @@ class TestGenerateSentencePair:
             (
                 "## Positive\n\nThis is a paraphrase",
                 True,
+                False,
                 {"positive": "This is a paraphrase", "negative": None},
             ),
             (
                 "## Positive\n\nThis is a paraphrase",
+                False,
                 False,
                 {"positive": "This is a paraphrase"},
             ),
             (
                 "random",
                 False,
+                False,
                 {"positive": None},
+            ),
+            (
+                '{ \n  "negative": "This is not a paraphrase",\n  "positive": "This is a paraphrase"\n}',
+                True,
+                True,
+                {
+                    "positive": "This is a paraphrase",
+                    "negative": "This is not a paraphrase",
+                },
+            ),
+            (
+                '{ \n   "positive": "This is a paraphrase"\n}',
+                True,
+                True,
+                {
+                    "positive": "This is a paraphrase",
+                },
+            ),
+            (
+                "{ \n   random\n}",
+                False,
+                True,
+                {
+                    "positive": None,
+                },
+            ),
+            (
+                "{ \n   random\n}",
+                True,
+                True,
+                {"positive": None, "negative": None},
             ),
         ],
     )
     def test_format_output(
-        self, output: str, triplet: bool, expected: Dict[str, Any]
+        self,
+        output: str,
+        triplet: bool,
+        use_default_structured_output: bool,
+        expected: Dict[str, Any],
     ) -> None:
         task = GenerateSentencePair(
-            llm=DummyLLM(), action="paraphrase", triplet=triplet
+            llm=DummyLLM(),
+            action="paraphrase",
+            triplet=triplet,
+            use_default_structured_output=use_default_structured_output,
         )
         task.load()
 


### PR DESCRIPTION
## Description

Adds a default JSON schema to generate the scores in a structured manner.

```python
from distilabel.steps.tasks import ComplexityScorer
from distilabel.llms.huggingface import InferenceEndpointsLLM

scorer = ComplexityScorer(
    llm=InferenceEndpointsLLM(
        model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
    ),
    use_default_structured_output=True
)

scorer.load()

result = next(
    scorer.process(
        [{"instructions": ["plain instruction", "highly complex instruction"]}]
    )
)

>>> result
[{'instructions': ['plain instruction', 'highly complex instruction'],
  'scores': [1, 2],
  'distilabel_metadata': {'raw_output_complexity_scorer_0': '{ \n  "scores": [\n    1, \n    2\n  ]\n}'},
  'model_name': 'meta-llama/Meta-Llama-3.1-70B-Instruct'}]
```

Closes #869, **must** be merged after #868 .
