### PR TITLE
Enable valid OpenAI `response_format` specification

### DIFF
--- a/src/distilabel/llms/openai.py
+++ b/src/distilabel/llms/openai.py
@@ -301,7 +301,7 @@ class OpenAILLM(AsyncLLM):
             if response_format == "json":
                 response_format = "json_object"
 
-            kwargs["response_format"] = response_format
+            kwargs["response_format"] = {"type": response_format}
 
         if structured_output:
             kwargs = self._prepare_kwargs(kwargs, structured_output)  # type: ignore
@@ -395,6 +395,18 @@ class OpenAILLM(AsyncLLM):
             return self._check_and_get_batch_results()
 
         if inputs:
+            if response_format is not None:
+                if response_format not in ["text", "json", "json_object"]:
+                    raise ValueError(
+                        f"Invalid response format '{response_format}'. Must be either 'text'"
+                        " or 'json'."
+                    )
+
+                if response_format == "json":
+                    response_format = "json_object"
+
+                response_format = {"type": response_format}
+
             self.jobs_ids = self._create_jobs(
                 inputs=inputs,
                 **{


### PR DESCRIPTION
When specifying the `response_format` within the current version of the OpenAI API it expects this via an object containing a `"type"` attribute, e.g. `{"type": "<type>"}`. However, distilabel is enforcing a string representation for this, which leads to either an error or silent failure.

E.g. when using a `TextGeneration` task under the existing codebase:
```python
text_gen = TextGeneration(
    llm=OpenAILLM(
        model="gpt-4o",
        generation_kwargs={
            "response_format": "json"
        },
    )
)
text_gen.load()

output = next(
    text_gen.process(
        [{"instruction": "Convert this info to a JSON: John Smith is 30 years old."}]
    )
)
```
The OpenAI API will fail and yield `BadRequestError: Error code: 400 - {'error': {'message': "Invalid type for 'response_format': expected an object, but got a string instead.", 'type': 'invalid_request_error', 'param': 
'response_format', 'code': 'invalid_type'}}`.

The same happens when directly calling generation from the `LLM`:
```python
llm = OpenAILLM(
    model="gpt-4o",
)

llm.load()

output = llm.generate_outputs(
    inputs=[[{"role": "user", "content": "Convert this info to a JSON: John Smith is 30 years old."}]],
    response_format="json"
)
```

Presumably the same happens for requests to the batch api, which ultimately leads to `AssertionError: No output file ID was found in the batch.`.
```python
load = llm = OpenAILLM(
    model="gpt-4o",
    use_offline_batch_generation=True,
    offline_batch_generation_block_until_done=2,  # poll for results every 5 seconds
)

llm.load()
output = llm.generate_outputs(
    inputs=[[{"role": "user", "content": "Convert this info to a JSON: John Smith is 30 years old."}]],
    response_format="json"
)
```

---
This pr simply wraps the string representation of the specified `response_format` inside the object expected by OpenAI. 
I have also added the same value checking that is done in `agenerate()` to `offline_batch_generate()`.