### PR TITLE
Fix vLLM v1 compatibility

### DIFF
--- a/src/distilabel/models/llms/vllm.py
+++ b/src/distilabel/models/llms/vllm.py
@@ -243,7 +243,10 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
 
         destroy_model_parallel()
         destroy_distributed_environment()
-        del self._model.llm_engine.model_executor
+
+        # Don't delete model_executor if it does not exist, e.g. when VLLM_USE_V1 is set
+        if hasattr(self._model.llm_engine, 'model_executor'):
+            del self._model.llm_engine.model_executor
         del self._model
         with contextlib.suppress(AssertionError):
             torch.distributed.destroy_process_group()

--- a/src/distilabel/models/llms/vllm.py
+++ b/src/distilabel/models/llms/vllm.py
@@ -245,7 +245,7 @@ class vLLM(LLM, MagpieChatTemplateMixin, CudaDevicePlacementMixin):
         destroy_distributed_environment()
 
         # Don't delete model_executor if it does not exist, e.g. when VLLM_USE_V1 is set
-        if hasattr(self._model.llm_engine, 'model_executor'):
+        if hasattr(self._model.llm_engine, "model_executor"):
             del self._model.llm_engine.model_executor
         del self._model
         with contextlib.suppress(AssertionError):


### PR DESCRIPTION
Don't delete model_executor if it does not exist, e.g. when VLLM_USE_V1 is set.

See https://docs.vllm.ai/en/stable/serving/env_vars.html and https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/llm_engine.py