### PR TITLE
Fix exam example and update `InferenceEndpointsLLM`

### DIFF
--- a/examples/exam_questions.py
+++ b/examples/exam_questions.py
@@ -59,7 +59,7 @@ with Pipeline(name="ExamGenerator") as pipeline:
         name="load_instructions",
         data=[
             {
-                "page": page.content,
+                "instruction": page.content,
             }
         ],
     )
@@ -67,7 +67,7 @@ with Pipeline(name="ExamGenerator") as pipeline:
     text_generation = TextGeneration(
         name="exam_generation",
         system_prompt=SYSTEM_PROMPT,
-        template="Generate a list of answers and questions about the document. Document:\n\n{{ page }}",
+        template="Generate a list of answers and questions about the document. Document:\n\n{{ instruction }}",
         llm=InferenceEndpointsLLM(
             model_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
             tokenizer_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
@@ -95,4 +95,4 @@ if __name__ == "__main__":
         },
         use_cache=False,
     )
-    distiset.push_to_hub("USERNAME/exam_questions")
+    # distiset.push_to_hub("USERNAME/exam_questions")

--- a/src/distilabel/models/base_clients/inference_endpoints.py
+++ b/src/distilabel/models/base_clients/inference_endpoints.py
@@ -108,9 +108,7 @@ class InferenceEndpointsBaseClient(BaseModel):
                     f"Model {self.model_id} is not currently deployed or is not running the TGI framework"
                 )
 
-            self.base_url = client._resolve_url(
-                model=self.model_id, task="text-generation"
-            )
+            self._base_url = client.base_url
 
         if self.endpoint_name is not None:
             client = get_inference_endpoint(


### PR DESCRIPTION
## Description

Updates an outdated example and updates the `InferenceEndpointsLLM` to avoid using a removed private method from `InferenceClient`