### PR TITLE
Update docs-pr.yml to have explicit permission for issues

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: read
 
 jobs:
   publish:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  issues: read
 
 jobs:
   publish:


### PR DESCRIPTION
Having debugged the docs build gen_popular_issues.py script output running in GitHub Actions versus locally in #1145  - it was observed that issues were not being returned from the GitHub API, only pull requests.

As the script filters out pull requests, no information was shown having made the script fail safe instead of failing as it was previously.

Adding explicit read-only permissions allows the GitHub API to access this information, restoring the Issue dashboard information in the documentation.