### PR TITLE
Fix schema inference structured generation

### DIFF
--- a/docs/sections/how_to_guides/advanced/structured_generation.md
+++ b/docs/sections/how_to_guides/advanced/structured_generation.md
@@ -129,7 +129,7 @@ These were some simple examples, but one can see the options this opens.
 
 ## Instructor
 
-When working with model providers behind an API, there's no direct way of accessing the internal logit processor like `outlines` does, but thanks to [`instructor`](https://python.useinstructor.com/) we can generate structured output from LLM providers based on `pydantic.BaseModel` objects. We have integrated `instructor` to deal with the [`AsyncLLM`][distilabel.llms.AsyncLLM], so you can work with the following LLMs: [`OpenAILLM`][distilabel.llms.OpenAILLM], [`AzureOpenAILLM`][distilabel.llms.AzureOpenAILLM], [`CohereLLM`][distilabel.llms.CohereLLM], [`GroqLLM`][distilabel.llms.GroqLLM], [`LiteLLM`][distilabel.llms.LiteLLM] and [`MistralLLM`][distilabel.llms.MistralLLM].
+For other LLM providers behinds APIs, there's no direct way of accessing the internal logit processor like `outlines` does, but thanks to [`instructor`](https://python.useinstructor.com/) we can generate structured output from LLM providers based on `pydantic.BaseModel` objects. We have integrated `instructor` to deal with the [`AsyncLLM`][distilabel.llms.AsyncLLM].
 
 !!! Note
     For `instructor` integration to work you may need to install the corresponding dependencies:
@@ -155,14 +155,15 @@ class User(BaseModel):
 
 And then we provide that schema to the `structured_output` argument of the LLM:
 
-!!! Note
-    In this example we are using *open-mixtral-8x22b*, keep in mind not all the models work with the function calling functionality required for this example to work.
+!!! NOTE
+    In this example we are using *Meta Llama 3.1 8B Instruct*, keep in mind not all the models support structured outputs.
 
 ```python
 from distilabel.llms import MistralLLM
 
-llm = MistralLLM(
-    model="open-mixtral-8x22b",
+llm = InferenceEndpointsLLM(
+    model_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
+    tokenizer_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
     structured_output={"schema": User}
 )
 llm.load()

--- a/docs/sections/how_to_guides/advanced/structured_generation.md
+++ b/docs/sections/how_to_guides/advanced/structured_generation.md
@@ -129,7 +129,7 @@ These were some simple examples, but one can see the options this opens.
 
 ## Instructor
 
-For other LLM providers behinds APIs, there's no direct way of accessing the internal logit processor like `outlines` does, but thanks to [`instructor`](https://python.useinstructor.com/) we can generate structured output from LLM providers based on `pydantic.BaseModel` objects. We have integrated `instructor` to deal with the [`AsyncLLM`][distilabel.llms.AsyncLLM].
+For other LLM providers behind APIs, there's no direct way of accessing the internal logit processor like `outlines` does, but thanks to [`instructor`](https://python.useinstructor.com/) we can generate structured output from LLM providers based on `pydantic.BaseModel` objects. We have integrated `instructor` to deal with the [`AsyncLLM`][distilabel.llms.AsyncLLM].
 
 !!! Note
     For `instructor` integration to work you may need to install the corresponding dependencies:

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -364,8 +364,11 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
                     "the `structured_output` attribute."
                 ) from e
 
-        if isinstance(structured_output["value"], ModelMetaclass):
-            structured_output["value"] = structured_output["value"].model_json_schema()
+        if structured_output:
+            if isinstance(structured_output["value"], ModelMetaclass):
+                structured_output["value"] = structured_output[
+                    "value"
+                ].model_json_schema()
 
         return structured_output
 

--- a/src/distilabel/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/llms/huggingface/inference_endpoints.py
@@ -26,6 +26,7 @@ from pydantic import (
     model_validator,
     validate_call,
 )
+from pydantic._internal._model_construction import ModelMetaclass
 from typing_extensions import Annotated, override
 
 from distilabel.llms.base import AsyncLLM
@@ -362,6 +363,9 @@ class InferenceEndpointsLLM(AsyncLLM, MagpieChatTemplateMixin):
                     "To use the structured output you have to inform the `format` and `schema` in "
                     "the `structured_output` attribute."
                 ) from e
+
+        if isinstance(structured_output["value"], ModelMetaclass):
+            structured_output["value"] = structured_output["value"].model_json_schema()
 
         return structured_output
 

--- a/src/distilabel/steps/tasks/typing.py
+++ b/src/distilabel/steps/tasks/typing.py
@@ -49,6 +49,8 @@ class OutlinesStructuredOutputType(TypedDict, total=False):
 class InstructorStructuredOutputType(TypedDict, total=False):
     """TypedDict to represent the structured output configuration from `instructor`."""
 
+    format: Optional[Literal["json"]]
+    """One of "json"."""
     schema: Union[Type[BaseModel], Dict[str, Any]]
     """The schema to use for the structured output, a `pydantic.BaseModel` class. """
     mode: Optional[str]


### PR DESCRIPTION
- Fixes the `InferenceEndpointsLLM` workflow for structured generation by converting the ModelMetaclass to json
- Fixes an optional `format` argument to `InstructorStructuredOutputType` to allow the code to be more inter-exchangable.