### PR TITLE
Fix `StructuredGeneration` examples and internal check

### DIFF
--- a/src/distilabel/llms/base.py
+++ b/src/distilabel/llms/base.py
@@ -428,7 +428,10 @@ class AsyncLLM(LLM):
         # We can deal with json schema or BaseModel, but we need to convert it to a BaseModel
         # for the Instructor client.
         schema = structured_output.get("schema", {})
-        if not issubclass(schema, BaseModel):
+
+        # If there's already a pydantic model, we don't need to do anything,
+        # otherwise, try to obtain one.
+        if not (inspect.isclass(schema) and issubclass(schema, BaseModel)):
             from distilabel.steps.tasks.structured_outputs.utils import (
                 json_schema_to_model,
             )

--- a/src/distilabel/steps/tasks/structured_generation.py
+++ b/src/distilabel/steps/tasks/structured_generation.py
@@ -69,8 +69,8 @@ class StructuredGeneration(Task):
                     {
                         "instruction": "Create an RPG character",
                         "structured_output": {
-                            "type": "json",
-                            "value": {
+                            "format": "json",
+                            "schema": {
                                 "properties": {
                                     "name": {
                                         "title": "Name",
@@ -105,7 +105,7 @@ class StructuredGeneration(Task):
         )
         ```
 
-        Generate structured output from a regex pattern:
+        Generate structured output from a regex pattern (only works with LLMs that support regex, the providers using outlines):
 
         ```python
         from distilabel.steps.tasks import StructuredGeneration
@@ -126,8 +126,8 @@ class StructuredGeneration(Task):
                     {
                         "instruction": "What's the weather like today in Seattle in Celsius degrees?",
                         "structured_output": {
-                            "type": "regex",
-                            "value": r"(\\d{1,2})°C"
+                            "format": "regex",
+                            "schema": r"(\\d{1,2})°C"
                         },
 
                     }

--- a/src/distilabel/steps/tasks/structured_outputs/outlines.py
+++ b/src/distilabel/steps/tasks/structured_outputs/outlines.py
@@ -14,6 +14,7 @@
 
 import importlib
 import importlib.util
+import inspect
 import json
 from typing import (
     Any,
@@ -101,6 +102,13 @@ def prepare_guided_output(
 
     format = structured_output.get("format")
     schema = structured_output.get("schema")
+
+    # If schema not informed (may be forgotten), try infering it
+    if not format:
+        if isinstance(schema, dict) or inspect.isclass(schema):
+            format = "json"
+        elif isinstance(schema, str):
+            format = "regex"
 
     if format == "json":
         return {


### PR DESCRIPTION
## Description

The examples of `StructuredGeneration` have been updated to show how the values can be informed, they are the same as a `TextGeneration` that takes a `structured_output` argument.

Both `AsyncLLM` and `LLM` (plus `InferenceEndpointsLLM`) take the same input:

```python
{"format": "json", "schema": "..."}
```

If the `format` is not informed (outlines requires that), we will try to infer it from the `schema`.

Closes #906 