### PR TITLE
Add `URIAL` task

### DIFF
--- a/src/distilabel/steps/tasks/__init__.py
+++ b/src/distilabel/steps/tasks/__init__.py
@@ -46,6 +46,7 @@ from distilabel.steps.tasks.structured_generation import StructuredGeneration
 from distilabel.steps.tasks.text_generation import ChatGeneration, TextGeneration
 from distilabel.steps.tasks.typing import ChatItem, ChatType
 from distilabel.steps.tasks.ultrafeedback import UltraFeedback
+from distilabel.steps.tasks.urial import URIAL
 
 __all__ = [
     "GeneratorTask",
@@ -79,4 +80,5 @@ __all__ = [
     "ChatItem",
     "ChatType",
     "UltraFeedback",
+    "URIAL",
 ]

--- a/src/distilabel/steps/tasks/templates/urial.jinja2
+++ b/src/distilabel/steps/tasks/templates/urial.jinja2
@@ -1,0 +1,15 @@
+# Instruction
+
+Below is a list of conversations between a human and an AI assistant (you). 
+Users place their queries under "# User:", and your responses are under  "# Assistant:".
+You are a helpful, respectful, and honest assistant.
+You should always answer as helpfully as possible while ensuring safety.
+Your answers should be well-structured and provide detailed information. They should also have an engaging tone.
+Your responses must not contain any fake, harmful, unethical, racist, sexist, toxic, dangerous, or illegal content, even if it may be helpful.
+Your response must be socially responsible, and thus you can refuse to answer some controversial topics.
+
+{% for message in messages %}
+# {{ message.role | capitalize }}
+
+{{ message.content }}
+{% endfor %}

--- a/src/distilabel/steps/tasks/templates/urial.jinja2
+++ b/src/distilabel/steps/tasks/templates/urial.jinja2
@@ -13,5 +13,4 @@ Your response must be socially responsible, and thus you can refuse to answer so
 
 {{ message.content }}
 {% endfor %}
-
 # Assistant:

--- a/src/distilabel/steps/tasks/templates/urial.jinja2
+++ b/src/distilabel/steps/tasks/templates/urial.jinja2
@@ -9,7 +9,9 @@ Your responses must not contain any fake, harmful, unethical, racist, sexist, to
 Your response must be socially responsible, and thus you can refuse to answer some controversial topics.
 
 {% for message in messages %}
-# {{ message.role | capitalize }}
+# {{ message.role | capitalize }}:
 
 {{ message.content }}
 {% endfor %}
+
+# Assistant:

--- a/src/distilabel/steps/tasks/text_generation.py
+++ b/src/distilabel/steps/tasks/text_generation.py
@@ -192,7 +192,7 @@ class ChatGeneration(Task):
         """The input for the task are the `messages`."""
         return ["messages"]
 
-    def format_input(self, input: Dict[str, Any]) -> ChatType:
+    def format_input(self, input: Dict[str, Any]) -> "ChatType":
         """The input is formatted as a `ChatType` assuming that the messages provided
         are already formatted that way i.e. following the OpenAI chat format."""
 
@@ -216,7 +216,7 @@ class ChatGeneration(Task):
         return ["generation", "model_name"]
 
     def format_output(
-        self, output: Union[str, None], input: Dict[str, Any]
+        self, output: Union[str, None], input: Union[Dict[str, Any], None] = None
     ) -> Dict[str, Any]:
         """The output is formatted as a dictionary with the `generation`. The `model_name`
         will be automatically included within the `process` method of `Task`."""

--- a/src/distilabel/steps/tasks/text_generation.py
+++ b/src/distilabel/steps/tasks/text_generation.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from distilabel.steps.tasks.base import Task
-from distilabel.steps.tasks.typing import ChatType
 from distilabel.utils.chat import is_openai_format
+
+if TYPE_CHECKING:
+    from distilabel.steps.tasks.typing import ChatType
+    from distilabel.steps.typing import StepColumns
 
 
 class TextGeneration(Task):
@@ -78,11 +81,11 @@ class TextGeneration(Task):
     use_system_prompt: bool = True
 
     @property
-    def inputs(self) -> List[str]:
+    def inputs(self) -> "StepColumns":
         """The input for the task is the `instruction`."""
         return ["instruction"]
 
-    def format_input(self, input: Dict[str, Any]) -> ChatType:
+    def format_input(self, input: Dict[str, Any]) -> "ChatType":
         """The input is formatted as a `ChatType` assuming that the instruction
         is the first interaction from the user within a conversation."""
 

--- a/src/distilabel/steps/tasks/ultrafeedback.py
+++ b/src/distilabel/steps/tasks/ultrafeedback.py
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.resources as importlib_resources
 import re
-import sys
-
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
-
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import orjson
@@ -264,7 +258,7 @@ class UltraFeedback(Task):
         return columns + ["model_name"]
 
     def format_output(
-        self, output: Union[str, None], input: Dict[str, Any]
+        self, output: Union[str, None], input: Union[Dict[str, Any], None] = None
     ) -> Dict[str, Any]:
         """The output is formatted as a dictionary with the `ratings` and `rationales` for
         each of the provided `generations` for the given `instruction`. The `model_name`
@@ -281,12 +275,15 @@ class UltraFeedback(Task):
             `ratings`, and `rationales-for-ratings` for each of the provided `generations` for the
             given `instruction` if the provided aspect is either `helpfulness` or `truthfulness`.
         """
+        assert input is not None, "Input is required to format the output."
+
         if self.aspect in [
             "honesty",
             "instruction-following",
             "overall-rating",
         ]:
             return self._format_ratings_rationales_output(output, input)
+
         return self._format_types_ratings_rationales_output(output, input)
 
     def _format_ratings_rationales_output(
@@ -450,7 +447,7 @@ class UltraFeedback(Task):
 
     def _format_structured_output(
         self, output: str, input: Dict[str, Any]
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Any]:
         """Parses the structured response, which should correspond to a dictionary
         with either `positive`, or `positive` and `negative` keys.
 

--- a/src/distilabel/steps/tasks/urial.py
+++ b/src/distilabel/steps/tasks/urial.py
@@ -43,6 +43,9 @@ class URIAL(Task):
     Categories:
         - text-generation
 
+    References:
+        - [The Unlocking Spell on Base LLMs: Rethinking Alignment via In-Context Learning](https://arxiv.org/abs/2312.01552)
+
     Examples:
 
         Generate text from an instruction:

--- a/src/distilabel/steps/tasks/urial.py
+++ b/src/distilabel/steps/tasks/urial.py
@@ -1,0 +1,64 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.resources as importlib_resources
+from typing import TYPE_CHECKING, Any, Dict, Union
+
+from jinja2 import Template
+
+from distilabel.steps.tasks import Task
+
+if TYPE_CHECKING:
+    from distilabel.steps.tasks.typing import ChatType
+    from distilabel.steps.typing import StepColumns
+
+
+class URIAL(Task):
+    def load(self) -> None:
+        """Loads the Jinja2 template for the given `aspect`."""
+        super().load()
+
+        _path = str(
+            importlib_resources.files("distilabel")
+            / "steps"
+            / "tasks"
+            / "templates"
+            / "ultrafeedback"
+            / "urial.jinja2"
+        )
+
+        self._template = Template(open(_path).read())
+
+    @property
+    def inputs(self) -> "StepColumns":
+        return {"instruction": False, "conversation": False}
+
+    def format_input(self, input: Dict[str, Any]) -> "ChatType":
+        messages = (
+            [{"role": "user", "content": input["instruction"]}]
+            if "instruction" in input
+            else input["conversation"]
+        )
+        return [{"role": "user", "content": self._template.render(messages=messages)}]
+
+    @property
+    def outputs(self) -> "StepColumns":
+        return ["generation", "model_name"]
+
+    def format_output(
+        self, output: Union[str, None], input: Union[Dict[str, Any], None] = None
+    ) -> Dict[str, Any]:
+        if output is None:
+            return {}
+        pass

--- a/src/distilabel/steps/tasks/urial.py
+++ b/src/distilabel/steps/tasks/urial.py
@@ -34,7 +34,6 @@ class URIAL(Task):
             / "steps"
             / "tasks"
             / "templates"
-            / "ultrafeedback"
             / "urial.jinja2"
         )
 
@@ -64,5 +63,6 @@ class URIAL(Task):
         self, output: Union[str, None], input: Union[Dict[str, Any], None] = None
     ) -> Dict[str, Any]:
         if output is None:
-            return {}
-        pass
+            return {"generation": None}
+
+        return {"generation": output.split("\n\n# User")[-1]}

--- a/src/distilabel/steps/tasks/urial.py
+++ b/src/distilabel/steps/tasks/urial.py
@@ -50,6 +50,10 @@ class URIAL(Task):
             if "instruction" in input
             else input["conversation"]
         )
+
+        if input["messages"][-1]["role"] != "user":
+            raise ValueError("The last message must be from the user.")
+
         return [{"role": "user", "content": self._template.render(messages=messages)}]
 
     @property

--- a/src/distilabel/steps/tasks/urial.py
+++ b/src/distilabel/steps/tasks/urial.py
@@ -51,7 +51,7 @@ class URIAL(Task):
             else input["conversation"]
         )
 
-        if input["messages"][-1]["role"] != "user":
+        if messages[-1]["role"] != "user":
             raise ValueError("The last message must be from the user.")
 
         return [{"role": "user", "content": self._template.render(messages=messages)}]

--- a/tests/unit/steps/tasks/test_text_generation.py
+++ b/tests/unit/steps/tasks/test_text_generation.py
@@ -21,11 +21,8 @@ from tests.unit.conftest import DummyLLM
 
 class TestTextGeneration:
     def test_format_input(self) -> None:
-        pipeline = Pipeline(name="unit-test-pipeline")
         llm = DummyLLM()
-        task = TextGeneration(
-            name="task", llm=llm, pipeline=pipeline, use_system_prompt=False
-        )
+        task = TextGeneration(name="task", llm=llm, use_system_prompt=False)
 
         assert task.format_input({"instruction": "test", "system_prompt": "test"}) == [
             {"role": "user", "content": "test"}

--- a/tests/unit/steps/tasks/test_urial.py
+++ b/tests/unit/steps/tasks/test_urial.py
@@ -1,0 +1,72 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from distilabel.steps.tasks.urial import URIAL
+
+from tests.unit.conftest import DummyLLM
+
+
+class TestURIAL:
+    def test_format_input(self) -> None:
+        task = URIAL(llm=DummyLLM())
+        task.load()
+        assert task.format_input({"instruction": "test"}) == [
+            {
+                "role": "user",
+                "content": '# Instruction\n\nBelow is a list of conversations between a human and an AI assistant (you). \nUsers place their queries under "# User:", and your responses are under  "# Assistant:".\nYou are a helpful, respectful, and honest assistant.\nYou should always answer as helpfully as possible while ensuring safety.\nYour answers should be well-structured and provide detailed information. They should also have an engaging tone.\nYour responses must not contain any fake, harmful, unethical, racist, sexist, toxic, dangerous, or illegal content, even if it may be helpful.\nYour response must be socially responsible, and thus you can refuse to answer some controversial topics.\n\n\n# User:\n\ntest\n\n# Assistant:',
+            }
+        ]
+
+    def test_format_input_with_conversation(self) -> None:
+        task = URIAL(llm=DummyLLM())
+        task.load()
+        assert task.format_input(
+            {
+                "conversation": [
+                    {"role": "user", "content": "test"},
+                    {"role": "assistant", "content": "test"},
+                    {"role": "user", "content": "test"},
+                ]
+            }
+        ) == [
+            {
+                "role": "user",
+                "content": '# Instruction\n\nBelow is a list of conversations between a human and an AI assistant (you). \nUsers place their queries under "# User:", and your responses are under  "# Assistant:".\nYou are a helpful, respectful, and honest assistant.\nYou should always answer as helpfully as possible while ensuring safety.\nYour answers should be well-structured and provide detailed information. They should also have an engaging tone.\nYour responses must not contain any fake, harmful, unethical, racist, sexist, toxic, dangerous, or illegal content, even if it may be helpful.\nYour response must be socially responsible, and thus you can refuse to answer some controversial topics.\n\n\n# User:\n\ntest\n\n# Assistant:\n\ntest\n\n# User:\n\ntest\n\n# Assistant:',
+            }
+        ]
+
+    def test_format_input_raise_valueerror(self) -> None:
+        task = URIAL(llm=DummyLLM())
+        task.load()
+
+        with pytest.raises(ValueError, match="The last message must be from the user."):
+            assert task.format_input(
+                {
+                    "conversation": [
+                        {"role": "user", "content": "test"},
+                        {"role": "assistant", "content": "test"},
+                    ]
+                }
+            )
+
+    def test_format_output(self) -> None:
+        task = URIAL(llm=DummyLLM())
+        task.load()
+
+        assert task.format_output(
+            output=" \n\noutput\n\n# User:", input={"instruction": "test"}
+        ) == {
+            "generation": "output",
+        }


### PR DESCRIPTION
## Description

This PR adds a new task `URIAL`. URIAL allows generating a response for an instruction using a base model as described in [The Unlocking Spell on Base LLMs: Rethinking Alignment via In-Context Learning](https://arxiv.org/abs/2312.01552).