### PR TITLE
Add `logging_handlers` argument

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -312,6 +312,7 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
         storage_parameters: Optional[Dict[str, Any]] = None,
         use_fs_to_pass_data: bool = False,
         dataset: Optional["InputDataset"] = None,
+        logging_handlers: Optional[List[logging.Handler]] = None,
     ) -> "Distiset":  # type: ignore
         """Run the pipeline. It will set the runtime parameters for the steps and validate
         the pipeline.
@@ -338,6 +339,9 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
             dataset: If given, it will be used to create a `GeneratorStep` and put it as the
                 root step. Convenient method when you have already processed the dataset in
                 your script and just want to pass it already processed. Defaults to `None`.
+            logging_handlers: A list of logging handlers that will be used to log the
+                output of the pipeline. This argument can be useful so the logging messages
+                can be extracted and used in a different context. Defaults to `None`.
 
         Returns:
             The `Distiset` created by the pipeline.
@@ -356,7 +360,9 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
             self._add_dataset_generator_step(dataset)
 
         setup_logging(
-            log_queue=self._log_queue, filename=str(self._cache_location["log_file"])
+            log_queue=self._log_queue,
+            filename=str(self._cache_location["log_file"]),
+            logging_handlers=logging_handlers,
         )
 
         # Set the name of the pipeline if it's the default one. This should be called

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -16,7 +16,17 @@ import multiprocessing as mp
 import signal
 import sys
 from multiprocessing.pool import Pool
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+    cast,
+)
 
 import tblib
 
@@ -30,6 +40,7 @@ from distilabel.utils.logging import setup_logging, stop_logging
 from distilabel.utils.ray import script_executed_in_ray_cluster
 
 if TYPE_CHECKING:
+    import logging
     from queue import Queue
 
     from distilabel.distiset import Distiset
@@ -141,6 +152,7 @@ class Pipeline(BasePipeline):
         storage_parameters: Optional[Dict[str, Any]] = None,
         use_fs_to_pass_data: bool = False,
         dataset: Optional["InputDataset"] = None,
+        logging_handlers: Optional[List["logging.Handler"]] = None,
     ) -> "Distiset":
         """Runs the pipeline.
 
@@ -163,6 +175,9 @@ class Pipeline(BasePipeline):
             dataset: If given, it will be used to create a `GeneratorStep` and put it as the
                 root step. Convenient method when you have already processed the dataset in
                 your script and just want to pass it already processed. Defaults to `None`.
+            logging_handlers: A list of logging handlers that will be used to log the
+                output of the pipeline. This argument can be useful so the logging messages
+                can be extracted and used in a different context. Defaults to `None`.
 
         Returns:
             The `Distiset` created by the pipeline.

--- a/src/distilabel/pipeline/local.py
+++ b/src/distilabel/pipeline/local.py
@@ -198,11 +198,12 @@ class Pipeline(BasePipeline):
         self._log_queue = cast("Queue[Any]", mp.Queue())
 
         if distiset := super().run(
-            parameters,
-            use_cache,
-            storage_parameters,
-            use_fs_to_pass_data,
+            parameters=parameters,
+            use_cache=use_cache,
+            storage_parameters=storage_parameters,
+            use_fs_to_pass_data=use_fs_to_pass_data,
             dataset=dataset,
+            logging_handlers=logging_handlers,
         ):
             return distiset
 

--- a/src/distilabel/pipeline/ray.py
+++ b/src/distilabel/pipeline/ray.py
@@ -25,6 +25,7 @@ from distilabel.utils.logging import setup_logging, stop_logging
 from distilabel.utils.serialization import TYPE_INFO_KEY
 
 if TYPE_CHECKING:
+    import logging
     from os import PathLike
     from queue import Queue
 
@@ -82,6 +83,7 @@ class RayPipeline(BasePipeline):
         storage_parameters: Optional[Dict[str, Any]] = None,
         use_fs_to_pass_data: bool = False,
         dataset: Optional["InputDataset"] = None,
+        logging_handlers: Optional[List["logging.Handler"]] = None,
     ) -> "Distiset":
         """Runs the pipeline in the Ray cluster.
 
@@ -104,6 +106,9 @@ class RayPipeline(BasePipeline):
             dataset: If given, it will be used to create a `GeneratorStep` and put it as the
                 root step. Convenient method when you have already processed the dataset in
                 your script and just want to pass it already processed. Defaults to `None`.
+            logging_handlers: A list of logging handlers that will be used to log the
+                output of the pipeline. This argument can be useful so the logging messages
+                can be extracted and used in a different context. Defaults to `None`.
 
         Returns:
             The `Distiset` created by the pipeline.

--- a/src/distilabel/pipeline/ray.py
+++ b/src/distilabel/pipeline/ray.py
@@ -125,11 +125,12 @@ class RayPipeline(BasePipeline):
         )
 
         if distiset := super().run(
-            parameters,
-            use_cache,
-            storage_parameters,
-            use_fs_to_pass_data,
+            parameters=parameters,
+            use_cache=use_cache,
+            storage_parameters=storage_parameters,
+            use_fs_to_pass_data=use_fs_to_pass_data,
             dataset=dataset,
+            logging_handlers=logging_handlers,
         ):
             return distiset
 


### PR DESCRIPTION
## Description

This PR adds `logging_handlers` argument to the `run` method of the pipelines, so the user can provide logging handlers that will receive the messages of the pipeline. This is useful as for example, a Gradio app could create a logging handler that dumps the logging messages of the pipeline in a `gr.Textbox`