### PR TITLE
Exclude `repo_id` from `LoadDataFromFileSystem`

### DIFF
--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -343,7 +343,7 @@ class LoadDataFromFileSystem(LoadDataFromHub):
         default=None,
         description="The expected filetype. If not provided, it will be inferred from the file extension.",
     )
-    repo_id: ExcludedField[str | None] = None
+    repo_id: ExcludedField[Union[str, None]] = None
 
     def load(self) -> None:
         """Load the dataset from the file/s in disk."""

--- a/src/distilabel/steps/generators/huggingface.py
+++ b/src/distilabel/steps/generators/huggingface.py
@@ -17,6 +17,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Dict,
     List,
@@ -24,6 +25,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -44,6 +46,13 @@ from distilabel.steps.base import GeneratorStep
 
 if TYPE_CHECKING:
     from distilabel.steps.typing import GeneratorStepOutput
+
+
+T = TypeVar("T")
+
+# To avoid using repo_id in LoadDataFromFileSystem:
+# https://github.com/pydantic/pydantic/discussions/7076#discussioncomment-6699138
+ExcludedField = Annotated[T, Field(exclude=True)]
 
 
 class LoadDataFromHub(GeneratorStep):
@@ -334,6 +343,7 @@ class LoadDataFromFileSystem(LoadDataFromHub):
         default=None,
         description="The expected filetype. If not provided, it will be inferred from the file extension.",
     )
+    repo_id: ExcludedField[str | None] = None
 
     def load(self) -> None:
         """Load the dataset from the file/s in disk."""
@@ -416,9 +426,7 @@ class LoadDataFromFileSystem(LoadDataFromHub):
         """
         # We assume there are Dataset/IterableDataset, not it's ...Dict counterparts
         if self._dataset is None:
-            raise ValueError(
-                "Dataset not loaded yet, you must call `load` method first."
-            )
+            self.load()
 
         return self._dataset.column_names
 

--- a/tests/unit/steps/generators/test_huggingface.py
+++ b/tests/unit/steps/generators/test_huggingface.py
@@ -27,6 +27,8 @@ from distilabel.steps.generators.huggingface import (
     LoadDataFromHub,
 )
 
+from tests.unit.pipeline.utils import DummyStep1
+
 DISTILABEL_RUN_SLOW_TESTS = os.getenv("DISTILABEL_RUN_SLOW_TESTS", False)
 
 
@@ -133,18 +135,23 @@ class TestLoadDataFromFileSystem:
             assert isinstance(generator_step_output[1], bool)
             assert len(generator_step_output[0]) == 22
 
-    @pytest.mark.parametrize("load", [True, False])
-    def test_outputs(self, load: bool) -> None:
+    def test_outputs(self) -> None:
         loader = LoadDataFromFileSystem(
             filetype="json",
             data_files=str(Path(__file__).parent / "sample_functions.jsonl"),
         )
-        if load:
-            loader.load()
-            assert loader.outputs == ["type", "function"]
-        else:
-            with pytest.raises(ValueError):
-                loader.outputs  # noqa: B018
+        loader.load()
+        assert loader.outputs == ["type", "function"]
+
+    def test_loading_in_pipeline(self):
+        with Pipeline():
+            loader = LoadDataFromFileSystem(
+                filetype="json",
+                data_files=str(Path(__file__).parent / "sample_functions.jsonl"),
+            )
+            dummy = DummyStep1(input_mappings={"instruction": "function"})
+            loader >> dummy
+        assert loader.outputs == ["type", "function"]
 
 
 class TestLoadDataFromDisk:


### PR DESCRIPTION
## Description

This PR removes the `repo_id` from the generator class as it won't be necessary, even if we inherit from the `LoadFromHub` class to access the common methods and attributes.