### PR TITLE
Fix applying input mapping when mapping overrides another column

### DIFF
--- a/src/distilabel/steps/base.py
+++ b/src/distilabel/steps/base.py
@@ -670,15 +670,12 @@ class Step(_Step, ABC):
                 for k, v in row.items():
                     renamed_key = reverted_input_mappings.get(k, k)
 
-                    # `renamed_key` will replace another key after renaming. Store the
-                    # value of the key to be replaced, so we can recover it after applying
-                    # output mappings. If `len(inputs) > 1`, then we can't recover the
-                    # original key, as the `Step` logic could have aggregated the values
-                    # of the keys.
-                    if renamed_key in row and len(inputs) == 1:
-                        overriden_keys[renamed_key] = row[renamed_key]
+                    if renamed_key not in renamed_row or k != renamed_key:
+                        renamed_row[renamed_key] = v
 
-                    renamed_row[renamed_key] = v
+                        if k != renamed_key and renamed_key in row and len(inputs) == 1:
+                            overriden_keys[renamed_key] = row[renamed_key]
+
                 overriden_inputs.append(overriden_keys)
                 renamed_row_inputs.append(renamed_row)
             renamed_inputs.append(renamed_row_inputs)

--- a/tests/unit/steps/test_base.py
+++ b/tests/unit/steps/test_base.py
@@ -251,6 +251,42 @@ class TestStep:
             {"prompt": "hello 3", "generation": "unit test"},
         ]
 
+    def test_process_applying_mappings_and_overriden_inputs(self) -> None:
+        step = DummyStep(
+            name="dummy",
+            pipeline=Pipeline(name="unit-test-pipeline"),
+            input_mappings={"instruction": "prompt"},
+            output_mappings={"response": "generation"},
+        )
+
+        outputs = next(
+            step.process_applying_mappings(
+                [
+                    {"prompt": "hello 1", "instruction": "overriden 1"},
+                    {"prompt": "hello 2", "instruction": "overriden 2"},
+                    {"prompt": "hello 3", "instruction": "overriden 3"},
+                ]
+            )
+        )
+
+        assert outputs == [
+            {
+                "prompt": "hello 1",
+                "generation": "unit test",
+                "instruction": "overriden 1",
+            },
+            {
+                "prompt": "hello 2",
+                "generation": "unit test",
+                "instruction": "overriden 2",
+            },
+            {
+                "prompt": "hello 3",
+                "generation": "unit test",
+                "instruction": "overriden 3",
+            },
+        ]
+
     def test_connect(self) -> None:
         @step(inputs=["instruction"], outputs=["generation"])
         def GenerationStep(input: StepInput):


### PR DESCRIPTION
## Description

Before, if we provided an input like `{"instruction": "Resolve 2 + 2", "response" : "2+2 is 4", "response_base": "2+2 is 4"}` with an input mapping like `{"response": "response_base"}` then the output would be `{"instruction": "Resolve 2 + 2", "response_base": "2+2 is 4", ...output columns}`. The mapping has overriden/replaced the original `response` column, but it hasn't recovered it after processing.

This PR fixes this behaviour.