### PR TITLE
fix: prevent IndexError in InstructionBacktranslation.format_output on unparseable output

### DIFF
--- a/src/distilabel/steps/tasks/instruction_backtranslation.py
+++ b/src/distilabel/steps/tasks/instruction_backtranslation.py
@@ -157,7 +157,10 @@ class InstructionBacktranslation(Task):
         matches = None
         if output is not None:
             matches = re.findall(pattern, output, re.DOTALL)
-        if matches is None:
+        # re.findall returns [] (not None) when the pattern is absent, so guard on
+        # falsiness to also cover unparseable output; otherwise matches[0] below
+        # raises IndexError and crashes the pipeline on any malformed response.
+        if not matches:
             return {"score": None, "reason": None}
 
         return {

--- a/tests/unit/steps/tasks/test_instruction_backtranslation.py
+++ b/tests/unit/steps/tasks/test_instruction_backtranslation.py
@@ -78,6 +78,22 @@ class TestInstructionBacktranslation:
             "reason": "This is the reason.",
         }
 
+    def test_format_output_malformed(self) -> None:
+        task = InstructionBacktranslation(
+            name="instruction-backtranslation",
+            llm=InstructionBacktranslationLLM(),
+            pipeline=Pipeline(name="unit-test-pipeline"),
+        )
+        task.load()
+
+        # Output that doesn't contain the "Score:" pattern must degrade gracefully
+        # (re.findall returns [], which previously raised IndexError).
+        assert task.format_output("I could not evaluate this.", {}) == {
+            "score": None,
+            "reason": None,
+        }
+        assert task.format_output(None, {}) == {"score": None, "reason": None}
+
     def test_process(self) -> None:
         task = InstructionBacktranslation(
             name="instruction-backtranslation",


### PR DESCRIPTION
### What's broken

`InstructionBacktranslation.format_output` guards with `if matches is None`:

```python
matches = None
if output is not None:
    matches = re.findall(pattern, output, re.DOTALL)   # pattern = r"(.+?)Score: (\d)"
if matches is None:
    return {"score": None, "reason": None}
return {"score": int(matches[0][1]), "reason": matches[0][0].strip()}
```

But `re.findall` returns an empty **list** (not `None`) when nothing matches. So for any non-`None` LLM output lacking the `Score:` pattern, `matches` is `[]`, the guard is skipped, and `matches[0][1]` raises `IndexError: list index out of range` — crashing the whole pipeline. (The pattern requires ≥1 char before `Score:`, so even a bare `"Score: 1"` triggers it.)

The dead `return {"score": None, "reason": None}` shows graceful degradation is the intended behavior — matching the sibling parsers (`clair`, `genstruct`, quality/complexity scorers) which all handle non-matching output.

### Fix

Change the guard to `if not matches`, which catches both `None` and `[]`.

### Tests

Adds `test_format_output_malformed` (unparseable text and `None` both return `{"score": None, "reason": None}`); there was no coverage for non-matching output. Full test file passes (4).