### PR TITLE
Inference Provider Updates

### DIFF
--- a/src/distilabel/models/llms/huggingface/inference_endpoints.py
+++ b/src/distilabel/models/llms/huggingface/inference_endpoints.py
@@ -71,6 +71,7 @@ class InferenceEndpointsLLM(
         endpoint_namespace: the namespace of the Inference Endpoint to use for the LLM. Defaults to `None`.
         base_url: the base URL to use for the Inference Endpoints API requests.
         api_key: the API key to authenticate the requests to the Inference Endpoints API.
+        provider: the name of the provider to use for inference. Defaults to `None`.
         tokenizer_id: the tokenizer ID to use for the LLM as available in the Hugging Face Hub.
             Defaults to `None`, but defining one is recommended to properly format the prompt.
         model_display_name: the model display name to use for the LLM. Defaults to `None`.


### PR DESCRIPTION
### Description

Updates to Inference Endpoint client following Inference Provider updates for serverless inference, which is deprecating and now broken model status checking.

This aims to address #1140 and #1131, as well as allow support for third-party inference providers.

### Changes
- Updated inference_endpoints base client to support new model status checking
- Added optional inference provider parameter

