### PR TITLE
Fixed a pipeline docs typo in the cache section

### DIFF
--- a/docs/sections/how_to_guides/basic/pipeline/index.md
+++ b/docs/sections/how_to_guides/basic/pipeline/index.md
@@ -388,7 +388,7 @@ In case you want to stop the pipeline while it's running, you can press ++ctrl+c
 
 If for some reason, the pipeline execution stops (for example by pressing `Ctrl+C`), the state of the pipeline and the outputs will be stored in the cache, so we can resume the pipeline execution from the point where it was stopped.
 
-If we want to force the pipeline to run again without can, then we can use the `use_cache` argument of the `Pipeline.run()` method:
+If we want to force the pipeline to run again without cache, then we can use the `use_cache` argument of the `Pipeline.run()` method:
 
 ```python
 if __name__ == "__main__":


### PR DESCRIPTION
Addressed this issue: https://github.com/argilla-io/distilabel/issues/1171

Replaced "to run again without can" to "to run again without cache".

Target branch is `main` since the change is for the documentation (per [contributing guideline](https://github.com/argilla-io/distilabel/issues/1171)).
