### PR TITLE
fix(models): merge generation_kwargs into generate_outputs kwargs

### DIFF
--- a/src/distilabel/models/llms/base.py
+++ b/src/distilabel/models/llms/base.py
@@ -167,8 +167,14 @@ class LLM(RuntimeParametersModelMixin, BaseModel, _Serializable, ABC):
         **kwargs: Any,
     ) -> List["GenerateOutput"]:
         """Generates outputs for the given inputs using either `generate` method or the
-        `offine_batch_generate` method if `use_offline_
+        `offline_batch_generate` method if `use_offline_batch_generation` is enabled.
+
+        The `generation_kwargs` set at the `LLM` level are merged with the `kwargs`
+        passed to this method, giving precedence to the latter.
         """
+        generation_kwargs = self.get_generation_kwargs() or {}
+        kwargs = {**generation_kwargs, **kwargs}
+
         if self.use_offline_batch_generation:
             if self.offline_batch_generation_block_until_done is not None:
                 return self._offline_batch_generate_polling(

--- a/tests/unit/models/llms/test_base.py
+++ b/tests/unit/models/llms/test_base.py
@@ -12,10 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Dict, List
+
 import pytest
+from pydantic import PrivateAttr
 
 from distilabel.errors import DistilabelNotImplementedError
+from distilabel.models.llms.base import LLM
 from tests.unit.conftest import DummyLLM
+
+
+class _DummyLLMWithKwargs(LLM):
+    _last_kwargs: Dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    def load(self) -> None:
+        super().load()
+
+    @property
+    def model_name(self) -> str:
+        return "test-kwargs"
+
+    def generate(  # type: ignore[override]
+        self,
+        inputs: List[Any],
+        num_generations: int = 1,
+        **kwargs: Any,
+    ) -> List[Any]:
+        self._last_kwargs = kwargs
+        return [
+            {
+                "generations": ["output"] * num_generations,
+                "statistics": {
+                    "input_tokens": [0] * num_generations,
+                    "output_tokens": [0] * num_generations,
+                },
+            }
+        ] * len(inputs)
 
 
 class TestLLM:
@@ -26,3 +58,21 @@ class TestLLM:
 
         with pytest.raises(DistilabelNotImplementedError):
             llm.offline_batch_generate()
+
+    def test_generate_outputs_merges_generation_kwargs(self) -> None:
+        llm = _DummyLLMWithKwargs(generation_kwargs={"max_new_tokens": 2048})
+        llm.load()
+
+        llm.generate_outputs(inputs=[[]])
+
+        assert llm._last_kwargs == {"max_new_tokens": 2048}
+
+    def test_generate_outputs_call_kwargs_override_generation_kwargs(self) -> None:
+        llm = _DummyLLMWithKwargs(
+            generation_kwargs={"max_new_tokens": 2048, "temperature": 0.5}
+        )
+        llm.load()
+
+        llm.generate_outputs(inputs=[[]], max_new_tokens=100)
+
+        assert llm._last_kwargs == {"max_new_tokens": 100, "temperature": 0.5}


### PR DESCRIPTION
### Description

Fixes #1158.

`LLM.generate_outputs` now merges the LLM-level `generation_kwargs` with the kwargs passed to the call, giving precedence to the kwargs passed directly. This ensures that settings like `max_new_tokens` configured at LLM construction are respected when calling `generate_outputs` directly, matching the behavior already provided when a `Task` unpacks the same dict.

### Changes

- Updated `LLM.generate_outputs` to combine `self.get_generation_kwargs()` with `**kwargs`.
- Added unit tests for merge and override behavior.

### Tests

```bash
uv run pytest tests/unit/models/llms/test_base.py -v
```

All new and existing tests in the file pass.