### PR TITLE
Fix unloading steps with more than 1 replica

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -1496,7 +1496,8 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
         with self._steps_load_status_lock:
             for step_name, replicas in self._steps_load_status.items():
                 if replicas > 0:
-                    self._send_to_step(step_name, None)
+                    for _ in range(replicas):
+                        self._send_to_step(step_name, None)
 
     def _get_successors(self, batch: "_Batch") -> Tuple[List[str], List[str], bool]:
         """Gets the successors and the successors to which the batch has to be routed.

--- a/src/distilabel/pipeline/step_wrapper.py
+++ b/src/distilabel/pipeline/step_wrapper.py
@@ -134,14 +134,23 @@ class _StepWrapper:
 
     def _notify_load(self) -> None:
         """Notifies that the step has finished executing its `load` function successfully."""
+        self.step._logger.debug(
+            f"Notifying load of step '{self.step.name}' (replica ID {self.replica})..."
+        )
         self.load_queue.put({"name": self.step.name, "status": "loaded"})  # type: ignore
 
     def _notify_unload(self) -> None:
         """Notifies that the step has been unloaded."""
+        self.step._logger.debug(
+            f"Notifying unload of step '{self.step.name}' (replica ID {self.replica})..."
+        )
         self.load_queue.put({"name": self.step.name, "status": "unloaded"})  # type: ignore
 
     def _notify_load_failed(self) -> None:
         """Notifies that the step failed to load."""
+        self.step._logger.debug(
+            f"Notifying load failed of step '{self.step.name}' (replica ID {self.replica})..."
+        )
         self.load_queue.put({"name": self.step.name, "status": "load_failed"})  # type: ignore
 
     def _generator_step_process_loop(self) -> None:


### PR DESCRIPTION
## Description

This PR fixes a bug that occurred when using more than one replica per step. The unloading logic was not sending enough `None`s (one per replica) to notify the loaded step replicas that they should stop.

Closes #976 