### PR TITLE
Structured output json to model and LiteLLM async completion client fix

### DIFF
--- a/src/distilabel/models/llms/litellm.py
+++ b/src/distilabel/models/llms/litellm.py
@@ -246,7 +246,9 @@ class LiteLLM(AsyncLLM):
         async def _call_aclient_until_n_choices() -> List["Choices"]:
             choices = []
             while len(choices) < num_generations:
-                completion: Union["ModelResponse", "BaseModel"] = await self._aclient(**kwargs)  # type: ignore
+                completion: Union["ModelResponse", "BaseModel"] = await self._aclient(
+                    **kwargs
+                )  # type: ignore
                 if self.structured_output:
                     # Prevent pydantic model from being cast to list during list extension
                     completion = [completion]


### PR DESCRIPTION
This pull request solves two issues:

1. It enables users to use more complex pydantic models for structured output generation with instructor. The current implementation does not allow union types and it does not resolve all references of the serialized pydantic model when de-serializing.
2. It fixes the async completion client of LiteLLM which is currently broken if structured output is requested. The fix is inspired by the implementation of the [anthropic client](https://github.com/argilla-io/distilabel/blob/main/src/distilabel/models/llms/anthropic.py#L268). It is not entirely the same because I needed to do some additional changes to make it work.

I will create the corresponding issues for documentation in a moment. Please let me know if there is anything you would like me to change.

Below is a minimal working example of what previously failed and now works. You should be able to use it out-of-the-box because Together AI is currently granting free access to the Llama 3.3 model for development, experimentation, and personal non-commercial applications - so you don't need an API key.

```python
from typing import Union, Literal, List

from pydantic import BaseModel
from distilabel.models import LiteLLM


class EntitySpecification(BaseModel):
    entity_type: str
    entity_name: str


class EntityQA(BaseModel):
    question: str
    entities: List[EntitySpecification]


class SimpleQA(BaseModel):
    question: str
    answer: str


class Question(BaseModel):
    question_category: Literal["Simple", "Entity"]
    question: Union[SimpleQA, EntityQA]


class ExpectedOutput(BaseModel):
    reasoning: str
    questions: list[Question]


completion_prefix = """
Given a text excerpt, generate meaningful questions. Each question should belong to one of the following categories:

# Simple
Open-ended questions with answers derived directly from the text.

# Entity
Questions about specific entities in the text. Each question should include:
- "question": The question string.
- "entities": A list of entities, where each entity has:
  - "entity_type": The type of the entity (e.g., "Person", "Location").
  - "entity_name": The name of the entity.

Return the output as JSON with:
- "reasoning": A string explaining the logic behind the generated questions.
- "questions": A list of question objects. Each question object should include:
  - "question_category": The category of the question ("Simple" or "Entity").
  - "question": An object containing the question and its components.

Example JSON output:
{
  "reasoning": "Generated questions based on key details in the text.",
  "questions": [
    {
      "question_category": "Simple",
      "question": {
        "question": "What is the main topic?",
        "answer": "The main topic is ..."
      }
    },
    {
      "question_category": "Entity",
      "question": {
        "question": "Who is mentioned in the text?",
        "entities": [
          {"entity_type": "Person", "entity_name": "John Doe"},
          {"entity_type": "Organization", "entity_name": "Acme Corp"}
        ]
      }
    }
  ]
}

Text excerpt to generate questions for:
"""

excerpt = """
Distilabel can be used for generating synthetic data and AI feedback for a wide 
variety of projects including traditional predictive NLP (classification, extraction, 
etc.), or generative and large language model scenarios (instruction following, 
dialogue generation, judging etc.). Distilabel's programmatic approach allows you 
to build scalable pipelines for data generation and AI feedback. The goal of distilabel 
is to accelerate your AI development by quickly generating high-quality, diverse datasets 
based on verified research methodologies for generating and judging with AI feedback.
"""

llm = LiteLLM(
    model="together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
    structured_output={"schema": ExpectedOutput},
)

llm.load()

output = llm.generate_outputs(inputs=[[{"role": "user", "content": completion_prefix + excerpt}]])
```