### PR TITLE
bug: preserve generator parameters during dry runs

### DIFF
--- a/src/distilabel/pipeline/base.py
+++ b/src/distilabel/pipeline/base.py
@@ -440,14 +440,16 @@ class BasePipeline(ABC, RequirementsMixin, _Serializable):
             Will return the `Distiset` as the main run method would do.
         """
         self._dry_run = True
+        parameters = {} if parameters is None else dict(parameters)
 
         for step_name in self.dag:
             step = self.dag.get_step(step_name)[constants.STEP_ATTR_NAME]
 
             if step.is_generator:
-                if not parameters:
-                    parameters = {}
-                parameters[step_name] = {"batch_size": batch_size}
+                parameters[step_name] = {
+                    **parameters.get(step_name, {}),
+                    "batch_size": batch_size,
+                }
 
         distiset = self.run(parameters=parameters, use_cache=False, dataset=dataset)
 

--- a/tests/integration/test_dry_run.py
+++ b/tests/integration/test_dry_run.py
@@ -12,8 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
+from distilabel.mixins.runtime_parameters import RuntimeParameter
 from distilabel.pipeline import Pipeline
 from distilabel.steps import LoadDataFromDicts, StepInput, StepOutput, step
+from distilabel.steps.base import GeneratorStep
+
+if TYPE_CHECKING:
+    from distilabel.steps import GeneratorStepOutput
+
+
+class RuntimeParameterGenerator(GeneratorStep):
+    greeting: RuntimeParameter[str] = "default"
+
+    @property
+    def outputs(self) -> list[str]:
+        return ["instruction"]
+
+    def process(self, offset: int = 0) -> "GeneratorStepOutput":
+        yield ([{"instruction": self.greeting}] * self.batch_size, True)
 
 
 @step(inputs=["instruction"], outputs=["response"])
@@ -57,3 +75,21 @@ def test_dry_run():
         parameters={load_dataset_name: {"batch_size": 10}}, use_cache=False
     )
     assert len(distiset["default"]["train"]) == 50
+
+
+def test_dry_run_preserves_generator_runtime_parameters():
+    with Pipeline(name="runtime-parameter-dry-run") as pipeline:
+        generator = RuntimeParameterGenerator(name="generator", batch_size=5)
+        text_generation = SucceedAlways()
+
+        generator >> text_generation
+
+    distiset = pipeline.dry_run(
+        parameters={"generator": {"greeting": "runtime override"}},
+        batch_size=2,
+    )
+
+    assert len(distiset["default"]["train"]) == 2
+    assert distiset["default"]["train"][0]["instruction"] == "runtime override"
+    assert distiset["default"]["train"][1]["instruction"] == "runtime override"
+    assert pipeline._dry_run is False


### PR DESCRIPTION
## Description

Closes #1137.

`Pipeline.dry_run()` replaced each generator step's complete runtime-parameter mapping with `{"batch_size": ...}`. This preserves the caller's generator parameters and overrides only `batch_size`, which is the dry-run-specific setting.

The method also copies the outer parameter mapping before adding generator overrides, so preparing a dry run does not add or replace step entries in the caller's dictionary.

## Test plan

- Added an integration regression with a custom generator runtime parameter.
- Verified that the runtime override reaches generated rows while dry-run `batch_size` still limits the result.
- Ran:

```text
PYTHONPATH=src .venv/bin/pytest -q tests/integration/test_dry_run.py
2 passed

uvx --from 'ruff==0.8.1' ruff check src/distilabel/pipeline/base.py tests/integration/test_dry_run.py
All checks passed!

uvx --from 'ruff==0.8.1' ruff format --check src/distilabel/pipeline/base.py tests/integration/test_dry_run.py
2 files already formatted
```

AI assistance was used for repository analysis and implementation; I reviewed the final diff and ran the tests above.
