### PR TITLE
fix(models): handle empty LiteLLM responses without crashing token_counter

### DIFF
--- a/src/distilabel/models/llms/litellm.py
+++ b/src/distilabel/models/llms/litellm.py
@@ -295,6 +295,9 @@ class LiteLLM(AsyncLLM):
                     f"Received no response using LiteLLM client (model: '{self.model}')."
                     f" Finish reason was: {choice.finish_reason}"
                 )
+                generations.append(content)
+                output_tokens.append(0)
+                continue
             generations.append(content)
             output_tokens.append(token_counter(model=self.model, text=content))
 

--- a/tests/unit/models/llms/test_litellm.py
+++ b/tests/unit/models/llms/test_litellm.py
@@ -86,6 +86,37 @@ class TestLiteLLM:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_agenerate_empty_content(
+        self, mock_litellm: MagicMock, model: str
+    ) -> None:
+        llm = LiteLLM(model=model)  # type: ignore
+        llm.load()
+        llm._aclient = AsyncMock(
+            return_value=Mock(
+                choices=[Mock(message=Mock(content=None), finish_reason="length")]
+            )
+        )
+
+        with patch("litellm.token_counter") as mock_token_counter:
+            mock_token_counter.side_effect = (
+                lambda model, messages=None, text=None: len(messages or text or [])
+            )
+            result = await llm.agenerate(
+                input=[
+                    {"role": "system", "content": ""},
+                    {
+                        "role": "user",
+                        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    },
+                ]
+            )
+
+        assert result["generations"] == [None]
+        assert result["statistics"]["output_tokens"] == [0]
+        assert len(mock_token_counter.call_args_list) == 1
+        assert mock_token_counter.call_args_list[0].kwargs.get("messages") is not None
+
     def test_serialization(self, _: MagicMock, model: str) -> None:
         llm = LiteLLM(model=model)  # type: ignore
 


### PR DESCRIPTION
Fixes #1178

`LiteLLM.agenerate` now handles empty content responses (e.g. reasoning models that spend the token budget on reasoning and return `finish_reason="length"`) without calling `token_counter(model=..., text=None)`.

Changes:
- Skip output-token counting for `None` content and record `0` tokens.
- Keep the existing warning log.
- Add `test_agenerate_empty_content` regression test.

The new regression test was verified locally with a mocked `token_counter`. Existing tests that assert exact token counts are sensitive to the installed LiteLLM tokenizer version and were not modified.