### PR TITLE
Update `LLM`s to support prompt logprobs use-case

### DIFF
--- a/src/distilabel/models/base_clients/inference_endpoints.py
+++ b/src/distilabel/models/base_clients/inference_endpoints.py
@@ -16,7 +16,6 @@ import os
 from typing import (
     TYPE_CHECKING,
     Optional,
-    Union,
 )
 
 from pydantic import (
@@ -143,9 +142,9 @@ class InferenceEndpointsBaseClient(BaseModel):
             self._tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_id)
 
     @property
-    def model_name(self) -> Union[str, None]:  # type: ignore
+    def model_name(self) -> str:
         """Returns the model name used for the model."""
-        return (
+        return (  # type: ignore
             self.model_display_name
             or self._model_name
             or self.model_id

--- a/src/distilabel/models/llms/openai.py
+++ b/src/distilabel/models/llms/openai.py
@@ -16,7 +16,7 @@ import io
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union
 
 import orjson
-from pydantic import PositiveInt, validate_call
+from pydantic import NonNegativeInt, PositiveInt, validate_call
 
 from distilabel import envs
 from distilabel.exceptions import DistilabelOfflineBatchGenerationNotFinishedException
@@ -156,7 +156,7 @@ class OpenAILLM(OpenAIBaseClient, AsyncLLM):
         self,
         input: FormattedInput,
         num_generations: int = 1,
-        max_new_tokens: int = 128,
+        max_new_tokens: NonNegativeInt = 128,
         logprobs: bool = False,
         top_logprobs: Optional[PositiveInt] = None,
         echo: bool = False,

--- a/src/distilabel/models/llms/vllm.py
+++ b/src/distilabel/models/llms/vllm.py
@@ -47,7 +47,8 @@ if TYPE_CHECKING:
     from openai import OpenAI  # noqa
     from transformers import PreTrainedTokenizer
     from vllm import LLM as _vLLM
-    from vllm.outputs import RequestOutput, CompletionOutput
+    from vllm.outputs import RequestOutput
+    from vllm.sequence import SampleLogprobs, PromptLogprobs
 
     from distilabel.typing import (
         StandardInput,
@@ -342,8 +343,10 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
         stop: Optional[List[str]] = None,
         stop_token_ids: Optional[List[int]] = None,
         include_stop_str_in_output: bool = False,
+        skip_special_tokens: bool = True,
         logits_processors: Optional[LogitsProcessors] = None,
         extra_sampling_params: Optional[Dict[str, Any]] = None,
+        echo: bool = False,
     ) -> List[GenerateOutput]:
         """Generates `num_generations` responses for each input.
 
@@ -371,10 +374,14 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
                 when found. Defaults to `None`.
             include_stop_str_in_output: whether to include the stop string in the output.
                 Defaults to `False`.
+            skip_special_tokens: whether to exclude special tokens from the output. Defaults
+                to `False`.
             logits_processors: a list of functions to process the logits before sampling.
                 Defaults to `None`.
             extra_sampling_params: dictionary with additional arguments to be passed to
                 the `SamplingParams` class from `vllm`.
+            echo: whether to echo the include the prompt in the response or not. Defaults
+                to `False`.
 
         Returns:
             A list of lists of strings containing the generated responses for each input.
@@ -427,10 +434,12 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
                 top_k=top_k,
                 min_p=min_p,
                 max_tokens=max_new_tokens,
+                prompt_logprobs=logprobs if echo else None,
                 logprobs=logprobs,
                 stop=stop,
                 stop_token_ids=stop_token_ids,
                 include_stop_str_in_output=include_stop_str_in_output,
+                skip_special_tokens=skip_special_tokens,
                 logits_processors=logits_processors,
                 **extra_sampling_params,
             )
@@ -447,18 +456,26 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
                 logits_processors.pop(-1)
 
             for input, outputs in zip(prepared_inputs, batch_outputs):
+                processed_prompt_logprobs = []
+                if outputs.prompt_logprobs is not None:
+                    processed_prompt_logprobs = self._get_llm_logprobs(
+                        outputs.prompt_logprobs
+                    )
                 texts, statistics, outputs_logprobs = self._process_outputs(
-                    input, outputs
+                    input=input,
+                    outputs=outputs,
+                    echo=echo,
+                    prompt_logprobs=processed_prompt_logprobs,
                 )
                 batched_outputs.append(texts)
-                generations.append(
-                    prepare_output(
-                        generations=texts,
-                        input_tokens=statistics["input_tokens"],
-                        output_tokens=statistics["output_tokens"],
-                        logprobs=outputs_logprobs,
-                    )
+                generation = prepare_output(
+                    generations=texts,
+                    input_tokens=statistics["input_tokens"],
+                    output_tokens=statistics["output_tokens"],
+                    logprobs=outputs_logprobs,
                 )
+
+                generations.append(generation)
 
         if sorted_indices is not None:
             pairs = list(enumerate(sorted_indices))
@@ -468,7 +485,11 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
         return generations
 
     def _process_outputs(
-        self, input: str, outputs: "RequestOutput"
+        self,
+        input: str,
+        outputs: "RequestOutput",
+        prompt_logprobs: List[List["Logprob"]],
+        echo: bool = False,
     ) -> Tuple["LLMOutput", "LLMStatistics", "LLMLogprobs"]:
         texts = []
         outputs_logprobs = []
@@ -478,10 +499,14 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
             "output_tokens": [],
         }
         for output in outputs.outputs:
-            texts.append(output.text)
+            text = output.text
+            if echo:
+                text = input + text
+            texts.append(text)
             statistics["output_tokens"].append(len(output.token_ids))
             if output.logprobs is not None:
-                outputs_logprobs.append(self._get_llm_logprobs(output))
+                processed_output_logprobs = self._get_llm_logprobs(output.logprobs)
+                outputs_logprobs.append(prompt_logprobs + processed_output_logprobs)
         return texts, statistics, outputs_logprobs
 
     def _prepare_structured_output(  # type: ignore
@@ -506,16 +531,21 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
             self.structured_output["schema"] = schema
         return result["processor"]
 
-    def _get_llm_logprobs(self, output: "CompletionOutput") -> List[List["Logprob"]]:
-        logprobs = []
-        for token_logprob in output.logprobs:  # type: ignore
+    def _get_llm_logprobs(
+        self, logprobs: Union["PromptLogprobs", "SampleLogprobs"]
+    ) -> List[List["Logprob"]]:
+        processed_logprobs = []
+        for token_logprob in logprobs:  # type: ignore
             token_logprobs = []
+            if token_logprob is None:
+                processed_logprobs.append(None)
+                continue
             for logprob in token_logprob.values():
                 token_logprobs.append(
                     {"token": logprob.decoded_token, "logprob": logprob.logprob}
                 )
-            logprobs.append(token_logprobs)
-        return logprobs
+            processed_logprobs.append(token_logprobs)
+        return processed_logprobs
 
 
 class ClientvLLM(OpenAILLM, MagpieChatTemplateMixin):

--- a/src/distilabel/typing/models.py
+++ b/src/distilabel/typing/models.py
@@ -106,7 +106,7 @@ StandardInput = ChatType
 """StandardInput is an alias for ChatType that defines the default / standard input produced by `format_input`."""
 StructuredInput = Tuple[StandardInput, Union[StructuredOutputType, None]]
 """StructuredInput defines a type produced by `format_input` when using either `StructuredGeneration` or a subclass of it."""
-FormattedInput = Union[StandardInput, StructuredInput]
+FormattedInput = Union[StandardInput, StructuredInput, str]
 """FormattedInput is an alias for the union of `StandardInput` and `StructuredInput` as generated
 by `format_input` and expected by the `LLM`s, as well as `ConversationType` for the vision language models."""
 

--- a/tests/unit/models/llms/test_vllm.py
+++ b/tests/unit/models/llms/test_vllm.py
@@ -106,8 +106,8 @@ class TestvLLM:
     @pytest.mark.parametrize(
         "multi_structured_output",
         # TODO:  uncomment once with update our code to work with `outlines>0.1.0`
-        # (True, False),
-        (False,),
+        (True, False),
+        # (False,),
     )
     @pytest.mark.parametrize(
         "num_generations, expected_result",
@@ -183,6 +183,7 @@ class TestvLLM:
 
         mocked_requests_output = [
             mock.Mock(  # RequestOutput
+                prompt_logprobs=[],
                 outputs=[
                     mock.Mock(  # CompletionOutput
                         text="I'm fine thank you",


### PR DESCRIPTION
## Description

This PR updates `OpenAILLM`, `InferenceEndpointsLLM` and `vLLM` so they return the logprobs of the input prompt. This is useful for the use-case in which an already formatted message (instruction-response) is passed to an LLM to get the prompt logprobs to be later used for training a student model using KD from a teacher model.