### PR TITLE
Fix passing `base_url` in `model_id` in `InferenceEndpointsLLM`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@ sources = src/distilabel tests
 
 .PHONY: format
 format:
+	ruff --version
 	ruff check --fix $(sources)
 	ruff format $(sources)
 
 .PHONY: lint
 lint:
+	ruff --version
 	ruff check $(sources)
 	ruff format --check $(sources)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ distilabel = "distilabel.cli.app:app"
 "distilabel/components-gallery" = "distilabel.utils.mkdocs.components_gallery:ComponentsGalleryPlugin"
 
 [project.optional-dependencies]
-dev = ["ruff == 0.4.5", "pre-commit >= 3.5.0"]
+dev = ["ruff == 0.6.2", "pre-commit >= 3.5.0"]
 docs = [
     "mkdocs-material >=9.5.17",
     "mkdocstrings[python] >= 0.24.0",

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -6,7 +6,7 @@ python_version=$(python -c "import sys; print(sys.version_info[:2])")
 
 python -m pip install uv
 
-uv pip install --system -e ".[dev,tests,anthropic,argilla,cohere,groq,hf-inference-endpoints,hf-transformers,litellm,llama-cpp,ollama,openai,outlines,vertexai,mistralai,instructor,sentence-transformers,faiss-cpu]"
+uv pip install --system -e ".[anthropic,argilla,cohere,groq,hf-inference-endpoints,hf-transformers,litellm,llama-cpp,ollama,openai,outlines,vertexai,mistralai,instructor,sentence-transformers,faiss-cpu]"
 
 if [ "${python_version}" != "(3, 12)" ]; then
   uv pip install --system -e .[ray]
@@ -14,3 +14,5 @@ fi
 
 ./scripts/install_cpu_vllm.sh
 uv pip install --system git+https://github.com/argilla-io/LLM-Blender.git
+
+uv pip install --system -e ".[dev,tests]"

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -281,7 +281,7 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
             self._model_name = client.repository
 
         self._aclient = AsyncInferenceClient(
-            model=self.base_url,
+            base_url=self.base_url,
             token=self.api_key.get_secret_value(),
         )
 

--- a/src/distilabel/llms/vllm.py
+++ b/src/distilabel/llms/vllm.py
@@ -37,7 +37,7 @@ from distilabel.mixins.runtime_parameters import RuntimeParameter
 from distilabel.steps.tasks.typing import FormattedInput, OutlinesStructuredOutputType
 
 if TYPE_CHECKING:
-    from openai import OpenAI
+    from openai import OpenAI  # noqa
     from transformers import PreTrainedTokenizer
     from vllm import LLM as _vLLM
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from typing import TYPE_CHECKING, List
+
+import pytest
+
+if TYPE_CHECKING:
+    from _pytest.config import Config
+    from _pytest.nodes import Item
+
+
+def pytest_configure(config: "Config") -> None:
+    config.addinivalue_line(
+        "markers",
+        "skip_python_versions(versions): mark test to be skipped on specified Python versions",
+    )
+
+
+def pytest_collection_modifyitems(config: "Config", items: List["Item"]) -> None:
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    for item in items:
+        skip_versions_marker = item.get_closest_marker("skip_python_versions")
+        if skip_versions_marker:
+            versions_to_skip = skip_versions_marker.args[0]
+            if current_version in versions_to_skip:
+                skip_reason = f"Test not supported on Python {current_version}"
+                item.add_marker(pytest.mark.skip(reason=skip_reason))

--- a/tests/integration/test_ray_pipeline.py
+++ b/tests/integration/test_ray_pipeline.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from typing import TYPE_CHECKING, Dict, List
 
 import pytest
@@ -149,9 +148,7 @@ class GenerateResponse(Step):
         return ["response"]
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="`ray` is not compatible with `python>=3.12`"
-)
+@pytest.mark.skip_python_versions(["3.12"])
 def test_run_pipeline() -> None:
     import ray
     from ray.cluster_utils import Cluster

--- a/tests/unit/pipeline/test_ray.py
+++ b/tests/unit/pipeline/test_ray.py
@@ -15,8 +15,6 @@
 from typing import Generator
 
 import pytest
-import ray
-from ray.cluster_utils import Cluster
 
 from distilabel.llms.vllm import vLLM
 from distilabel.pipeline.ray import RayPipeline
@@ -27,6 +25,9 @@ from distilabel.utils.serialization import TYPE_INFO_KEY
 
 @pytest.fixture
 def ray_test_cluster() -> Generator[None, None, None]:
+    import ray
+    from ray.cluster_utils import Cluster
+
     cluster = Cluster(
         initialize_head=True,
         head_node_args={
@@ -54,11 +55,13 @@ class TestRayPipeline:
             "name": "Pipeline",
         }
 
+    @pytest.mark.skip_python_versions(["3.12"])
     def test_get_ray_gpus_per_node(self) -> None:
         pipeline = RayPipeline(name="unit-test")
         pipeline._init_ray()
         assert list(pipeline._ray_node_ids.values()) == [8, 8, 8, 8]
 
+    @pytest.mark.skip_python_versions(["3.12"])
     def test_create_vllm_placement_group(self) -> None:
         with RayPipeline(name="unit-test") as pipeline:
             step_1 = TextGeneration(
@@ -128,6 +131,7 @@ class TestRayPipeline:
         pipeline._create_vllm_placement_group(step_5)
         assert sum(pipeline._ray_node_ids.values()) == num_gpus - allocated_gpus
 
+    @pytest.mark.skip_python_versions(["3.12"])
     def test_create_vllm_placement_group_raise_valueerror(self) -> None:
         with RayPipeline(name="unit-test") as pipeline:
             step = TextGeneration(

--- a/tests/unit/pipeline/test_ray.py
+++ b/tests/unit/pipeline/test_ray.py
@@ -44,6 +44,7 @@ def ray_test_cluster() -> Generator[None, None, None]:
     ray.shutdown()
 
 
+@pytest.mark.skip_python_versions(["3.12"])
 @pytest.mark.usefixtures("ray_test_cluster")
 class TestRayPipeline:
     def test_dump(self) -> None:
@@ -55,13 +56,11 @@ class TestRayPipeline:
             "name": "Pipeline",
         }
 
-    @pytest.mark.skip_python_versions(["3.12"])
     def test_get_ray_gpus_per_node(self) -> None:
         pipeline = RayPipeline(name="unit-test")
         pipeline._init_ray()
         assert list(pipeline._ray_node_ids.values()) == [8, 8, 8, 8]
 
-    @pytest.mark.skip_python_versions(["3.12"])
     def test_create_vllm_placement_group(self) -> None:
         with RayPipeline(name="unit-test") as pipeline:
             step_1 = TextGeneration(
@@ -131,7 +130,6 @@ class TestRayPipeline:
         pipeline._create_vllm_placement_group(step_5)
         assert sum(pipeline._ray_node_ids.values()) == num_gpus - allocated_gpus
 
-    @pytest.mark.skip_python_versions(["3.12"])
     def test_create_vllm_placement_group_raise_valueerror(self) -> None:
         with RayPipeline(name="unit-test") as pipeline:
             step = TextGeneration(


### PR DESCRIPTION
## Description

We were passing the `base_url` using the `model_id` argument to the `huggingface_hub.AsyncInferenceClient`. This worked if using Inference Endpoint solutions, but if using a local TGI deployment, it didn't causing the `chat_completion` endpoint to return a 422.