### PR TITLE
bug: align write buffer tables before schema casting

### DIFF
--- a/src/distilabel/pipeline/write_buffer.py
+++ b/src/distilabel/pipeline/write_buffer.py
@@ -148,7 +148,7 @@ class _WriteBuffer:
                 else:
                     new_schema = pa.unify_schemas([last_schema, table.schema])
                     self._buffer_last_schema[step_name] = new_schema
-                    table = table.cast(new_schema)
+                    table = self._align_table_to_schema(table, new_schema)
 
         next_file_number = self._buffers_last_file[step_name]
         self._buffers_last_file[step_name] = next_file_number + 1
@@ -169,6 +169,26 @@ class _WriteBuffer:
         self._logger.debug(f"Written to file '{parquet_file}'")
 
         self._clean_buffer(step_name)
+
+    @staticmethod
+    def _align_table_to_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
+        """Reorders a table to match a target schema and backfills missing columns.
+
+        When a step's columns evolve, `pyarrow.unify_schemas` preserves the existing
+        schema order and appends new fields. `Table.cast`, however, still expects the
+        table's columns to match the target schema exactly. Aligning the current table
+        before casting keeps schemas stable across parquet shards.
+        """
+
+        missing_columns = [
+            field for field in schema if field.name not in table.column_names
+        ]
+        for field in missing_columns:
+            table = table.append_column(
+                field, pa.nulls(table.num_rows, type=field.type)
+            )
+
+        return table.select(schema.names).cast(schema)
 
     def _clean_buffer(self, step_name: str) -> None:
         """Cleans the buffer by setting it's content to `None`.

--- a/tests/unit/pipeline/test_write_buffer.py
+++ b/tests/unit/pipeline/test_write_buffer.py
@@ -15,6 +15,9 @@
 import tempfile
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from distilabel.constants import STEPS_OUTPUTS_PATH
 from distilabel.distiset import Distiset, create_distiset
 from distilabel.pipeline.local import Pipeline
@@ -157,3 +160,28 @@ class TestWriteBuffer:
             assert len(ds.keys()) == 2
             assert len(ds["dummy_step_2"]["train"]) == 75
             assert len(ds["dummy_step_3"]["train"]) == 75
+
+    def test_write_buffer_reorders_unified_schema_before_casting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            write_buffer = _WriteBuffer(path=Path(tmpdirname), leaf_steps={"leaf"})
+            write_buffer._buffer_last_schema["leaf"] = pa.table(
+                {"old": [1], "kept": ["previous"]}
+            ).schema
+            write_buffer._buffers["leaf"] = [
+                {"new": "value", "kept": "current", "old": 2}
+            ]
+
+            write_buffer._write("leaf")
+
+            table = pq.read_table(Path(tmpdirname) / "leaf" / "00001.parquet")
+            assert table.column_names == ["old", "kept", "new"]
+            assert table.to_pylist() == [{"old": 2, "kept": "current", "new": "value"}]
+
+    def test_align_table_to_schema_backfills_missing_columns(self) -> None:
+        table = pa.table({"new": [1]})
+        schema = pa.schema([pa.field("old", pa.string()), pa.field("new", pa.int64())])
+
+        aligned = _WriteBuffer._align_table_to_schema(table, schema)
+
+        assert aligned.schema == schema
+        assert aligned.to_pylist() == [{"old": None, "new": 1}]


### PR DESCRIPTION
## Description

`pyarrow.unify_schemas` keeps fields from the previous write in their existing order and appends newly observed fields. The current batch can have those same fields in a different order, but `Table.cast` requires its input column order to match the target schema exactly. That mismatch raises the `ValueError` reported in #935.

This change aligns each evolved batch before casting:

- append typed null columns for target fields absent from the current batch
- select columns in the unified schema's stable order
- cast only after names and order match

The regression test covers the reported combination of a newly added column and a different input order. A focused helper test also covers backfilling a field omitted from a later batch.

Fixes #935.

## Validation

```text
# Before the fix, the new regression test failed with the reported
# "Target schema's field names are not matching" ValueError.

$ PYTHONPATH=.:src .venv/bin/pytest -q tests/unit/pipeline/test_write_buffer.py
5 passed, 2 warnings in 0.63s

$ .venv/bin/ruff format --check src/distilabel/pipeline/write_buffer.py tests/unit/pipeline/test_write_buffer.py
2 files already formatted

$ .venv/bin/ruff check src/distilabel/pipeline/write_buffer.py tests/unit/pipeline/test_write_buffer.py
All checks passed!

$ git diff --check
# no output
```

AI-assisted implementation; I reviewed the diff and ran the checks above locally.
