### PR TITLE
Add new `add_raw_input` argument to `_Task` so we can automatically include the formatted input

### DIFF
--- a/docs/sections/how_to_guides/basic/task/index.md
+++ b/docs/sections/how_to_guides/basic/task/index.md
@@ -24,7 +24,12 @@ next(task.process([{"instruction": "What's the capital of Spain?"}]))
 #     {
 #         'instruction': "What's the capital of Spain?",
 #         'generation': 'The capital of Spain is Madrid.',
-#         'distilabel_metadata': {'raw_output_text-generation': 'The capital of Spain is Madrid.'},
+#         'distilabel_metadata': {
+#               'raw_output_text-generation': 'The capital of Spain is Madrid.',
+#               'raw_input_text-generation': [
+#                   {'role': 'user', 'content': "What's the capital of Spain?"}
+#               ]
+#         },
 #         'model_name': 'meta-llama/Meta-Llama-3-70B-Instruct'
 #     }
 # ]
@@ -33,7 +38,24 @@ next(task.process([{"instruction": "What's the capital of Spain?"}]))
 !!! NOTE
     The `Step.load()` always needs to be executed when being used as a standalone. Within a pipeline, this will be done automatically during pipeline execution.
 
-As shown above, the [`TextGeneration`][distilabel.steps.tasks.TextGeneration] task adds a `generation` based on the `instruction`. Additionally, it provides some metadata about the LLM call through `distilabel_metadata`. This can be disabled by setting the `add_raw_output` attribute to `False` when creating the task.
+As shown above, the [`TextGeneration`][distilabel.steps.tasks.TextGeneration] task adds a `generation` based on the `instruction`.
+
+!!! Tip
+    Since version `1.2.0`, we provide some metadata about the LLM call through `distilabel_metadata`. This can be disabled by setting the `add_raw_output` attribute to `False` when creating the task.
+
+    Additionally, since version `1.4.0`, the formatted input can also be included, which can be helpful when testing
+    custom templates (testing the pipeline using the [`dry_run`][distilabel.pipeline.local.Pipeline.dry_run] method).
+
+    ```python title="disable raw input and output"
+    task = TextGeneration(
+        llm=InferenceEndpointsLLM(
+            model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+            tokenizer_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+        ),
+        add_raw_output=False,
+        add_raw_input=False
+    )
+    ```
 
 ## Specifying the number of generations and grouping generations
 

--- a/src/distilabel/steps/tasks/base.py
+++ b/src/distilabel/steps/tasks/base.py
@@ -61,6 +61,13 @@ class _Task(_Step, ABC):
             " of the `distilabel_metadata` dictionary output column"
         ),
     )
+    add_raw_input: RuntimeParameter[bool] = Field(
+        default=True,
+        description=(
+            "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>`"
+            " of the `distilabel_metadata` dictionary column"
+        ),
+    )
     num_generations: RuntimeParameter[int] = Field(
         default=1, description="The number of generations to be produced per input."
     )
@@ -113,10 +120,12 @@ class _Task(_Step, ABC):
         for output, input in zip(outputs, inputs * len(outputs)):  # type: ignore
             try:
                 formatted_output = self.format_output(output, input)
-                formatted_output = self._maybe_add_raw_output(
+                formatted_output = self._maybe_add_raw_input_output(
                     formatted_output,
                     output,
+                    input,
                     add_raw_output=self.add_raw_output,  # type: ignore
+                    add_raw_input=self.add_raw_input,  # type: ignore
                 )
                 formatted_outputs.append(formatted_output)
             except Exception as e:
@@ -135,24 +144,35 @@ class _Task(_Step, ABC):
         # Create a dictionary with the outputs of the task (every output set to None)
         outputs = {output: None for output in self.outputs}
         outputs["model_name"] = self.llm.model_name  # type: ignore
-        outputs = self._maybe_add_raw_output(
+        outputs = self._maybe_add_raw_input_output(
             outputs,
             output,
+            input,
             add_raw_output=self.add_raw_output,  # type: ignore
+            add_raw_input=self.add_raw_input,  # type: ignore
         )
         return outputs
 
-    def _maybe_add_raw_output(
+    def _maybe_add_raw_input_output(
         self,
         output: Dict[str, Any],
         raw_output: Union[str, None],
+        input: Union[str, None],
         add_raw_output: bool = True,
-    ) -> Dict[str, Any]:
-        """Adds the raw output of the LLM to the output dictionary if `add_raw_output` is True."""
+        add_raw_input: bool = True,
+    ):
+        """Adds the raw output and or the formatted input of the LLM to the output dictionary
+        if `add_raw_output` is True or `add_raw_input` is True.
+        """
+        meta = output.get(DISTILABEL_METADATA_KEY, {})
+
         if add_raw_output:
-            meta = output.get(DISTILABEL_METADATA_KEY, {})
             meta[f"raw_output_{self.name}"] = raw_output
+        if add_raw_input:
+            meta[f"raw_input_{self.name}"] = self.format_input(input)
+        if meta:
             output[DISTILABEL_METADATA_KEY] = meta
+
         return output
 
     def _set_default_structured_output(self) -> None:

--- a/tests/unit/steps/tasks/evol_instruct/test_base.py
+++ b/tests/unit/steps/tasks/evol_instruct/test_base.py
@@ -122,6 +122,7 @@ class TestEvolInstruct:
         assert task.dump() == {
             "name": "task",
             "add_raw_output": True,
+            "add_raw_input": True,
             "input_mappings": task.input_mappings,
             "output_mappings": task.output_mappings,
             "resources": {
@@ -204,6 +205,11 @@ class TestEvolInstruct:
                 {
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
                     "name": "add_raw_output",
+                    "optional": True,
+                },
+                {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
                     "optional": True,
                 },
                 {

--- a/tests/unit/steps/tasks/evol_instruct/test_generator.py
+++ b/tests/unit/steps/tasks/evol_instruct/test_generator.py
@@ -124,6 +124,7 @@ class TestEvolInstructGenerator:
                 },
             },
             "add_raw_output": True,
+            "add_raw_input": True,
             "input_mappings": task.input_mappings,
             "output_mappings": task.output_mappings,
             "resources": {
@@ -199,6 +200,11 @@ class TestEvolInstructGenerator:
                 {
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
                     "name": "add_raw_output",
+                    "optional": True,
+                },
+                {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
                     "optional": True,
                 },
                 {

--- a/tests/unit/steps/tasks/evol_quality/test_base.py
+++ b/tests/unit/steps/tasks/evol_quality/test_base.py
@@ -93,6 +93,7 @@ class TestEvolQuality:
         assert task.dump() == {
             "name": "task",
             "add_raw_output": True,
+            "add_raw_input": True,
             "input_mappings": task.input_mappings,
             "output_mappings": task.output_mappings,
             "resources": {
@@ -168,6 +169,11 @@ class TestEvolQuality:
                 {
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
                     "name": "add_raw_output",
+                    "optional": True,
+                },
+                {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
                     "optional": True,
                 },
                 {

--- a/tests/unit/steps/tasks/magpie/test_base.py
+++ b/tests/unit/steps/tasks/magpie/test_base.py
@@ -422,6 +422,7 @@ class TestMagpie:
             "input_batch_size": 50,
             "group_generations": False,
             "add_raw_output": True,
+            "add_raw_input": True,
             "num_generations": 1,
             "use_default_structured_output": False,
             "runtime_parameters_info": [
@@ -499,6 +500,11 @@ class TestMagpie:
                     "name": "add_raw_output",
                     "optional": True,
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
+                },
+                {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
+                    "optional": True,
                 },
                 {
                     "name": "num_generations",

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -78,6 +78,7 @@ class TestMagpieGenerator:
             "batch_size": 50,
             "group_generations": False,
             "add_raw_output": True,
+            "add_raw_input": True,
             "num_generations": 1,
             "num_rows": None,
             "use_default_structured_output": False,
@@ -156,6 +157,11 @@ class TestMagpieGenerator:
                     "name": "add_raw_output",
                     "optional": True,
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
+                },
+                {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
+                    "optional": True,
                 },
                 {
                     "name": "num_generations",

--- a/tests/unit/steps/tasks/test_base.py
+++ b/tests/unit/steps/tasks/test_base.py
@@ -107,7 +107,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_0",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_0", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_0",
@@ -115,7 +121,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_0",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_0", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_0",
@@ -123,7 +135,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_0",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_0", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_1",
@@ -131,7 +149,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_1",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_1", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_1",
@@ -139,7 +163,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_1",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_1", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_1",
@@ -147,7 +177,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_1",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_1", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_2",
@@ -155,7 +191,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_2",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_2", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_2",
@@ -163,7 +205,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_2",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_2", "role": "user"},
+                            ],
+                        },
                     },
                     {
                         "instruction": "test_2",
@@ -171,7 +219,13 @@ class TestTask:
                         "output": "output",
                         "info_from_input": "additional_info_2",
                         "model_name": "test",
-                        "distilabel_metadata": {"raw_output_task": "output"},
+                        "distilabel_metadata": {
+                            "raw_output_task": "output",
+                            "raw_input_task": [
+                                {"content": "", "role": "system"},
+                                {"content": "test_2", "role": "user"},
+                            ],
+                        },
                     },
                 ],
             ),
@@ -194,9 +248,48 @@ class TestTask:
                         ],
                         "model_name": "test",
                         "distilabel_metadata": [
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_0",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_0",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_0",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            # {"raw_output_task": "output"},
+                            # {"raw_output_task": "output"},
+                            # {"raw_output_task": "output"},
                         ],
                     },
                     {
@@ -210,9 +303,45 @@ class TestTask:
                         ],
                         "model_name": "test",
                         "distilabel_metadata": [
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_1",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_1",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_1",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
                         ],
                     },
                     {
@@ -226,9 +355,45 @@ class TestTask:
                         ],
                         "model_name": "test",
                         "distilabel_metadata": [
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
-                            {"raw_output_task": "output"},
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_2",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_2",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
+                            {
+                                "raw_output_task": "output",
+                                "raw_input_task": [
+                                    {
+                                        "content": "",
+                                        "role": "system",
+                                    },
+                                    {
+                                        "content": "test_2",
+                                        "role": "user",
+                                    },
+                                ],
+                            },
                         ],
                     },
                 ],
@@ -308,6 +473,7 @@ class TestTask:
         assert task.dump() == {
             "name": "task",
             "add_raw_output": True,
+            "add_raw_input": True,
             "input_mappings": {},
             "output_mappings": {},
             "resources": {
@@ -381,6 +547,11 @@ class TestTask:
                     "optional": True,
                 },
                 {
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
+                    "name": "add_raw_input",
+                    "optional": True,
+                },
+                {
                     "name": "num_generations",
                     "description": "The number of generations to be produced per input.",
                     "optional": True,
@@ -396,3 +567,46 @@ class TestTask:
         with Pipeline(name="unit-test-pipeline") as pipeline:
             new_task = DummyTask.from_dict(task.dump())
             assert isinstance(new_task, DummyTask)
+
+    @pytest.mark.parametrize(
+        "add_raw_output, add_raw_input",
+        [
+            (True, False),
+            (False, True),
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_add_raw_input_and_or_output(
+        self, add_raw_output: bool, add_raw_input: bool
+    ) -> None:
+        task = DummyTask(
+            llm=DummyLLM(),
+            add_raw_output=add_raw_output,
+            add_raw_input=add_raw_input,
+        )
+        assert task.add_raw_output is add_raw_output
+        assert task.add_raw_input is add_raw_input
+        task.load()
+        input = [
+            {"instruction": "test_0", "additional_info": "additional_info_0"},
+            {"instruction": "test_1", "additional_info": "additional_info_1"},
+            {"instruction": "test_2", "additional_info": "additional_info_2"},
+        ]
+        result = next(task.process(input))
+        import pprint
+
+        pprint.pprint(result)
+
+        if add_raw_output or add_raw_input:
+            assert "distilabel_metadata" in result[0].keys()
+            if add_raw_output:
+                assert (
+                    "raw_output_dummy_task_0" in result[0]["distilabel_metadata"].keys()
+                )
+            if add_raw_input:
+                assert (
+                    "raw_input_dummy_task_0" in result[0]["distilabel_metadata"].keys()
+                )
+        else:
+            assert "distilabel_metadata" not in result[0].keys()

--- a/tests/unit/steps/tasks/test_improving_text_embeddings.py
+++ b/tests/unit/steps/tasks/test_improving_text_embeddings.py
@@ -66,6 +66,7 @@ class TestEmbeddingTaskGenerator:
             add_raw_output=False,
             llm=MockLLM(output="[ 'A', 'B', 'C' ]"),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
 
@@ -122,6 +123,7 @@ class TestBitextRetrievalGenerator:
             add_raw_output=False,
             llm=MockLLM(output=json.dumps({"S1": "A", "S2": "B", "S3": "C"})),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
 
@@ -184,6 +186,7 @@ class TestMonolingualTripletGenerator:
             add_raw_output=False,
             llm=MockLLM(output=json.dumps({"S1": "A", "S2": "B", "S3": "C"})),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
         assert task.outputs == ["S1", "S2", "S3", "model_name"]
@@ -230,6 +233,7 @@ class TestGenerateLongTextMatchingData:
             add_raw_output=False,
             llm=MockLLM(output=json.dumps({"input": "A", "positive_document": "B"})),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
 
@@ -261,6 +265,7 @@ class TestGenerateShortTextMatchingData:
             add_raw_output=False,
             llm=MockLLM(output=json.dumps({"input": "A", "positive_document": "B"})),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
         assert task.outputs == ["input", "positive_document", "model_name"]
@@ -316,6 +321,7 @@ class TestGenerateTextClassificationData:
                 )
             ),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
         assert task.outputs == ["input_text", "label", "misleading_label", "model_name"]
@@ -387,6 +393,7 @@ class TestGenerateTextRetrievalData:
                 )
             ),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
         assert task.outputs == [

--- a/tests/unit/steps/tasks/test_instruction_backtranslation.py
+++ b/tests/unit/steps/tasks/test_instruction_backtranslation.py
@@ -76,6 +76,7 @@ class TestInstructionBacktranslation:
             name="instruction-backtranslation",
             llm=InstructionBacktranslationLLM(),
             pipeline=Pipeline(name="unit-test-pipeline"),
+            add_raw_input=False,
         )
         task.load()
 

--- a/tests/unit/steps/tasks/test_structured_generation.py
+++ b/tests/unit/steps/tasks/test_structured_generation.py
@@ -86,7 +86,9 @@ class TestStructuredGeneration:
     def test_process(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyStructuredLLM()
-        task = StructuredGeneration(name="task", llm=llm, pipeline=pipeline)
+        task = StructuredGeneration(
+            name="task", llm=llm, pipeline=pipeline, add_raw_input=False
+        )
         assert next(
             task.process(
                 [

--- a/tests/unit/steps/tasks/test_text_generation.py
+++ b/tests/unit/steps/tasks/test_text_generation.py
@@ -75,7 +75,9 @@ class TestTextGeneration:
     def test_process(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
-        task = TextGeneration(name="task", llm=llm, pipeline=pipeline)
+        task = TextGeneration(
+            name="task", llm=llm, pipeline=pipeline, add_raw_input=False
+        )
 
         assert next(task.process([{"instruction": "test"}])) == [
             {
@@ -125,7 +127,9 @@ class TestChatGeneration:
     def test_process(self) -> None:
         pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
-        task = ChatGeneration(name="task", llm=llm, pipeline=pipeline)
+        task = ChatGeneration(
+            name="task", llm=llm, pipeline=pipeline, add_raw_input=False
+        )
 
         assert next(
             task.process(

--- a/tests/unit/steps/tasks/test_ultrafeedback.py
+++ b/tests/unit/steps/tasks/test_ultrafeedback.py
@@ -50,6 +50,7 @@ class TestUltraFeedback:
             aspect="instruction-following",
             llm=UltraFeedbackLLM(),
             use_default_structured_output=False,
+            add_raw_input=False,
         )
         task.load()
 
@@ -74,6 +75,7 @@ class TestUltraFeedback:
             aspect="truthfulness",
             llm=UltraFeedbackLLM(),
             use_default_structured_output=False,
+            add_raw_input=False,
         )
         task.load()
 


### PR DESCRIPTION
## Description

Adds a new attribute to the `Tasks` to automatically include the formatted input in the `distilabel_metadata` column.

Example from the tests:

```python
class DummyTask(Task):
    @property
    def inputs(self) -> List[str]:
        return ["instruction", "additional_info"]

    def format_input(self, input: Dict[str, Any]) -> "ChatType":
        return [
            {"role": "system", "content": ""},
            {"role": "user", "content": input["instruction"]},
        ]

    @property
    def outputs(self) -> List[str]:
        return ["output", "info_from_input"]

    def format_output(
        self, output: Union[str, None], input: Union[Dict[str, Any], None] = None
    ) -> Dict[str, Any]:
        return {"output": output, "info_from_input": input["additional_info"]}  # type: ignore


task = DummyTask(
    llm=DummyLLM(),
    add_raw_output=True,
    add_raw_input=True,
)
task.load()
next(task.process([
    {"instruction": "test_0", "additional_info": "additional_info_0"},
]))
# {'additional_info': 'additional_info_0',
#  'distilabel_metadata': {'raw_input_dummy_task_0': [{'content': '',
#                                                      'role': 'system'},
#                                                     {'content': 'test_0',
#                                                      'role': 'user'}],
#                          'raw_output_dummy_task_0': 'output'},
#  'info_from_input': 'additional_info_0',
#  'instruction': 'test_0',
#  'model_name': 'test',
#  'output': 'output'}]
```

Example in the docs:

![image](https://github.com/user-attachments/assets/7ae0b0ef-6d87-46fc-ae00-788d65cf1cca)


Closes #698 