### PR TITLE
fix: handle empty / non-text Anthropic responses without crashing the batch

### DIFF
--- a/src/distilabel/models/llms/anthropic.py
+++ b/src/distilabel/models/llms/anthropic.py
@@ -275,7 +275,15 @@ class AnthropicLLM(AsyncLLM):
                 **self._get_llm_statistics(completion._raw_response),
             )
 
-        if (content := completion.content[0].text) is None:
+        # `completion.content` may be empty (e.g. `stop_reason="max_tokens"`
+        # reached while the budget was spent on extended thinking, or a refusal)
+        # or its first block may not be a text block (a `ThinkingBlock` or
+        # `ToolUseBlock` has no `.text`). Handle those gracefully with `None`
+        # instead of crashing the whole batch, mirroring `OpenAILLM`.
+        content = None
+        if completion.content:
+            content = getattr(completion.content[0], "text", None)
+        if content is None:
             self._logger.warning(
                 f"Received no response using Anthropic client (model: '{self.model}')."
                 f" Finish reason was: {completion.stop_reason}"

--- a/tests/unit/models/llms/test_anthropic.py
+++ b/tests/unit/models/llms/test_anthropic.py
@@ -59,6 +59,60 @@ class TestAnthropicLLM:
         }
 
     @pytest.mark.asyncio
+    async def test_agenerate_empty_content(self, mock_anthropic: MagicMock) -> None:
+        # `completion.content` can be empty (e.g. `stop_reason="max_tokens"`
+        # reached during extended thinking, or a refusal). This used to raise
+        # `IndexError` and crash the whole batch; it must degrade to `None`.
+        llm = AnthropicLLM(model="claude-3-opus-20240229", api_key="api.key")  # type: ignore
+        llm._aclient = mock_anthropic
+        llm._logger = MagicMock()
+
+        mocked_completion = Mock(
+            content=[],
+            usage=Mock(input_tokens=100, output_tokens=0),
+        )
+        llm._aclient.messages.create = AsyncMock(return_value=mocked_completion)
+
+        result = await llm.agenerate(
+            input=[
+                {"role": "system", "content": ""},
+                {"role": "user", "content": "Lorem ipsum."},
+            ]
+        )
+        assert result == {
+            "generations": [None],
+            "statistics": {"input_tokens": [100], "output_tokens": [0]},
+        }
+
+    @pytest.mark.asyncio
+    async def test_agenerate_non_text_first_block(
+        self, mock_anthropic: MagicMock
+    ) -> None:
+        # A thinking / tool-use block has no `.text` attribute. This used to
+        # raise `AttributeError` and crash the batch; it must degrade to `None`.
+        llm = AnthropicLLM(model="claude-3-opus-20240229", api_key="api.key")  # type: ignore
+        llm._aclient = mock_anthropic
+        llm._logger = MagicMock()
+
+        non_text_block = Mock(spec=[])  # no `.text` attribute
+        mocked_completion = Mock(
+            content=[non_text_block],
+            usage=Mock(input_tokens=100, output_tokens=100),
+        )
+        llm._aclient.messages.create = AsyncMock(return_value=mocked_completion)
+
+        result = await llm.agenerate(
+            input=[
+                {"role": "system", "content": ""},
+                {"role": "user", "content": "Lorem ipsum."},
+            ]
+        )
+        assert result == {
+            "generations": [None],
+            "statistics": {"input_tokens": [100], "output_tokens": [100]},
+        }
+
+    @pytest.mark.asyncio
     async def test_agenerate_structured(self, mock_openai: MagicMock) -> None:
         llm = AnthropicLLM(
             model="claude-3-opus-20240229",


### PR DESCRIPTION
## Description

`AnthropicLLM.agenerate` reads the response text with:

```python
if (content := completion.content[0].text) is None:
    ...
return prepare_output([content], **self._get_llm_statistics(completion))
```

The `warning` branch shows the intent was to handle an empty response gracefully (return `None` + warn), but the guard indexes `completion.content[0].text` **unconditionally**. `anthropic.types.Message.content` is a *list of content blocks* that can be:

- **empty** — `stop_reason="max_tokens"` reached while the budget was spent on extended thinking, `stop_reason="refusal"`, or `pause_turn` → **`IndexError: list index out of range`**;
- **a non-text first block** — a `ThinkingBlock` (extended thinking) or `ToolUseBlock` has no `.text` → **`AttributeError: 'ThinkingBlock' object has no attribute 'text'`**.

Either way the entire generation batch crashes instead of degrading to the intended `None`. (Also: `TextBlock.text` is always a `str`, so the original `is None` check was effectively dead for the normal case — it borrowed `OpenAILLM`'s nullable-`content` idiom onto Anthropic's structurally different response.)

This is the Anthropic sibling of the empty-content handling already accepted for LiteLLM (#1178) and Ollama (#1175).

## Fix

```python
content = None
if completion.content:
    content = getattr(completion.content[0], "text", None)
if content is None:
    self._logger.warning(...)
return prepare_output([content], **self._get_llm_statistics(completion))
```

`prepare_output([None], ...)` is already the established "no response" contract (`OpenAILLM` does exactly this), so downstream handling is unchanged.

## Tests

Two regression tests in `tests/unit/models/llms/test_anthropic.py`:
- `test_agenerate_empty_content` — `content=[]` → graceful `{"generations": [None], ...}` (pre-fix: `IndexError`).
- `test_agenerate_non_text_first_block` — a first block with no `.text` → same (pre-fix: `AttributeError`).

Both fail on `main` and pass with the fix; the existing anthropic tests still pass (8 passed).