### PR TITLE
Fix: ensure setup_logging does not modify the root logger

### DIFF
--- a/src/distilabel/utils/logging.py
+++ b/src/distilabel/utils/logging.py
@@ -93,7 +93,7 @@ def setup_logging(
         )
         log_level = "INFO"
 
-    root_logger = logging.getLogger()
+    root_logger = logging.getLogger('distilabel.root')
     root_logger.handlers.clear()
 
     if log_queue is not None:


### PR DESCRIPTION
**Issue**
Attempting to log after executing `pipeline.run()` may result in an error. This issue arises due to `setup_logging()`, which modifies the root logger using `getLogger()`, potentially causing unintended side effects.

**Proposed fix**
Modify `setup_logging()` to ensure it  configures a dedicated logger for the pipeline.