### PR TITLE
docs: add text clustering pipeline example

### DIFF
--- a/docs/sections/pipeline_samples/examples/text_clustering.md
+++ b/docs/sections/pipeline_samples/examples/text_clustering.md
@@ -1,0 +1,24 @@
+---
+hide: toc
+---
+# Text clustering pipeline with `distilabel`
+
+Build a text clustering pipeline with [`EmbeddingGeneration`](../../../components-gallery/steps/embeddinggeneration.md), [`UMAP`](../../../components-gallery/steps/umap.md), [`DBSCAN`](../../../components-gallery/steps/dbscan.md), and [`TextClustering`](../../../components-gallery/tasks/textclustering.md).
+
+The example also includes an optional branch using [`FaissNearestNeighbour`](../../../components-gallery/steps/faissnearestneighbour.md) to retrieve semantic nearest neighbours for each sample.
+
+To run this example, install the optional dependencies for embeddings, clustering, and nearest neighbours:
+
+```console
+pip install "distilabel[sentence-transformers,text-clustering,hf-inference-endpoints,faiss-cpu]"
+```
+
+??? Run
+
+    ```python
+    python examples/text_clustering.py
+    ```
+
+```python title="text_clustering.py"
+--8<-- "examples/text_clustering.py"
+```

--- a/docs/sections/pipeline_samples/index.md
+++ b/docs/sections/pipeline_samples/index.md
@@ -169,6 +169,14 @@ hide: toc
 
     [:octicons-arrow-right-24: Example](examples/image_generation.md)
 
+-   __Text clustering pipeline__
+
+    ---
+
+    Learn how to combine embeddings, UMAP, DBSCAN, and TextClustering in one pipeline.
+
+    [:octicons-arrow-right-24: Example](examples/text_clustering.md)
+
 -   __Text generation with images in distilabel__
 
     ---
@@ -178,7 +186,6 @@ hide: toc
     [:octicons-arrow-right-24: Example](examples/text_generation_with_image.md)
 
 </div>
-
 
 
 

--- a/examples/text_clustering.py
+++ b/examples/text_clustering.py
@@ -1,0 +1,70 @@
+# Copyright 2023-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datasets import load_dataset
+
+from distilabel.models import InferenceEndpointsLLM, SentenceTransformerEmbeddings
+from distilabel.pipeline import Pipeline
+from distilabel.steps import (
+    DBSCAN,
+    UMAP,
+    EmbeddingGeneration,
+    FaissNearestNeighbour,
+    TextClustering,
+    make_generator_step,
+)
+
+ds_name = "ag_news"
+dataset = load_dataset(ds_name, split="train").select(range(2000))
+
+with Pipeline(name="text-clustering-pipeline") as pipeline:
+    loader = make_generator_step(dataset=dataset, batch_size=200, repo_id=ds_name)
+
+    embeddings = EmbeddingGeneration(
+        embeddings=SentenceTransformerEmbeddings(
+            model="mixedbread-ai/mxbai-embed-large-v1",
+        )
+    )
+
+    umap = UMAP(n_components=2, metric="cosine")
+    dbscan = DBSCAN(eps=0.15, min_samples=10)
+
+    text_clustering = TextClustering(
+        llm=InferenceEndpointsLLM(
+            model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+            tokenizer_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+        ),
+        n=3,
+        query_title="Examples of news",
+        samples_per_cluster=10,
+        context=(
+            "Describe the main themes, topics, or categories shared by these news "
+            "examples. All samples in the same cluster must share the same set of labels."
+        ),
+        default_label="Unclassified",
+        input_batch_size=8,
+        use_default_structured_output=True,
+    )
+
+    # Optional branch to inspect semantic neighbours for each sample.
+    nearest_neighbours = FaissNearestNeighbour(k=3)
+
+    loader >> embeddings
+    embeddings >> umap >> dbscan >> text_clustering
+    embeddings >> nearest_neighbours
+
+
+if __name__ == "__main__":
+    distiset = pipeline.run(use_cache=False)
+    distiset.push_to_hub("USERNAME/text-clustering-example")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,6 +224,7 @@ nav:
           - Create a social network with FinePersonas: "sections/pipeline_samples/examples/fine_personas_social_network.md"
           - Create questions and answers for a exam: "sections/pipeline_samples/examples/exam_questions.md"
           - Image generation with distilabel: "sections/pipeline_samples/examples/image_generation.md"
+          - Text clustering pipeline: "sections/pipeline_samples/examples/text_clustering.md"
           - Text generation with images in distilabel: "sections/pipeline_samples/examples/text_generation_with_image.md"
   - API Reference:
       - Step:


### PR DESCRIPTION
## Summary
- add a new docs example page for a text clustering pipeline
- include a runnable `examples/text_clustering.py` script using UMAP, DBSCAN and TextClustering
- wire the new example into tutorials index and mkdocs navigation

Fixes #979