### PR TITLE
Update `make_generator_step` to set pipeline to step and add edge to steps in trophic level 1

### DIFF
--- a/src/distilabel/pipeline/_dag.py
+++ b/src/distilabel/pipeline/_dag.py
@@ -154,8 +154,9 @@ class DAG(_Serializable):
         Args:
             step: The generator step that will be set as the new root.
         """
-        self.add_step(step)
-        self.add_edge(step.name, next(iter(self)))
+        for other_step, level in self.trophic_levels.items():
+            if level == 1 and other_step != step.name:
+                self.add_edge(step.name, other_step)  # type: ignore
 
     @cached_property
     def root_steps(self) -> Set[str]:
@@ -175,14 +176,14 @@ class DAG(_Serializable):
         """
         return {node for node, degree in self.G.out_degree() if degree == 0}
 
-    @cached_property
+    @property
     def trophic_levels(self) -> Dict[str, int]:
         """The trophic level of each step in the DAG.
 
         Returns:
             A dictionary with the trophic level of each step.
         """
-        return {step: int(level) for step, level in nx.trophic_levels(self.G).items()}
+        return nx.trophic_levels(self.G)
 
     def get_step_predecessors(self, step_name: str) -> Iterable[str]:
         """Gets the predecessors of a step.

--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -471,7 +471,7 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
                     f" `GeneratorStep`: {step}",
                     page="sections/how_to_guides/basic/step/#types-of-steps",
                 )
-        loader = make_generator_step(dataset)
+        loader = make_generator_step(dataset, self)
         self.dag.add_root_step(loader)
 
     def get_runtime_parameters_info(self) -> "PipelineRuntimeParametersInfo":

--- a/src/distilabel/steps/generators/utils.py
+++ b/src/distilabel/steps/generators/utils.py
@@ -21,11 +21,13 @@ from distilabel.errors import DistilabelUserError
 from distilabel.steps.base import StepResources
 
 if TYPE_CHECKING:
+    from distilabel.pipeline.base import BasePipeline
     from distilabel.steps import GeneratorStep
 
 
 def make_generator_step(
     dataset: Union[Dataset, pd.DataFrame, List[Dict[str, str]]],
+    pipeline: "BasePipeline",
     batch_size: int = 50,
     input_mappings: Optional[Dict[str, str]] = None,
     output_mappings: Optional[Dict[str, str]] = None,
@@ -52,6 +54,7 @@ def make_generator_step(
 
     if isinstance(dataset, list):
         return LoadDataFromDicts(
+            pipeline=pipeline,
             data=dataset,
             batch_size=batch_size,
             input_mappings=input_mappings or {},
@@ -70,6 +73,7 @@ def make_generator_step(
         )
 
     loader = LoadDataFromHub(
+        pipeline=pipeline,
         repo_id="placeholder_name",
         batch_size=batch_size,
         input_mappings=input_mappings or {},

--- a/src/distilabel/steps/generators/utils.py
+++ b/src/distilabel/steps/generators/utils.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 def make_generator_step(
     dataset: Union[Dataset, pd.DataFrame, List[Dict[str, str]]],
-    pipeline: "BasePipeline",
+    pipeline: Union["BasePipeline", None] = None,
     batch_size: int = 50,
     input_mappings: Optional[Dict[str, str]] = None,
     output_mappings: Optional[Dict[str, str]] = None,

--- a/tests/unit/steps/generators/test_utils.py
+++ b/tests/unit/steps/generators/test_utils.py
@@ -18,7 +18,8 @@ import pandas as pd
 import pytest
 from datasets import Dataset
 
-from distilabel.steps import make_generator_step
+from distilabel.pipeline.local import Pipeline
+from distilabel.steps.generators.utils import make_generator_step
 
 data = [{"instruction": "Tell me a joke."}] * 10
 
@@ -26,7 +27,7 @@ data = [{"instruction": "Tell me a joke."}] * 10
 @pytest.mark.parametrize("dataset", (data, Dataset.from_list(data), pd.DataFrame(data)))
 def test_make_generator_step(
     dataset: Union[Dataset, pd.DataFrame, List[Dict[str, str]]],
-):
+) -> None:
     batch_size = 5
     load_dataset = make_generator_step(
         dataset, batch_size=batch_size, output_mappings={"instruction": "other"}
@@ -40,3 +41,9 @@ def test_make_generator_step(
         assert isinstance(load_dataset.data, list)
 
     assert load_dataset.output_mappings == {"instruction": "other"}
+
+
+def test_make_generator_step_with_pipeline() -> None:
+    pipeline = Pipeline()
+    load_dataset = make_generator_step(data, pipeline=pipeline)
+    assert load_dataset.pipeline == pipeline


### PR DESCRIPTION
## Description

This PR updates adding a `Step` created with `make_generator_step` so its `pipeline` attribute gets assigned the pipeline to which it will be added. In addition, it modifies the `add_root_step` method so all the steps in the first trophic level gets connected to the `GeneratorStep` created with `make_generator_step` function.