### PR TITLE
fix: correct patch target for _prepare_structured_output in AzureOpen…

### DIFF
--- a/src/distilabel/models/llms/azure.py
+++ b/src/distilabel/models/llms/azure.py
@@ -122,7 +122,7 @@ class AzureOpenAILLM(OpenAILLM):
         # This is a workaround to avoid the `OpenAILLM` calling the _prepare_structured_output
         # in the load method before we have the proper client.
         with patch(
-            "distilabel.models.openai.OpenAILLM._prepare_structured_output", lambda x: x
+            "distilabel.models.llms.openai.OpenAILLM._prepare_structured_output", lambda x: x
         ):
             super().load()
 

--- a/src/distilabel/models/llms/azure.py
+++ b/src/distilabel/models/llms/azure.py
@@ -122,7 +122,8 @@ class AzureOpenAILLM(OpenAILLM):
         # This is a workaround to avoid the `OpenAILLM` calling the _prepare_structured_output
         # in the load method before we have the proper client.
         with patch(
-            "distilabel.models.llms.openai.OpenAILLM._prepare_structured_output", lambda x: x
+            "distilabel.models.llms.openai.OpenAILLM._prepare_structured_output",
+            lambda x: x,
         ):
             super().load()
 


### PR DESCRIPTION
fix the [BUG] AttributeError in AzureOpenAILLM.load: Missing attribute openai in distilabel.models****

Fix this issue: https://github.com/argilla-io/distilabel/issues/1125

NOTE: Accidentally closed this issue