### PR TITLE
Do not cancel in progress docs workflows

### DIFF
--- a/.github/workflows/docs-pr-close.yml
+++ b/.github/workflows/docs-pr-close.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [closed]
 
-concurrency: distilabel-docs
+concurrency:
+  group: distilabel-docs
+  cancel-in-progress: false
 
 jobs:
   cleanup:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -6,7 +6,9 @@ on:
       - opened
       - synchronize
 
-concurrency: distilabel-docs
+concurrency:
+  group: distilabel-docs
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,9 @@ on:
     tags:
       - "**"
 
-concurrency: distilabel-docs
+concurrency:
+  group: distilabel-docs
+  cancel-in-progress: false
 
 jobs:
   publish:


### PR DESCRIPTION
## Description

Docs workflows were getting cancelled by each other, as they shared the same concurrency group (so one it executed at a time), but `cancel-in-progress` parameter was `True` by default.