### PR TITLE
Exclude token from serialization

### DIFF
--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -194,7 +194,7 @@ class _Serializable:
         """
         # Any parameter named api_key will be excluded from the dump (those are supposed to be SecretStr anyway,
         # and will remove them afterwards)
-        dump = obj.model_dump(exclude="api_key", **kwargs)
+        dump = obj.model_dump(exclude=("api_key", "token"), **kwargs)
 
         # Check if any attribute in value within the `dump` is an `EnumType`,
         # as it needs a specific serialization.

--- a/src/distilabel/utils/serialization.py
+++ b/src/distilabel/utils/serialization.py
@@ -192,8 +192,8 @@ class _Serializable:
         Returns:
             A dictionary containing the serializable content of the class.
         """
-        # Any parameter named api_key will be excluded from the dump (those are supposed to be SecretStr anyway,
-        # and will remove them afterwards)
+        # Any parameter named api_key or token will be excluded from the dump
+        # (those are supposed to be SecretStr anyway, and will remove them afterwards)
         dump = obj.model_dump(exclude=("api_key", "token"), **kwargs)
 
         # Check if any attribute in value within the `dump` is an `EnumType`,

--- a/tests/unit/steps/tasks/structured_outputs/test_outlines.py
+++ b/tests/unit/steps/tasks/structured_outputs/test_outlines.py
@@ -61,7 +61,6 @@ DUMP_JSON = {
     "chat_template": None,
     "device": None,
     "device_map": None,
-    "token": None,
     "use_magpie_template": False,
     "disable_cuda_device_placement": False,
     "type_info": {
@@ -91,7 +90,6 @@ DUMP_REGEX = {
     "chat_template": None,
     "device": None,
     "device_map": None,
-    "token": None,
     "use_magpie_template": False,
     "disable_cuda_device_placement": False,
     "type_info": {


### PR DESCRIPTION
Based on #1129 from @sysradium this PR excludes all token field from serialization and adds a test