### PR TITLE
fix: regex expression in POSITIVE_NEGATIVE

### DIFF
--- a/src/distilabel/steps/tasks/sentence_transformers.py
+++ b/src/distilabel/steps/tasks/sentence_transformers.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 GenerationAction = Literal["paraphrase", "semantically-similar", "query", "answer"]
 
 POSITIVE_NEGATIVE_PAIR_REGEX = re.compile(
-    r"## Positive\s+(.*?)(?:\s+## Negative\s+(.*?))?\s*$",
+    r"\s*## Positive\s+(.*?)(?:\s+## Negative\s+(.*?))?\s*$",
     re.DOTALL,
 )
 


### PR DESCRIPTION
Just a very small change to the POSITIVE_NEGATIVE_PAIR_REGEX. Checking the raw output, for instance, here: https://huggingface.co/datasets/distilabel-internal-testing/example-retrieval-reranking-dataset?row=0. Don't know why, but the LLM adds a \s just before ##Positive. So, it was not possible to capture it without this small change.