### PR TITLE
fix: simplify prompt template `ArgillaLabeller`

### DIFF
--- a/src/distilabel/steps/tasks/argilla_labeller.py
+++ b/src/distilabel/steps/tasks/argilla_labeller.py
@@ -208,17 +208,13 @@ class ArgillaLabeller(Task):
     system_prompt: str = (
         "You are an expert annotator and labelling assistant that understands complex domains and natural language processing. "
         "You are given input fields and a question. "
-        "You should create a valid JSON object as an answer to the question based on the input fields. "
-        "1. Understand the input fields and optional guidelines. "
-        "2. Understand the question type and the question settings. "
-        "3. Reason through your response step-by-step. "
-        "4. Provide a valid JSON object as an answer to the question."
+        "You should create a valid JSON object as an response to the question based on the input fields. "
     )
     question_to_label_instruction: Dict[str, str] = {
-        "label_selection": "Select the appropriate label from the list of provided labels.",
-        "multi_label_selection": "Select none, one or multiple labels from the list of provided labels.",
-        "text": "Provide a text response to the question.",
-        "rating": "Provide a rating for the question.",
+        "label_selection": "Select the appropriate label for the fields from the list of optional labels.",
+        "multi_label_selection": "Select none, one or multiple labels for the fields from the list of optional labels.",
+        "text": "Provide a response to the question based on the fields.",
+        "rating": "Provide a rating for the question based on the fields.",
     }
     example_records: Optional[
         RuntimeParameter[Union[List[Union[Dict[str, Any], BaseModel]], None]]
@@ -290,12 +286,8 @@ class ArgillaLabeller(Task):
         """
         output = []
         for field in fields:
-            if title := field.get("title"):
-                output.append(f"title: {title}")
-            if description := field.get("description"):
-                output.append(f"description: {description}")
             output.append(record.get("fields", {}).get(field.get("name", "")))
-        return "\n".join(output)
+        return "fields: " + "\n".join(output)
 
     def _get_label_instruction(self, question: Dict[str, Any]) -> str:
         """Get the label instruction for the question.
@@ -318,15 +310,13 @@ class ArgillaLabeller(Task):
         Returns:
             str: The formatted question.
         """
-        output = [
-            f"title: {question.get('title', '')}",
-            f"description: {question.get('description', '')}",
-            f"label_instruction: {self._get_label_instruction(question)}",
-        ]
-        settings = question.get("settings", {})
-        if "options" in settings:
+        output = []
+        if question_context := question.get("description"):
+            output.append(f"question context: {question_context}")
+        output.append(f"question: {self._get_label_instruction(question)}")
+        if "options" in question.get("settings", {}):
             output.append(
-                f"labels: {[option['value'] for option in settings.get('options', [])]}"
+                f"optional labels: {[option['value'] for option in question.get('settings', {}).get('options', [])]}"
             )
         return "\n".join(output)
 
@@ -355,7 +345,7 @@ class ArgillaLabeller(Task):
                 formatted_value = self._assign_value_to_question_value_model(
                     value, question
                 )
-                base.append(f"Response: {formatted_value}")
+                base.append(f"response: {formatted_value}")
                 base.append("")
             else:
                 warnings.warn(

--- a/src/distilabel/steps/tasks/argilla_labeller.py
+++ b/src/distilabel/steps/tasks/argilla_labeller.py
@@ -311,8 +311,6 @@ class ArgillaLabeller(Task):
             str: The formatted question.
         """
         output = []
-        if question_context := question.get("description"):
-            output.append(f"question context: {question_context}")
         output.append(f"question: {self._get_label_instruction(question)}")
         if "options" in question.get("settings", {}):
             output.append(

--- a/src/distilabel/steps/tasks/templates/argillalabeller.jinja2
+++ b/src/distilabel/steps/tasks/templates/argillalabeller.jinja2
@@ -3,11 +3,11 @@ Please provide an answer to the question based on the input fields{% if examples
 # Guidelines
 {{ guidelines }}
 {% endif %}
-# Input Fields
-{{ fields }}
-# Question
-{{ question }}
 {% if examples %}
 # Examples
 {{ examples }}
 {% endif %}
+# Question
+{{ question }}
+{{ fields }}
+response:

--- a/src/distilabel/steps/tasks/templates/argillalabeller.jinja2
+++ b/src/distilabel/steps/tasks/templates/argillalabeller.jinja2
@@ -1,13 +1,13 @@
 Please provide an answer to the question based on the input fields{% if examples %} and examples{% endif %}.
 {% if guidelines %}
 # Guidelines
-{{ guidelines }}
-{% endif %}
+{{ guidelines }}{% endif %}
 {% if examples %}
 # Examples
-{{ examples }}
-{% endif %}
+{{ examples }}{% endif %}
 # Question
 {{ question }}
+
+# Fields
 {{ fields }}
 response:

--- a/tests/unit/steps/tasks/test_argilla_labeller.py
+++ b/tests/unit/steps/tasks/test_argilla_labeller.py
@@ -142,7 +142,6 @@ class TestArgillaLabeller:
                 }
             )
             assert question["description"] in result[-1]["content"]
-            assert question["title"] in result[-1]["content"]
             if question["settings"]["type"] in [
                 "label_selection",
                 "multi_label_selection",

--- a/tests/unit/steps/tasks/test_argilla_labeller.py
+++ b/tests/unit/steps/tasks/test_argilla_labeller.py
@@ -28,8 +28,6 @@ def fields() -> Dict[str, Any]:
     return [
         {
             "name": "text",
-            "description": "The text of the question",
-            "title": "The text of the question",
             "settings": {"type": "text"},
         }
     ]
@@ -40,8 +38,6 @@ def questions() -> List[Dict[str, Any]]:
     return [
         {
             "name": "label_selection",
-            "description": "The class of the question",
-            "title": "Is the question a question?",
             "settings": {
                 "type": "label_selection",
                 "options": [
@@ -52,8 +48,6 @@ def questions() -> List[Dict[str, Any]]:
         },
         {
             "name": "multi_label_selection",
-            "description": "The class of the question",
-            "title": "Is the question a question?",
             "settings": {
                 "type": "multi_label_selection",
                 "options": [
@@ -64,8 +58,6 @@ def questions() -> List[Dict[str, Any]]:
         },
         {
             "name": "rating",
-            "description": "The class of the question",
-            "title": "Is the question a question?",
             "settings": {
                 "type": "rating",
                 "options": [
@@ -75,8 +67,6 @@ def questions() -> List[Dict[str, Any]]:
         },
         {
             "name": "text",
-            "description": "The class of the question",
-            "title": "Is the question a question?",
             "settings": {
                 "type": "text",
             },
@@ -141,11 +131,9 @@ class TestArgillaLabeller:
                     "record": records[0],
                 }
             )
-            assert question["description"] in result[-1]["content"]
             if question["settings"]["type"] in [
                 "label_selection",
                 "multi_label_selection",
-                "span",
                 "rating",
             ]:
                 assert (


### PR DESCRIPTION
# OLD
```
Please provide an answer to the question based on the input fields.

# Guidelines
We are dealing with input data about detailed customer reviews of 3 corresponding labels: positive, negative, and neutral.
# Question
title: label
description: Provide a single label for the emotion of the text.
provided labels: ['positive', 'negative', 'neutral']
label instruction: Select the appropriate label from the list of provided labels.
# Examples
I just got this new PC, and the CPU, some Intel thing, keeps overheating! I followed the guide on the forum, but it’s still a mess. Maybe I should have gone with AMD, like everyone says.
negative
I just upgraded to the Ryzen 5 5600X and it’s been a game-changer, really smooth for gaming and streaming. The cooling with my NZXT Kraken X63 is solid, temps stay low even during long sessions. 🏆
positive
# Input Fields
I just upgraded my PC with an Intel Core i5 and 16GB of RAM, and it’s like I have a brand new machine! The performance boost is amazing, and everything runs so smoothly now.
```
# NEW:
```
Please provide an answer to the question based on the input fields and examples.

# Guidelines
Classify the reviews as positive or negative.

# Examples
fields: I finally got my hands on the Ryzen 9 7950X and paired it with an X670E motherboard, and it\'s a beast! The performance gains over my old 5900X are insane, especially in multi-threaded tasks. The power efficiency is also a game changer. Can\'t wait to see how it handles my next 3D rendering project.
response: {"label":"positive"}

# Question
question: Select the appropriate label for the fields from the list of optional labels.
optional labels: [\'positive\', \'negative\', \'neutral\']

# Fields
fields: I finally got my hands on the Ryzen 9 7950X and paired it with an X670E motherboard, and it\'s a beast! The performance gains over my old 5900X are insane, especially in multi-threaded tasks. The power efficiency is also a game changer. Can\'t wait to see how it handles my next 3D rendering project.
response:
```
