### PR TITLE
Exclude HF token from serialization

### DIFF
--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -194,7 +194,7 @@ class _Serializable:
         """
         # Any parameter named api_key will be excluded from the dump (those are supposed to be SecretStr anyway,
         # and will remove them afterwards)
-        dump = obj.model_dump(exclude="api_key", **kwargs)
+        dump = obj.model_dump(exclude=("api_key", "token"), **kwargs)
 
         # Check if any attribute in value within the `dump` is an `EnumType`,
         # as it needs a specific serialization.

--- a/tests/unit/steps/tasks/structured_outputs/test_outlines.py
+++ b/tests/unit/steps/tasks/structured_outputs/test_outlines.py
@@ -61,7 +61,6 @@ DUMP_JSON = {
     "chat_template": None,
     "device": None,
     "device_map": None,
-    "token": None,
     "use_magpie_template": False,
     "disable_cuda_device_placement": False,
     "type_info": {
@@ -91,7 +90,6 @@ DUMP_REGEX = {
     "chat_template": None,
     "device": None,
     "device_map": None,
-    "token": None,
     "use_magpie_template": False,
     "disable_cuda_device_placement": False,
     "type_info": {


### PR DESCRIPTION
Currently only `api_key` is being proactively excluded from dumps on any object.
However, HF related objects, like `TransformersLLM`, define `token` as a SecretStr: https://github.com/argilla-io/distilabel/blob/main/src/distilabel/models/llms/huggingface/transformers.py#L110

That leads either to a failure to save:
```
generation_model_1.save()
*** TypeError: Type is not JSON serializable: SecretStr
```
Or a successful save:
```python
generation_model_1.save(format="yaml")
```
That would produce a YAML file  with:
```
token: !!python/object:pydantic.types.SecretStr
  _secret_value: hf_lkjreglkn290Elnwef111j
```
That is unusable. And leads to a failure like:
```py
distiset = pipeline.run()             
distiset.save_to_disk(distiset_path="dataset") 

ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/object:pydantic.types.SecretStr'
  in "<unicode string>", line 105, column 16:
            token: !!python/object:pydantic.types.S ...
```
A comment says like it should have been filtered automatically out since it is a SecretStr, however, nowhere can I use an encoder defined to do this.

So I went with the smallest change, just including the `token` into the exclusion list.
