### PR TITLE
[DOCS] Add tips in the docs to avoid overloading Free Serverless Endpoints

### DIFF
--- a/docs/sections/getting_started/faq.md
+++ b/docs/sections/getting_started/faq.md
@@ -45,3 +45,18 @@ hide:
 
 ??? faq "Can `distilabel` be used with [OpenAI Batch API](https://platform.openai.com/docs/guides/batch)?"
     Yes, `distilabel` is integrated with OpenAI Batch API via [OpenAILLM][distilabel.llms.openai.OpenAILLM]. Check [LLMs - Offline Batch Generation](../how_to_guides/basic/llm/index.md#offline-batch-generation) for a small example on how to use it and [Advanced - Offline Batch Generation](../how_to_guides/advanced/offline_batch_generation.md) for a more detailed guide.
+
+??? faq "Prevent overloads on [Free Serverless Endpoints][distilabel.llms.huggingface.InferenceEndpointsLLM]"
+    When running a task using the [InferenceEndpointsLLM][distilabel.llms.huggingface.InferenceEndpointsLLM] with Free Serverless Endpoints, you may be facing some errors if you let the batch size to the default (set at 50 by default). Try to lower the value, or even better set `input_batch_size=1` in your task. It may take a longer time to finish, but please remember this is a free service.
+
+    ```python
+    from distilabel.llms.huggingface import InferenceEndpointsLLM
+    from distilabel.steps import TextGeneration
+
+    TextGeneration(
+        llm=InferenceEndpointsLLM(
+            model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+        ),
+        input_batch_size=1
+    )
+    ```

--- a/scripts/install_cpu_vllm.sh
+++ b/scripts/install_cpu_vllm.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Updating system and installing build dependencies..."
 sudo apt-get update -y
-sudo apt-get install -y gcc-12 g++-12 libnuma-dev cmake
+sudo apt-get install -y gcc-12 g++-12 libnuma-dev cmake libdnnl-dev
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 
 echo "Python version:"

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -74,7 +74,7 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
         `:hugging:`
 
     Examples:
-        Free serverless Inference API (set the `input_batch_size=1` to avoid overloadings!):
+        Free serverless Inference API, set the input_batch_size of the Task that uses this to avoid Model is overloaded:
 
         ```python
         from distilabel.llms.huggingface import InferenceEndpointsLLM

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -74,7 +74,7 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
         `:hugging:`
 
     Examples:
-        Free serverless Inference API:
+        Free serverless Inference API (set the `input_batch_size=1` to avoid overloadings!):
 
         ```python
         from distilabel.llms.huggingface import InferenceEndpointsLLM

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -80,7 +80,7 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
         from distilabel.llms.huggingface import InferenceEndpointsLLM
 
         llm = InferenceEndpointsLLM(
-            model_id="mistralai/Mistral-7B-Instruct-v0.2",
+            model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
         )
 
         llm.load()

--- a/src/distilabel/utils/docstring.py
+++ b/src/distilabel/utils/docstring.py
@@ -165,7 +165,8 @@ def parse_google_docstring(func: Callable) -> Docstring:  # noqa: C901
         elif section_name == "examples":
             # Parse examples into a dictionary
             example_items = re.findall(
-                r"(\w[\w\s]*?):\s*\n?\s*```python\n(.*?)\n\s*```",
+                r"""([\w,()'][\w\s,()=`!'"]*?):\s*\n?\s*```python\n(.*?)\n\s*```""",
+                # r"(\w[\w\s]*?):\s*\n?\s*```python\n(.*?)\n\s*```",
                 section_content,
                 re.DOTALL,
             )


### PR DESCRIPTION
## Description

To avoid unexpected errors due to overloading the Free Serverless Endpoints, we can just lower the input batch size, this PR adds hints in the docs to help the users it.

Title entry in the components gallery:

![image](https://github.com/user-attachments/assets/4e8ef6a6-b175-4858-b450-ebeed91a85c8)

FAQ entry:

![image](https://github.com/user-attachments/assets/ab930b1e-696d-4f4b-a3b5-aed09c0b19ed)
