### PR TITLE
New `TruncateTextColumn` to truncate the length of texts using the number of tokens or characters

### DIFF
--- a/src/distilabel/steps/__init__.py
+++ b/src/distilabel/steps/__init__.py
@@ -47,6 +47,7 @@ from distilabel.steps.generators.huggingface import (
 from distilabel.steps.generators.utils import make_generator_step
 from distilabel.steps.globals.huggingface import PushToHub
 from distilabel.steps.reward_model import RewardModelScore
+from distilabel.steps.truncate import TruncateRow
 from distilabel.steps.typing import GeneratorStepOutput, StepOutput
 
 __all__ = [
@@ -80,4 +81,5 @@ __all__ = [
     "GeneratorStepOutput",
     "StepOutput",
     "step",
+    "TruncateRow",
 ]

--- a/src/distilabel/steps/__init__.py
+++ b/src/distilabel/steps/__init__.py
@@ -78,8 +78,8 @@ __all__ = [
     "Step",
     "StepInput",
     "RewardModelScore",
+    "TruncateRow",
     "GeneratorStepOutput",
     "StepOutput",
     "step",
-    "TruncateRow",
 ]

--- a/src/distilabel/steps/__init__.py
+++ b/src/distilabel/steps/__init__.py
@@ -47,7 +47,7 @@ from distilabel.steps.generators.huggingface import (
 from distilabel.steps.generators.utils import make_generator_step
 from distilabel.steps.globals.huggingface import PushToHub
 from distilabel.steps.reward_model import RewardModelScore
-from distilabel.steps.truncate import TruncateRow
+from distilabel.steps.truncate import TruncateTextColumn
 from distilabel.steps.typing import GeneratorStepOutput, StepOutput
 
 __all__ = [
@@ -78,7 +78,7 @@ __all__ = [
     "Step",
     "StepInput",
     "RewardModelScore",
-    "TruncateRow",
+    "TruncateTextColumn",
     "GeneratorStepOutput",
     "StepOutput",
     "step",

--- a/src/distilabel/steps/truncate.py
+++ b/src/distilabel/steps/truncate.py
@@ -27,7 +27,7 @@ class TruncateRow(Step):
     """Truncate a row using a tokenizer or the number of characters.
 
     `TruncateRow` is a `Step` that truncates a row according to the max length. If
-    the `tokenizer_name` is provided, then the row will be truncated using the tokenizer,
+    the `tokenizer` is provided, then the row will be truncated using the tokenizer,
     and the `max_length` will be used as the maximum number of tokens, otherwise it will
     be used as the maximum number of characters. The `TruncateRow` step is useful when one
     wants to truncate a row to a certain length, to avoid posterior errors in the model due
@@ -36,9 +36,9 @@ class TruncateRow(Step):
     Attributes:
         column: the column to truncate. Defaults to `"text"`.
         max_length: the maximum length to use for truncation.
-            If a `tokenizer_name` is given, corresponds to the number of tokens,
+            If a `tokenizer` is given, corresponds to the number of tokens,
             otherwise corresponds to the number of characters. Defaults to `8192`.
-        tokenizer_name: the name of the tokenizer to use. If provided, the row will be
+        tokenizer: the name of the tokenizer to use. If provided, the row will be
             truncated using the tokenizer. Defaults to `None`.
 
     Input columns:
@@ -58,7 +58,7 @@ class TruncateRow(Step):
         from distilabel.steps import TruncateRow
 
         trunc = TruncateRow(
-            tokenizer_name="meta-llama/Meta-Llama-3.1-70B-Instruct",
+            tokenizer="meta-llama/Meta-Llama-3.1-70B-Instruct",
             max_length=4,
             column="text"
         )
@@ -99,13 +99,13 @@ class TruncateRow(Step):
 
     column: str = "text"
     max_length: int = 8192
-    tokenizer_name: Optional[str] = None
+    tokenizer: Optional[str] = None
     _truncator: Optional[Callable[[str], str]] = None
     _tokenizer: Optional[Any] = None
 
     def load(self):
         super().load()
-        if self.tokenizer_name:
+        if self.tokenizer:
             if not importlib.util.find_spec("transformers"):
                 raise ImportError(
                     "`transformers` is needed to tokenize, but is not installed. "
@@ -114,7 +114,7 @@ class TruncateRow(Step):
 
             from transformers import AutoTokenizer
 
-            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer)
             self._truncator = self._truncate_with_tokenizer
         else:
             self._truncator = self._truncate_with_length

--- a/src/distilabel/steps/truncate.py
+++ b/src/distilabel/steps/truncate.py
@@ -23,13 +23,13 @@ if TYPE_CHECKING:
     from distilabel.steps.typing import StepOutput
 
 
-class TruncateRow(Step):
+class TruncateTextColumn(Step):
     """Truncate a row using a tokenizer or the number of characters.
 
-    `TruncateRow` is a `Step` that truncates a row according to the max length. If
+    `TruncateTextColumn` is a `Step` that truncates a row according to the max length. If
     the `tokenizer` is provided, then the row will be truncated using the tokenizer,
     and the `max_length` will be used as the maximum number of tokens, otherwise it will
-    be used as the maximum number of characters. The `TruncateRow` step is useful when one
+    be used as the maximum number of characters. The `TruncateTextColumn` step is useful when one
     wants to truncate a row to a certain length, to avoid posterior errors in the model due
     to the length.
 
@@ -55,9 +55,9 @@ class TruncateRow(Step):
         Truncating a row to a given number of tokens:
 
         ```python
-        from distilabel.steps import TruncateRow
+        from distilabel.steps import TruncateTextColumn
 
-        trunc = TruncateRow(
+        trunc = TruncateTextColumn(
             tokenizer="meta-llama/Meta-Llama-3.1-70B-Instruct",
             max_length=4,
             column="text"
@@ -79,9 +79,9 @@ class TruncateRow(Step):
         Truncating a row to a given number of characters:
 
         ```python
-        from distilabel.steps import TruncateRow
+        from distilabel.steps import TruncateTextColumn
 
-        trunc = TruncateRow(max_length=10)
+        trunc = TruncateTextColumn(max_length=10)
 
         trunc.load()
 

--- a/src/distilabel/steps/truncate.py
+++ b/src/distilabel/steps/truncate.py
@@ -108,7 +108,7 @@ class TruncateRow(Step):
         if self.tokenizer_name:
             if not importlib.util.find_spec("transformers"):
                 raise ImportError(
-                    "transformers is needed to tokenize, but is not installed. "
+                    "`transformers` is needed to tokenize, but is not installed. "
                     "Please install it using `pip install transformers`."
                 )
 

--- a/src/distilabel/steps/truncate.py
+++ b/src/distilabel/steps/truncate.py
@@ -1,0 +1,149 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+from typing_extensions import override
+
+from distilabel.steps.base import Step, StepInput
+
+if TYPE_CHECKING:
+    from distilabel.steps.typing import StepOutput
+
+
+class TruncateRow(Step):
+    """Truncate a row using a tokenizer or the number of characters.
+
+    `TruncateRow` is a `Step` that truncates a row according to the max length. If
+    the `tokenizer_name` is provided, then the row will be truncated using the tokenizer,
+    and the `max_length` will be used as the maximum number of tokens, otherwise it will
+    be used as the maximum number of characters. The `TruncateRow` step is useful when one
+    wants to truncate a row to a certain length, to avoid posterior errors in the model due
+    to the length.
+
+    Attributes:
+        column: the column to truncate. Defaults to `"text"`.
+        max_length: the maximum length to use for truncation.
+            If a `tokenizer_name` is given, corresponds to the number of tokens,
+            otherwise corresponds to the number of characters. Defaults to `8192`.
+        tokenizer_name: the name of the tokenizer to use. If provided, the row will be
+            truncated using the tokenizer. Defaults to `None`.
+
+    Input columns:
+        - dynamic (determined by `column` attribute): The columns to be truncated, defaults to "text".
+
+    Output columns:
+        - dynamic (determined by `column` attribute): The truncated column.
+
+    Categories:
+        - text-manipulation
+
+    Examples:
+
+        Truncating a row to a given number of tokens:
+
+        ```python
+        from distilabel.steps import TruncateRow
+
+        trunc = TruncateRow(
+            tokenizer_name="meta-llama/Meta-Llama-3.1-70B-Instruct",
+            max_length=4,
+            column="text"
+        )
+
+        trunc.load()
+
+        result = next(
+            trunc.process(
+                [
+                    {"text": "This is a sample text that is longer than 10 characters"}
+                ]
+            )
+        )
+        # result
+        # [{'text': 'This is a sample'}]
+        ```
+
+        Truncating a row to a given number of characters:
+
+        ```python
+        from distilabel.steps import TruncateRow
+
+        trunc = TruncateRow(max_length=10)
+
+        trunc.load()
+
+        result = next(
+            trunc.process(
+                [
+                    {"text": "This is a sample text that is longer than 10 characters"}
+                ]
+            )
+        )
+        # result
+        # [{'text': 'This is a '}]
+        ```
+    """
+
+    column: str = "text"
+    max_length: int = 8192
+    tokenizer_name: Optional[str] = None
+    _truncator: Optional[Callable[[str], str]] = None
+    _tokenizer: Optional[Any] = None
+
+    def load(self):
+        super().load()
+        if self.tokenizer_name:
+            if not importlib.util.find_spec("transformers"):
+                raise ImportError(
+                    "transformers is needed to tokenize, but is not installed. "
+                    "Please install it using `pip install transformers`."
+                )
+
+            from transformers import AutoTokenizer
+
+            self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name)
+            self._truncator = self._truncate_with_tokenizer
+        else:
+            self._truncator = self._truncate_with_length
+
+    @property
+    def inputs(self) -> List[str]:
+        return [self.column]
+
+    @property
+    def outputs(self) -> List[str]:
+        return self.inputs
+
+    def _truncate_with_length(self, text: str) -> str:
+        """Truncates the text according to the number of characters."""
+        return text[: self.max_length]
+
+    def _truncate_with_tokenizer(self, text: str) -> str:
+        """Truncates the text according to the number of characters using the tokenizer."""
+        return self._tokenizer.decode(
+            self._tokenizer.encode(
+                text,
+                add_special_tokens=False,
+                max_length=self.max_length,
+                truncation=True,
+            )
+        )
+
+    @override
+    def process(self, inputs: StepInput) -> "StepOutput":
+        for input in inputs:
+            input[self.column] = self._truncator(input[self.column])
+        yield inputs

--- a/src/distilabel/utils/mkdocs/components_gallery.py
+++ b/src/distilabel/utils/mkdocs/components_gallery.py
@@ -75,16 +75,17 @@ _LLM_DETAIL_TEMPLATE = Template(
 )
 
 _STEPS_CATEGORY_TO_ICON = {
-    "text-generation": ":material-text-box-edit:",
-    "evol": ":material-dna:",
-    "preference": ":material-poll:",
     "critique": ":material-comment-edit:",
-    "scorer": ":octicons-number-16:",
     "embedding": ":material-vector-line:",
-    "format": ":material-format-list-bulleted:",
+    "evol": ":material-dna:",
     "filtering": ":material-filter:",
-    "save": ":material-content-save:",
+    "format": ":material-format-list-bulleted:",
     "load": ":material-file-download:",
+    "preference": ":material-poll:",
+    "save": ":material-content-save:",
+    "scorer": ":octicons-number-16:",
+    "text-generation": ":material-text-box-edit:",
+    "text-manipulation": ":material-receipt-text-edit:",
 }
 
 

--- a/tests/unit/steps/test_truncate.py
+++ b/tests/unit/steps/test_truncate.py
@@ -19,7 +19,7 @@ from distilabel.steps.truncate import TruncateRow
 
 
 @pytest.mark.parametrize(
-    "max_length, text, tokenizer_name, expected",
+    "max_length, text, tokenizer, expected",
     [
         (
             10,
@@ -36,11 +36,9 @@ from distilabel.steps.truncate import TruncateRow
     ],
 )
 def test_truncate_row(
-    max_length: int, text: str, tokenizer_name: Optional[str], expected: str
+    max_length: int, text: str, tokenizer: Optional[str], expected: str
 ) -> None:
-    trunc = TruncateRow(
-        column="text", max_length=max_length, tokenizer_name=tokenizer_name
-    )
+    trunc = TruncateRow(column="text", max_length=max_length, tokenizer=tokenizer)
     trunc.load()
 
     assert next(trunc.process([{"text": text}])) == [{"text": expected}]

--- a/tests/unit/steps/test_truncate.py
+++ b/tests/unit/steps/test_truncate.py
@@ -1,0 +1,46 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+from distilabel.steps.truncate import TruncateRow
+
+
+@pytest.mark.parametrize(
+    "max_length, text, tokenizer_name, expected",
+    [
+        (
+            10,
+            "This is a sample text that is longer than 10 characters",
+            None,
+            "This is a ",
+        ),
+        (
+            4,
+            "This is a sample text that is longer than 10 characters",
+            "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "This is a sample",
+        ),
+    ],
+)
+def test_truncate_row(
+    max_length: int, text: str, tokenizer_name: Optional[str], expected: str
+) -> None:
+    trunc = TruncateRow(
+        column="text", max_length=max_length, tokenizer_name=tokenizer_name
+    )
+    trunc.load()
+
+    assert next(trunc.process([{"text": text}])) == [{"text": expected}]

--- a/tests/unit/steps/test_truncate.py
+++ b/tests/unit/steps/test_truncate.py
@@ -15,7 +15,7 @@
 from typing import Optional
 
 import pytest
-from distilabel.steps.truncate import TruncateRow
+from distilabel.steps.truncate import TruncateTextColumn
 
 
 @pytest.mark.parametrize(
@@ -38,7 +38,9 @@ from distilabel.steps.truncate import TruncateRow
 def test_truncate_row(
     max_length: int, text: str, tokenizer: Optional[str], expected: str
 ) -> None:
-    trunc = TruncateRow(column="text", max_length=max_length, tokenizer=tokenizer)
+    trunc = TruncateTextColumn(
+        column="text", max_length=max_length, tokenizer=tokenizer
+    )
     trunc.load()
 
     assert next(trunc.process([{"text": text}])) == [{"text": expected}]

--- a/tests/unit/steps/test_truncate.py
+++ b/tests/unit/steps/test_truncate.py
@@ -30,7 +30,7 @@ from distilabel.steps.truncate import TruncateRow
         (
             4,
             "This is a sample text that is longer than 10 characters",
-            "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "teknium/OpenHermes-2.5-Mistral-7B",
             "This is a sample",
         ),
     ],


### PR DESCRIPTION
## Description

This PR adds a new `TruncateTextColumn` step to truncate the text.

While developing pipelines that start from datasets with longer texts, the model can fail for longer texts than the max context length the model can handle. This step can be useful to avoid such errors:

- Truncating a row to a given number of tokens:

```python
from distilabel.steps import TruncateTextColumn

trunc = TruncateTextColumn(
    tokenizer="meta-llama/Meta-Llama-3.1-70B-Instruct",
    max_length=4,
    column="text"
)

trunc.load()

result = next(
    trunc.process(
        [
            {"text": "This is a sample text that is longer than 10 characters"}
        ]
    )
)
# result
# [{'text': 'This is a sample'}]
```

- Truncating a row to a given number of characters


```python
from distilabel.steps import TruncateTextColumn

trunc = TruncateTextColumn(max_length=10)

trunc.load()

result = next(
    trunc.process(
        [
            {"text": "This is a sample text that is longer than 10 characters"}
        ]
    )
)
# result
# [{'text': 'This is a '}]
```
