### PR TITLE
fix: prevent IndexError in UltraFeedback.format_output on non-numeric ratings

### DIFF
--- a/src/distilabel/steps/tasks/ultrafeedback.py
+++ b/src/distilabel/steps/tasks/ultrafeedback.py
@@ -285,6 +285,20 @@ class UltraFeedback(Task):
 
         return self._format_types_ratings_rationales_output(output, input)
 
+    @staticmethod
+    def _parse_rating(rating: str) -> Union[int, None]:
+        """Extracts the integer rating from a matched `Rating:` (or `Type:`) group.
+
+        Returns `None` for the explicit `None`/`N/A` sentinels and for any other
+        text that contains no digit: `re.findall` returns `[]` in that case, and
+        indexing it would raise `IndexError`, crashing the pipeline on a malformed
+        response.
+        """
+        if rating in ["None", "N/A"]:
+            return None
+        digits = re.findall(r"\b\d+\b", rating)
+        return int(digits[0]) if digits else None
+
     def _format_ratings_rationales_output(
         self, output: Union[str, None], input: Dict[str, Any]
     ) -> Dict[str, List[Any]]:
@@ -312,11 +326,7 @@ class UltraFeedback(Task):
 
             formatted_outputs.append(
                 {
-                    "ratings": (
-                        int(re.findall(r"\b\d+\b", matches.group(1))[0])
-                        if matches.group(1) not in ["None", "N/A"]
-                        else None
-                    ),
+                    "ratings": self._parse_rating(matches.group(1)),
                     "rationales": matches.group(2),
                 }
             )
@@ -359,17 +369,9 @@ class UltraFeedback(Task):
 
             formatted_outputs.append(
                 {
-                    "types": (
-                        int(re.findall(r"\b\d+\b", matches.group(1))[0])
-                        if matches.group(1) not in ["None", "N/A"]
-                        else None
-                    ),
+                    "types": self._parse_rating(matches.group(1)),
                     "rationales": matches.group(2),
-                    "ratings": (
-                        int(re.findall(r"\b\d+\b", matches.group(3))[0])
-                        if matches.group(3) not in ["None", "N/A"]
-                        else None
-                    ),
+                    "ratings": self._parse_rating(matches.group(3)),
                     "rationales-for-ratings": matches.group(4),
                 }
             )

--- a/tests/unit/steps/tasks/test_ultrafeedback.py
+++ b/tests/unit/steps/tasks/test_ultrafeedback.py
@@ -171,3 +171,34 @@ class TestUltraFeedback:
         )
 
         assert result == expected
+
+    def test_format_output_non_numeric_rating(self) -> None:
+        """A non-numeric rating that isn't the `None`/`N/A` sentinel must degrade
+        gracefully to `None` instead of raising `IndexError` (`re.findall` returns
+        `[]`, which previously crashed the pipeline on a malformed response)."""
+        honesty_task = UltraFeedback(
+            llm=UltraFeedbackLLM(),
+            aspect="honesty",
+            use_default_structured_output=False,
+        )
+        honesty_task.load()
+        assert honesty_task.format_output(
+            output="Rating: high\nRationale: r1\n\nRating: low\nRationale: r2",
+            input={"instruction": "x", "generations": ["a", "b"]},
+        ) == {"ratings": [None, None], "rationales": ["r1", "r2"]}
+
+        helpfulness_task = UltraFeedback(
+            llm=UltraFeedbackLLM(),
+            aspect="helpfulness",
+            use_default_structured_output=False,
+        )
+        helpfulness_task.load()
+        assert helpfulness_task.format_output(
+            output="Type: good\nRationale: r1\nRating: high\nRationale: rr1",
+            input={"instruction": "x", "generations": ["a"]},
+        ) == {
+            "types": [None],
+            "rationales": ["r1"],
+            "ratings": [None],
+            "rationales-for-ratings": ["rr1"],
+        }


### PR DESCRIPTION
## Description

`UltraFeedback.format_output` crashes with `IndexError: list index out of range` whenever the model emits a non-numeric rating that isn't the literal `None`/`N/A` sentinel.

The rating is parsed like this (three sites, in `_format_ratings_rationales_output` and `_format_types_ratings_rationales_output`):

```python
int(re.findall(r"\b\d+\b", matches.group(N))[0])
if matches.group(N) not in ["None", "N/A"]
else None
```

The guard only covers the exact strings `"None"` and `"N/A"`. For any other rating text without a digit — e.g. a model that answers `Rating: high` or `Rating: excellent` — `re.findall` returns `[]`, so indexing `[0]` raises `IndexError`. This propagates out of `format_output` and crashes the whole batch on a single malformed response, rather than degrading that one item to `None` the way the surrounding code already does for unparseable sections.

This is the default parsing path (`use_default_structured_output=False`).

## Fix

Extract the parsing into a small `_parse_rating` helper that returns `None` when the matched group contains no digit, preserving the existing `None`/`N/A` → `None` convention. The three duplicated inline expressions now call it.

This mirrors the maintainers' fix for the same `re.findall(...)[0]` pattern in `InstructionBacktranslation.format_output` (#1181).

## Testing

- Added `test_format_output_non_numeric_rating` covering both aspect paths (`honesty` and `helpfulness`) with a non-numeric rating. It reproduces the `IndexError` on the current code (fails without the fix) and passes with it.
- Full `tests/unit/steps/tasks/test_ultrafeedback.py` suite passes (7 passed).
- `ruff check` and `ruff format --check` clean on both changed files.
