### PR TITLE
Update `system_prompt` attribute for adding probabilities in `MagpieBase`

### DIFF
--- a/src/distilabel/steps/tasks/magpie/base.py
+++ b/src/distilabel/steps/tasks/magpie/base.py
@@ -113,25 +113,6 @@ class MagpieBase(RuntimeParametersMixin):
                     )
         return system_prompts
 
-    @property
-    def outputs(self) -> "StepColumns":
-        """Either a multi-turn conversation or the instruction generated."""
-        outputs = []
-
-        if self.only_instruction:
-            outputs.append("instruction")
-        elif self.n_turns == 1:
-            outputs.extend(["instruction", "response"])
-        else:
-            outputs.append("conversation")
-
-        if isinstance(self.system_prompt, dict):
-            outputs.append("system_prompt_key")
-
-        outputs.append("model_name")
-
-        return outputs
-
     def _prepare_inputs_for_instruction_generation(
         self, inputs: List[Dict[str, Any]]
     ) -> Tuple[List["ChatType"], Union[str, None]]:
@@ -338,7 +319,7 @@ class MagpieBase(RuntimeParametersMixin):
         ]
 
 
-class Magpie(MagpieBase, Task):
+class Magpie(Task, MagpieBase):
     """Generates conversations using an instruct fine-tuned LLM.
 
     Magpie is a neat method that allows generating user instructions with no seed data
@@ -540,6 +521,25 @@ class Magpie(MagpieBase, Task):
     def format_input(self, input: Dict[str, Any]) -> "ChatType":
         """Does nothing."""
         return []
+
+    @property
+    def outputs(self) -> "StepColumns":
+        """Either a multi-turn conversation or the instruction generated."""
+        outputs = []
+
+        if self.only_instruction:
+            outputs.append("instruction")
+        elif self.n_turns == 1:
+            outputs.extend(["instruction", "response"])
+        else:
+            outputs.append("conversation")
+
+        if isinstance(self.system_prompt, dict):
+            outputs.append("system_prompt_key")
+
+        outputs.append("model_name")
+
+        return outputs
 
     def format_output(
         self,

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -23,10 +23,10 @@ from distilabel.steps.tasks.base import GeneratorTask
 from distilabel.steps.tasks.magpie.base import MagpieBase
 
 if TYPE_CHECKING:
-    from distilabel.steps.typing import GeneratorStepOutput
+    from distilabel.steps.typing import GeneratorStepOutput, StepColumns
 
 
-class MagpieGenerator(MagpieBase, GeneratorTask):
+class MagpieGenerator(GeneratorTask, MagpieBase):
     """Generator task the generates instructions or conversations using Magpie.
 
     Magpie is a neat method that allows generating user instructions with no seed data
@@ -264,6 +264,25 @@ class MagpieGenerator(MagpieBase, GeneratorTask):
             )
 
         self.llm.use_magpie_template = True
+
+    @property
+    def outputs(self) -> "StepColumns":
+        """Either a multi-turn conversation or the instruction generated."""
+        outputs = []
+
+        if self.only_instruction:
+            outputs.append("instruction")
+        elif self.n_turns == 1:
+            outputs.extend(["instruction", "response"])
+        else:
+            outputs.append("conversation")
+
+        if isinstance(self.system_prompt, dict):
+            outputs.append("system_prompt_key")
+
+        outputs.append("model_name")
+
+        return outputs
 
     def format_output(
         self,

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -23,10 +23,10 @@ from distilabel.steps.tasks.base import GeneratorTask
 from distilabel.steps.tasks.magpie.base import MagpieBase
 
 if TYPE_CHECKING:
-    from distilabel.steps.typing import GeneratorStepOutput, StepColumns
+    from distilabel.steps.typing import GeneratorStepOutput
 
 
-class MagpieGenerator(GeneratorTask, MagpieBase):
+class MagpieGenerator(MagpieBase, GeneratorTask):
     """Generator task the generates instructions or conversations using Magpie.
 
     Magpie is a neat method that allows generating user instructions with no seed data
@@ -50,12 +50,12 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        system_prompt: an optional system prompt or list or dict  of system prompts that
-            can be used to steer the LLM to generate content of certain topic, guide the
-            style, etc. If it's a list of system prompts, then a random system prompt will
-            be chosen per input/output batch. If the provided inputs contains a `system_prompt`
-            column, then this runtime parameter will be ignored and the one from the column
-            will be used. Defaults to `None`.
+        system_prompt: an optional system prompt, or a list of system prompts from which
+            a random one will be chosen, or a dictionary of system prompts from which a
+            random one will be choosen, or a dictionary of system prompts with their probability
+            of being chosen. The random system prompt will be chosen per input/output batch.
+            This system prompt can be used to guide the generation of the instruct LLM and
+            steer it to generate instructions of a certain topic. Defaults to `None`.
         num_rows: the number of rows to be generated.
 
     Runtime parameters:
@@ -67,12 +67,12 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             conversation. Defaults to `False`.
         - `only_instruction`: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        - `system_prompt`: an optional system prompt or list of system prompts that can
-            be used to steer the LLM to generate content of certain topic, guide the style,
-            etc. If it's a list of system prompts, then a random system prompt will be chosen
-            per input/output batch. If the provided inputs contains a `system_prompt` column,
-            then this runtime parameter will be ignored and the one from the column will
-            be used. Defaults to `None`.
+        - `system_prompt`: an optional system prompt, or a list of system prompts from which
+            a random one will be chosen, or a dictionary of system prompts from which a
+            random one will be choosen, or a dictionary of system prompts with their probability
+            of being chosen. The random system prompt will be chosen per input/output batch.
+            This system prompt can be used to guide the generation of the instruct LLM and
+            steer it to generate instructions of a certain topic.
         - `num_rows`: the number of rows to be generated.
 
     Output columns:
@@ -80,6 +80,8 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             items with a role and a message.
         - instruction (`str`): the generated instructions if `only_instruction=True`.
         - response (`str`): the generated response if `n_turns==1`.
+        - system_prompt_key (`str`, optional): the key of the system prompt used to generate
+            the conversation or instruction. Only if `system_prompt` is a dictionary.
         - model_name (`str`): The model name used to generate the `conversation` or `instruction`.
 
     Categories:
@@ -203,6 +205,34 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
         # )
         ```
 
+        Generating with system prompts with probabilities:
+
+        ```python
+        from distilabel.llms import InferenceEndpointsLLM
+        from distilabel.steps.tasks import MagpieGenerator
+
+        magpie = MagpieGenerator(
+            llm=InferenceEndpointsLLM(
+                model_id="meta-llama/Meta-Llama-3-8B-Instruct",
+                tokenizer_id="meta-llama/Meta-Llama-3-8B-Instruct",
+                magpie_pre_query_template="llama3",
+                generation_kwargs={
+                    "temperature": 0.8,
+                    "max_new_tokens": 256,
+                },
+            ),
+            n_turns=2,
+            system_prompt={
+                "math": ("You're an expert AI assistant.", 0.8),
+                "writing": ("You're an expert writing assistant.", 0.2),
+            },
+        )
+
+        magpie.load()
+
+        result = next(magpie.process())
+        ```
+
     Citations:
         ```
         @misc{xu2024magpiealignmentdatasynthesis,
@@ -242,15 +272,6 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
     ) -> Dict[str, Any]:
         """Does nothing."""
         return {}
-
-    @property
-    def outputs(self) -> "StepColumns":
-        """Either a multi-turn conversation or the instruction generated."""
-        if self.only_instruction:
-            return ["instruction", "model_name"]
-        if self.n_turns == 1:
-            return ["instruction", "response", "model_name"]
-        return ["conversation", "model_name"]
 
     def process(self, offset: int = 0) -> "GeneratorStepOutput":
         """Generates the desired number of instructions or conversations using Magpie.

--- a/src/distilabel/steps/tasks/magpie/generator.py
+++ b/src/distilabel/steps/tasks/magpie/generator.py
@@ -50,12 +50,12 @@ class MagpieGenerator(GeneratorTask, MagpieBase):
             conversation. Defaults to `False`.
         only_instruction: whether to generate only the instruction. If this argument is
             `True`, then `n_turns` will be ignored. Defaults to `False`.
-        system_prompt: an optional system prompt or list of system prompts that can
-            be used to steer the LLM to generate content of certain topic, guide the style,
-            etc. If it's a list of system prompts, then a random system prompt will be chosen
-            per input/output batch. If the provided inputs contains a `system_prompt` column,
-            then this runtime parameter will be ignored and the one from the column will
-            be used. Defaults to `None`.
+        system_prompt: an optional system prompt or list or dict  of system prompts that
+            can be used to steer the LLM to generate content of certain topic, guide the
+            style, etc. If it's a list of system prompts, then a random system prompt will
+            be chosen per input/output batch. If the provided inputs contains a `system_prompt`
+            column, then this runtime parameter will be ignored and the one from the column
+            will be used. Defaults to `None`.
         num_rows: the number of rows to be generated.
 
     Runtime parameters:

--- a/tests/unit/steps/tasks/magpie/test_base.py
+++ b/tests/unit/steps/tasks/magpie/test_base.py
@@ -592,17 +592,6 @@ class TestMagpie:
         )
 
         assert task.dump() == {
-            "name": None,
-            "resources": {
-                "replicas": 1,
-                "cpus": None,
-                "gpus": None,
-                "memory": None,
-                "resources": None,
-            },
-            "input_mappings": {},
-            "output_mappings": {},
-            "input_batch_size": 50,
             "llm": {
                 "use_magpie_template": True,
                 "magpie_pre_query_template": "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n",
@@ -615,17 +604,73 @@ class TestMagpie:
                     "name": "DummyMagpieLLM",
                 },
             },
-            "group_generations": False,
-            "add_raw_output": True,
-            "add_raw_input": True,
-            "num_generations": 1,
-            "use_default_structured_output": False,
             "n_turns": 1,
             "end_with_user": False,
             "include_system_prompt": False,
             "only_instruction": True,
             "system_prompt": None,
+            "name": "magpie_0",
+            "resources": {
+                "replicas": 1,
+                "cpus": None,
+                "gpus": None,
+                "memory": None,
+                "resources": None,
+            },
+            "input_mappings": {},
+            "output_mappings": {},
+            "input_batch_size": 50,
+            "group_generations": False,
+            "add_raw_output": True,
+            "add_raw_input": True,
+            "num_generations": 1,
+            "use_default_structured_output": False,
             "runtime_parameters_info": [
+                {
+                    "name": "llm",
+                    "runtime_parameters_info": [
+                        {
+                            "name": "generation_kwargs",
+                            "description": "The kwargs to be propagated to either `generate` or `agenerate` methods within each `LLM`.",
+                            "keys": [{"name": "kwargs", "optional": False}],
+                        },
+                        {
+                            "name": "use_offline_batch_generation",
+                            "optional": True,
+                            "description": "Whether to use the `offline_batch_generate` method to generate the responses.",
+                        },
+                        {
+                            "name": "offline_batch_generation_block_until_done",
+                            "optional": True,
+                            "description": "If provided, then polling will be done until the `ofline_batch_generate` method is able to retrieve the results. The value indicate the time to wait between each polling.",
+                        },
+                    ],
+                },
+                {
+                    "name": "n_turns",
+                    "optional": True,
+                    "description": "The number of turns to generate for the conversation.",
+                },
+                {
+                    "name": "end_with_user",
+                    "optional": True,
+                    "description": "Whether the conversation should end with a user message.",
+                },
+                {
+                    "name": "include_system_prompt",
+                    "optional": True,
+                    "description": "Whether to include the system prompt used in the generated conversation.",
+                },
+                {
+                    "name": "only_instruction",
+                    "optional": True,
+                    "description": "Whether to generate only the instruction. If this argument is `True`, then `n_turns` will be ignored.",
+                },
+                {
+                    "name": "system_prompt",
+                    "optional": True,
+                    "description": "An optional system prompt, or a list of system prompts from which a random one will be chosen, or a dictionary of system prompts from which a random one will be choosen, or a dictionary of system prompts with their probability of being chosen. The random system prompt will be chosen per input/output batch. This system prompt can be used to guide the generation of the instruct LLM and steer it to generate instructions of a certain topic.",
+                },
                 {
                     "name": "resources",
                     "runtime_parameters_info": [
@@ -662,26 +707,6 @@ class TestMagpie:
                     "description": "The number of rows that will contain the batches processed by the step.",
                 },
                 {
-                    "name": "llm",
-                    "runtime_parameters_info": [
-                        {
-                            "name": "generation_kwargs",
-                            "description": "The kwargs to be propagated to either `generate` or `agenerate` methods within each `LLM`.",
-                            "keys": [{"name": "kwargs", "optional": False}],
-                        },
-                        {
-                            "name": "use_offline_batch_generation",
-                            "optional": True,
-                            "description": "Whether to use the `offline_batch_generate` method to generate the responses.",
-                        },
-                        {
-                            "name": "offline_batch_generation_block_until_done",
-                            "optional": True,
-                            "description": "If provided, then polling will be done until the `ofline_batch_generate` method is able to retrieve the results. The value indicate the time to wait between each polling.",
-                        },
-                    ],
-                },
-                {
                     "name": "add_raw_output",
                     "optional": True,
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
@@ -695,31 +720,6 @@ class TestMagpie:
                     "name": "num_generations",
                     "optional": True,
                     "description": "The number of generations to be produced per input.",
-                },
-                {
-                    "name": "n_turns",
-                    "optional": True,
-                    "description": "The number of turns to generate for the conversation.",
-                },
-                {
-                    "name": "end_with_user",
-                    "optional": True,
-                    "description": "Whether the conversation should end with a user message.",
-                },
-                {
-                    "name": "include_system_prompt",
-                    "optional": True,
-                    "description": "Whether to include the system prompt used in the generated conversation.",
-                },
-                {
-                    "name": "only_instruction",
-                    "optional": True,
-                    "description": "Whether to generate only the instruction. If this argument is `True`, then `n_turns` will be ignored.",
-                },
-                {
-                    "name": "system_prompt",
-                    "optional": True,
-                    "description": "An optional system prompt, or a list of system prompts from which a random one will be chosen, or a dictionary of system prompts from which a random one will be choosen, or a dictionary of system prompts with their probability of being chosen. The random system prompt will be chosen per input/output batch. This system prompt can be used to guide the generation of the instruct LLM and steer it to generate instructions of a certain topic.",
                 },
             ],
             "type_info": {

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -27,26 +27,6 @@ class TestMagpieGenerator:
         ):
             MagpieGenerator(llm=OpenAILLM(model="gpt-4", api_key="fake"))  # type: ignore
 
-    def test_outputs(self) -> None:
-        task = MagpieGenerator(
-            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=1
-        )
-
-        assert task.outputs == ["instruction", "response", "model_name"]
-
-        task = MagpieGenerator(
-            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=2
-        )
-
-        assert task.outputs == ["conversation", "model_name"]
-
-        task = MagpieGenerator(
-            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
-            only_instruction=True,
-        )
-
-        assert task.outputs == ["instruction", "model_name"]
-
     def test_serialization(self) -> None:
         task = MagpieGenerator(llm=DummyMagpieLLM(magpie_pre_query_template="llama3"))
 

--- a/tests/unit/steps/tasks/magpie/test_generator.py
+++ b/tests/unit/steps/tasks/magpie/test_generator.py
@@ -27,6 +27,41 @@ class TestMagpieGenerator:
         ):
             MagpieGenerator(llm=OpenAILLM(model="gpt-4", api_key="fake"))  # type: ignore
 
+    def test_outputs(self) -> None:
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
+            only_instruction=True,
+        )
+
+        assert task.outputs == ["instruction", "model_name"]
+
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=1
+        )
+
+        assert task.outputs == ["instruction", "response", "model_name"]
+
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"), n_turns=2
+        )
+
+        assert task.outputs == ["conversation", "model_name"]
+
+        task = MagpieGenerator(
+            llm=DummyMagpieLLM(magpie_pre_query_template="llama3"),
+            system_prompt={
+                "system_prompt_1": ("system_prompt", 0.5),
+                "system_prompt_2": ("system_prompt", 0.5),
+            },
+        )
+
+        assert task.outputs == [
+            "instruction",
+            "response",
+            "system_prompt_key",
+            "model_name",
+        ]
+
     def test_serialization(self) -> None:
         task = MagpieGenerator(llm=DummyMagpieLLM(magpie_pre_query_template="llama3"))
 
@@ -35,9 +70,9 @@ class TestMagpieGenerator:
                 "use_magpie_template": True,
                 "magpie_pre_query_template": "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n",
                 "generation_kwargs": {},
-                "jobs_ids": None,
-                "offline_batch_generation_block_until_done": None,
                 "use_offline_batch_generation": False,
+                "offline_batch_generation_block_until_done": None,
+                "jobs_ids": None,
                 "type_info": {
                     "module": "tests.unit.conftest",
                     "name": "DummyMagpieLLM",
@@ -63,8 +98,8 @@ class TestMagpieGenerator:
             "add_raw_output": True,
             "add_raw_input": True,
             "num_generations": 1,
-            "num_rows": None,
             "use_default_structured_output": False,
+            "num_rows": None,
             "runtime_parameters_info": [
                 {
                     "name": "llm",
@@ -75,18 +110,14 @@ class TestMagpieGenerator:
                             "keys": [{"name": "kwargs", "optional": False}],
                         },
                         {
-                            "description": "Whether to use the `offline_batch_generate` method to "
-                            "generate the responses.",
                             "name": "use_offline_batch_generation",
                             "optional": True,
+                            "description": "Whether to use the `offline_batch_generate` method to generate the responses.",
                         },
                         {
-                            "description": "If provided, then polling will be done until the "
-                            "`ofline_batch_generate` method is able to retrieve the "
-                            "results. The value indicate the time to wait between each "
-                            "polling.",
                             "name": "offline_batch_generation_block_until_done",
                             "optional": True,
+                            "description": "If provided, then polling will be done until the `ofline_batch_generate` method is able to retrieve the results. The value indicate the time to wait between each polling.",
                         },
                     ],
                 },
@@ -113,7 +144,7 @@ class TestMagpieGenerator:
                 {
                     "name": "system_prompt",
                     "optional": True,
-                    "description": "An optional system prompt or list of system prompts that can be used to steer the LLM to generate content of certain topic, guide the style, etc.",
+                    "description": "An optional system prompt, or a list of system prompts from which a random one will be chosen, or a dictionary of system prompts from which a random one will be choosen, or a dictionary of system prompts with their probability of being chosen. The random system prompt will be chosen per input/output batch. This system prompt can be used to guide the generation of the instruct LLM and steer it to generate instructions of a certain topic.",
                 },
                 {
                     "name": "resources",
@@ -156,9 +187,9 @@ class TestMagpieGenerator:
                     "description": "Whether to include the raw output of the LLM in the key `raw_output_<TASK_NAME>` of the `distilabel_metadata` dictionary output column",
                 },
                 {
-                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
                     "name": "add_raw_input",
                     "optional": True,
+                    "description": "Whether to include the raw input of the LLM in the key `raw_input_<TASK_NAME>` of the `distilabel_metadata` dictionary column",
                 },
                 {
                     "name": "num_generations",


### PR DESCRIPTION
## Description

This PR updates the `system_prompt` attribute of Magpie tasks so it can be provided a dictionary in which the keys are the names of the prompts and the values are either the system prompt or a system prompt with an associated probability of being chosen for that batch.